### PR TITLE
Don't run tests when library is used with add_subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,14 +75,16 @@ if(CMAKE_BUILD_TYPE STREQUAL "")
   message(FATAL_ERROR "Setting CMAKE_BUILD_TYPE is required")
 endif()
 
-if(ASSERT_BUILD_TESTS)
-  include(CTest)
-  add_test(
-    NAME run-tests.py
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests
-    COMMAND
-    python3 run-tests.py --build --build_type=${CMAKE_BUILD_TYPE} --compiler=${CMAKE_CXX_COMPILER_ID}
-  )
+if (PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  if(ASSERT_BUILD_TESTS)
+    include(CTest)
+    add_test(
+      NAME run-tests.py
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests
+      COMMAND
+      python3 run-tests.py --build --build_type=${CMAKE_BUILD_TYPE} --compiler=${CMAKE_CXX_COMPILER_ID}
+    )
+  endif()
 endif()
 
 if(NOT CMAKE_SKIP_INSTALL_RULES)


### PR DESCRIPTION
When using a library with `add_subdirectory`, we generally don't want it to build and run its own test suite, especially since the tools required to do so aren't always available to consumers (such as python or make).

This PR is a simple fix, though you can probably make `ASSERT_BUILD_TESTS` a dependent option.