### PR TITLE
Add: Error if compiling with < C++17

### DIFF
--- a/include/assert.hpp
+++ b/include/assert.hpp
@@ -14,7 +14,13 @@
 #include <utility>
 #include <vector>
 
-#if __cplusplus >= 202002L
+#if defined(_MSVC_LANG) && _MSVC_LANG < 201703L
+#error "libassert requires C++17"
+#elif !defined(_MSVC_LANG) && __cplusplus < 201703L
+#pragma error "libassert requires C++17"
+#endif
+
+#if __cplusplus >= 202002L || _MSVC_LANG >= 202002L
  #include <compare>
 #endif
 


### PR DESCRIPTION
I noticed you had reverted 40490335fa102bc7f18adc8deca52efef1721f0a because the MSVC tests were failing. MSVC has not defined `__cplusplus` for ages and you need to resort to the `_MSVC_LANG` macro to check for C++ versions with it.

Also, for the check right below including the `<compare>` header, it could be possible to check for `__cpp_lib_three_way_comparison` from C++20's `<version>` header.