### PR TITLE
various CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,42 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.8...3.23)
 
-project(libassert)
+project(
+  libassert
+  VERSION 1.0.0
+  LANGUAGES CXX
+)
 
 option(ASSERT_DECOMPOSE_BINARY_LOGICAL "Enables expression decomposition of && and ||" OFF)
 option(ASSERT_LOWERCASE "Enables assert alias for ASSERT" OFF)
 option(ASSERT_USE_MAGIC_ENUM "Use the MagicEnum library to print better diagnostics for enum classes" ON)
 set(ASSERT_FAIL "" CACHE STRING "ASSERT_FAIL")
 
+
+# libassert uses relocs, -fpic has to be used to allow shared libs to link libassert as a static library.
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+include(GNUInstallDirs)
 add_library(assert src/assert.cpp)
 
 target_include_directories(
-  assert PUBLIC
+  assert
+  PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/assert/assert>
+)
+
+target_compile_features(
+  assert
+  PUBLIC
+  cxx_std_17
 )
 
 set_target_properties(
   assert
   PROPERTIES
-  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED TRUE
+  CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN TRUE
   CXX_EXTENSIONS OFF
 )
 
@@ -52,56 +69,57 @@ if(NOT "${ASSERT_FAIL}" STREQUAL "")
   target_compile_definitions(assert PUBLIC ASSERT_FAIL=${ASSERT_FAIL})
 endif()
 
-include(CMakePackageConfigHelpers)
-include(GNUInstallDirs)
+if(NOT CMAKE_SKIP_INSTALL_RULES)
+  include(CMakePackageConfigHelpers)
 
-install(
-  TARGETS assert
-  EXPORT assert_targets
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
+  install(
+    TARGETS assert
+    EXPORT assert_targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
 
-install(
-  FILES
-  include/assert.hpp
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/assert/assert
-)
+  install(
+    FILES
+    include/assert.hpp
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/assert/assert
+  )
 
-install(
-  FILES
-  third_party/magic_enum.hpp
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/assert/third_party
-)
+  install(
+    FILES
+    third_party/magic_enum.hpp
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/assert/third_party
+  )
 
-export(
-  EXPORT assert_targets
-  FILE ${CMAKE_CURRENT_BINARY_DIR}/assert/assert_targets.cmake
-  NAMESPACE assert::
-)
+  export(
+    EXPORT assert_targets
+    FILE ${CMAKE_CURRENT_BINARY_DIR}/assert/assert_targets.cmake
+    NAMESPACE assert::
+  )
 
-configure_package_config_file(
-  cmake/assert-config.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/assert/assert-config.cmake
-  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/assert
-)
+  configure_package_config_file(
+    cmake/assert-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/assert/assert-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/assert
+  )
 
-write_basic_package_version_file(
-  ${CMAKE_CURRENT_BINARY_DIR}/assert/assert-config-version.cmake
-  VERSION 1.0.0
-  COMPATIBILITY SameMajorVersion
-)
+  write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/assert/assert-config-version.cmake
+    COMPATIBILITY SameMajorVersion
+  )
 
-install(
-  EXPORT assert_targets
-  FILE assert_targets.cmake
-  NAMESPACE assert::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/assert
-)
+  install(
+    EXPORT assert_targets
+    FILE assert_targets.cmake
+    NAMESPACE assert::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/assert
+  )
 
-install(
-  FILES
-  ${CMAKE_CURRENT_BINARY_DIR}/assert/assert-config.cmake
-  ${CMAKE_CURRENT_BINARY_DIR}/assert/assert-config-version.cmake
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/assert
-)
+  install(
+    FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/assert/assert-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/assert/assert-config-version.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/assert
+  )
+endif()


### PR DESCRIPTION
- Add `ARCHIVE DESTINATION` to "install targets" to be compatible with older versions of CMake
- Move the include GNUInstallDirs to ensure that `CMAKE_INSTALL_INCLUDEDIR` is defined even with older versions of CMake
- Set the minimum version to 3.8 (3.8 is required for `cxx_std_17`)
- Set policy version to 3.23 (latest)
- Set the package version with the `project` command rather than with `write_basic_package_version_file`
- Respect `CMAKE_SKIP_INSTALL_RULES`
- Make C++17 a usage requirement of the library instead of a mere build requirement
- Fix a bug where libassert as a static lib couldn't be linked to a shared object because of relocations by activating `-fpic` through `CMAKE_POSITION_INDEPENDENT_CODE`, see `readelf --relocs libassert.a`
- Set the visibility of symbols to "hidden" rather than "default". 