### PR TITLE
MSVC: Support /Zc:preprocessor

### DIFF
--- a/.github/workflows/test-20.yml
+++ b/.github/workflows/test-20.yml
@@ -37,6 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [debug, release]
+        cppflags: ["", "/Zc:preprocessor"]
     steps:
     - uses: actions/checkout@v2
     - name: Enable Developer Command Prompt
@@ -46,10 +47,10 @@ jobs:
            python3 -m pip install --upgrade pip
            python3 -m pip install git+https://github.com/jeffkaufman/icdiff.git
     - name: build library
-      run: make COMPILER=msvc STD=c++20
+      run: make COMPILER=msvc STD=c++20 "CPPFLAGS=${{matrix.cppflags}}"
     - name: build tests
       working-directory: tests
-      run: make tests COMPILER=msvc STD=c++20
+      run: make tests COMPILER=msvc STD=c++20 "CPPFLAGS=${{matrix.cppflags}}"
     - name: dos2unix
       working-directory: tests/integration/expected
       run: dos2unix *.txt

--- a/include/assert.hpp
+++ b/include/assert.hpp
@@ -992,7 +992,7 @@ inline void ERROR_ASSERTION_FAILURE_IN_CONSTEXPR_CONTEXT() {}
 // NOLINTNEXTLINE(misc-unused-using-decls)
 using libassert::ASSERTION;
 
-#if LIBASSERT_IS_CLANG || LIBASSERT_IS_GCC
+#if LIBASSERT_IS_CLANG || LIBASSERT_IS_GCC || (defined(_MSVC_TRADITIONAL) && _MSVC_TRADITIONAL == 0)
  // Macro mapping utility by William Swanson https://github.com/swansontec/map-macro/blob/master/map.h
  #define LIBASSERT_EVAL0(...) __VA_ARGS__
  #define LIBASSERT_EVAL1(...) LIBASSERT_EVAL0(LIBASSERT_EVAL0(LIBASSERT_EVAL0(__VA_ARGS__)))


### PR DESCRIPTION
C++ Modules/Header Units enforce /Zc:preprocessor.

https://docs.microsoft.com/en-us/cpp/build/walkthrough-header-units#preprocessor-implications
https://docs.microsoft.com/en-us/cpp/preprocessor/preprocessor-experimental-overview

https://godbolt.org/z/YzEWT5s5v