### PR TITLE
Fix compilation with C++20

### DIFF
--- a/include/assert.hpp
+++ b/include/assert.hpp
@@ -169,6 +169,7 @@ namespace libassert::detail {
     struct opaque_trace {
         void* trace;
         ~opaque_trace();
+        opaque_trace(void* t) : trace(t) {}
         opaque_trace(const opaque_trace&) = delete;
         opaque_trace(opaque_trace&&) = delete;
         opaque_trace& operator=(const opaque_trace&) = delete;


### PR DESCRIPTION
Due to changes to aggregate initialisation in C++20 [dcl.init.aggr], a class type that has a user-declared constructor is no longer considered an aggregate, which means that code such as
```c++
struct S {
    int x;
    S(const S&) = delete;
};

S s{1}; // Error in C++20: Not an aggregate.
```
fails to compile in C++20, even though it was well-formed in C++17.

There was one instance of this in the library, i.e. `opaque_trace`, which is aggregate-initialised in the library, but is no longer an aggregate as of C++20. This pr adds a constructor to the class to make it possible again to initialise an instance of it with a `void*`.