### PR TITLE
Stringify expected

### DIFF
--- a/include/assert.hpp
+++ b/include/assert.hpp
@@ -544,7 +544,7 @@ namespace libassert::detail {
 
         template<typename T, typename E>
         [[nodiscard]] std::string stringify(const std::expected<T, E>& x, literal_format fmt = literal_format::none) {
-            if (x.has_value()) {
+            if(x.has_value()) {
                 if constexpr(std::is_void_v<T>) {
                     return "expected void";
                 } else {

--- a/include/assert.hpp
+++ b/include/assert.hpp
@@ -14,6 +14,9 @@
 #include <utility>
 #include <vector>
 #include <system_error>
+#ifdef __cpp_lib_expected
+#include <expected>
+#endif
 
 #if defined(_MSVC_LANG) && _MSVC_LANG < 201703L
 #error "libassert requires C++17"
@@ -531,6 +534,26 @@ namespace libassert::detail {
         [[nodiscard]] std::string stringify(std::strong_ordering, literal_format = literal_format::none);
         [[nodiscard]] std::string stringify(std::weak_ordering, literal_format = literal_format::none);
         [[nodiscard]] std::string stringify(std::partial_ordering, literal_format = literal_format::none);
+        #endif
+
+        #ifdef __cpp_lib_expected
+        template<typename E>
+        [[nodiscard]] std::string stringify(const std::unexpected<E>& x, literal_format fmt = literal_format::none) {
+            return "unexpected " + stringify(x.error(), fmt == literal_format::none ? literal_format::dec : fmt);
+        }
+
+        template<typename T, typename E>
+        [[nodiscard]] std::string stringify(const std::expected<T, E>& x, literal_format fmt = literal_format::none) {
+            if (x.has_value()) {
+                if constexpr(std::is_void_v<T>) {
+                    return "expected void";
+                } else {
+                    return "expected " + stringify(*x, fmt == literal_format::none ? literal_format::dec : fmt);
+                }
+            } else {
+                return "unexpected " + stringify(x.error(), fmt == literal_format::none ? literal_format::dec : fmt);
+            }
+        }
         #endif
 
         [[nodiscard]] std::string stringify_ptr(const void*, literal_format = literal_format::none);


### PR DESCRIPTION
Demo (rely on https://github.com/jeremy-rifkin/libassert/pull/28):

```cpp
#include <charconv>
#include <string_view>
#include <expected>

template<typename T>
std::expected<T, std::errc> to(std::string_view str) noexcept
{
    T t;
    auto first = str.data();
    auto last = first + str.size();
    auto r = std::from_chars(first, last, t);
    if (r.ec != std::errc{}) return std::unexpected(r.ec);
    else return t;
}

int main()
{
    int x = *VERIFY(to<int>("123456789123456789"));
}
```

![image](https://user-images.githubusercontent.com/8402260/184666115-3bc8571a-e2c2-4956-b56c-b54e5cc09e01.png)

