### PR TITLE
Possibly improve `LIBASSERT_UNREACHABLE` macro

### DIFF
--- a/include/libassert/assert.hpp
+++ b/include/libassert/assert.hpp
@@ -248,7 +248,7 @@ namespace libassert::detail {
     template<typename T>
     inline constexpr bool is_arith_not_bool_char =
             std::is_arithmetic_v<strip<T>>
-            && !isany<T, bool, char, unsigned char, signed char, wchar_t, char8_t, char16_t, char32_t>;
+            && !isany<T, bool, char, wchar_t, char8_t, char16_t, char32_t>;
 
     template<typename T>
     inline constexpr bool is_c_string = isany<std::decay_t<strip<T>>, char*, const char*>;

--- a/include/libassert/assert.hpp
+++ b/include/libassert/assert.hpp
@@ -63,18 +63,18 @@
 #endif
 
 #ifdef LIBASSERT_STATIC_DEFINE
-#  define LIBASSERT_EXPORT
-#  define LIBASSERT_NO_EXPORT
+ #define LIBASSERT_EXPORT
+ #define LIBASSERT_NO_EXPORT
 #else
-#  ifndef LIBASSERT_EXPORT
-#    ifdef libassert_lib_EXPORTS
-        /* We are building this library */
-#      define LIBASSERT_EXPORT LIBASSERT_EXPORT_ATTR
-#    else
-        /* We are using this library */
-#      define LIBASSERT_EXPORT LIBASSERT_IMPORT_ATTR
-#    endif
-#  endif
+ #ifndef LIBASSERT_EXPORT
+  #ifdef libassert_lib_EXPORTS
+   /* We are building this library */
+   #define LIBASSERT_EXPORT LIBASSERT_EXPORT_ATTR
+  #else
+   /* We are using this library */
+   #define LIBASSERT_EXPORT LIBASSERT_IMPORT_ATTR
+  #endif
+ #endif
 #endif
 
 #define LIBASSERT_IS_CLANG 0
@@ -99,12 +99,19 @@
  #define LIBASSERT_PFUNC __extension__ __PRETTY_FUNCTION__
  #define LIBASSERT_ATTR_COLD     [[gnu::cold]]
  #define LIBASSERT_ATTR_NOINLINE [[gnu::noinline]]
- #define LIBASSERT_UNREACHABLE __builtin_unreachable()
 #else
  #define LIBASSERT_PFUNC __FUNCSIG__
  #define LIBASSERT_ATTR_COLD
  #define LIBASSERT_ATTR_NOINLINE __declspec(noinline)
- #define LIBASSERT_UNREACHABLE __assume(false)
+#endif
+
+#if __cplusplus >= 202302 // C++23
+ #include <utility>
+ #define LIBASSERT_UNREACHABLE() ::std::unreachable()
+#elif LIBASSERT_IS_MSVC
+ #define LIBASSERT_UNREACHABLE() __assume(false)
+#else
+ #define LIBASSERT_UNREACHABLE() __builtin_unreachable()
 #endif
 
 #if LIBASSERT_IS_MSVC
@@ -1658,7 +1665,7 @@ namespace libassert {
     LIBASSERT_WARNING_PRAGMA_POP_CLANG
 
 #ifdef NDEBUG
- #define LIBASSERT_ASSUME_ACTION LIBASSERT_UNREACHABLE;
+ #define LIBASSERT_ASSUME_ACTION LIBASSERT_UNREACHABLE();
 #else
  #define LIBASSERT_ASSUME_ACTION
 #endif
@@ -1694,7 +1701,7 @@ namespace libassert {
 #ifndef NDEBUG
  #define UNREACHABLE(...) LIBASSERT_INVOKE_PANIC("UNREACHABLE", unreachable, __VA_ARGS__)
 #else
- #define UNREACHABLE(...) LIBASSERT_UNREACHABLE
+ #define UNREACHABLE(...) LIBASSERT_UNREACHABLE()
 #endif
 
 // value variants

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -17,7 +17,7 @@
 
 namespace libassert::detail {
     // Still present in release mode, nonfatal
-    #define internal_verify(c, ...) primitive_assert_impl(c, true, #c, LIBASSERT_PFUNC, {}, ##__VA_ARGS__)
+    #define internal_verify(c, ...) primitive_assert_impl(c, true, #c, LIBASSERT_PFUNC, {} LIBASSERT_VA_ARGS(__VA_ARGS__))
 
     /*
      * string utilities


### PR DESCRIPTION
- Make the macro function-like
- Use `std::unreachable()` if C++23
- Fix unrelated macro indentation