### PR TITLE
Fix -Wuseless-cast warning in ASSERT_INVOKE

### DIFF
--- a/include/assert.hpp
+++ b/include/assert.hpp
@@ -1249,8 +1249,7 @@ using libassert::ASSERTION;
         LIBASSERT_IGNORE_UNUSED_VALUE \
         LIBASSERT_STMTEXPR( \
           LIBASSERT_WARNING_PRAGMA \
-          auto libassert_decomposer = \
-                         libassert::detail::expression_decomposer(libassert::detail::expression_decomposer{} << expr); \
+          libassert::detail::expression_decomposer libassert_decomposer(libassert::detail::expression_decomposer{} << expr); \
           decltype(auto) libassert_value = libassert_decomposer.get_value(); \
           constexpr bool libassert_ret_lhs = libassert_decomposer.ret_lhs(); \
           if constexpr(check_expression) { \


### PR DESCRIPTION
Turning `auto xx = type(...);` into `type xx(...);` seems enough to silence the warning.

Fixes #49