### PR TITLE
Rework tokenization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ target_sources(
   src/platform.cpp
   src/printing.cpp
   src/paths.cpp
+  src/tokenizer.cpp
 )
 
 # link dependencies

--- a/include/libassert/assert.hpp
+++ b/include/libassert/assert.hpp
@@ -974,6 +974,7 @@ namespace libassert {
         std::string_view scope_resolution_identifier;
         std::string_view identifier;
         std::string_view accent;
+        std::string_view unknown;
         std::string_view reset;
         LIBASSERT_EXPORT static color_scheme ansi_basic;
         LIBASSERT_EXPORT static color_scheme ansi_rgb;

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -20,6 +20,7 @@
 #include "common.hpp"
 #include "utils.hpp"
 #include "analysis.hpp"
+#include "tokenizer.hpp"
 
 namespace libassert::detail {
     /*
@@ -75,21 +76,6 @@ namespace libassert::detail {
     }
 
     class analysis {
-        enum class token_e {
-            keyword,
-            punctuation,
-            number,
-            string,
-            named_literal,
-            identifier,
-            whitespace
-        };
-
-        struct token_t {
-            token_e token_type;
-            std::string str;
-        };
-
     public:
         // Analysis singleton, lazy-initialize all the regex nonsense
         // 8 BSS bytes and <512 bytes heap bytes not a problem
@@ -103,8 +89,6 @@ namespace libassert::detail {
             return *analysis_singleton;
         }
 
-        // could all be const but I don't want to try to pack everything into an init list
-        std::vector<std::pair<token_e, std::regex>> rules; // could be std::array but I don't want to hard-code a size
         std::regex escapes_re;
         std::unordered_map<std::string_view, int> precedence;
         std::unordered_map<std::string_view, std::string_view> braces = {
@@ -177,8 +161,6 @@ namespace libassert::detail {
             // https://eel.is/c++draft/lex.pptoken#3.2
             *std::find(std::begin(punctuators), std::end(punctuators), "<:") += "(?!:[^:>])";
             // regular expressions
-            std::string keywords_re    = "(?:" + join(keywords, "|") + ")\\b";
-            std::string punctuators_re = join(punctuators, "|");
             // numeric literals
             const std::string optional_integer_suffix = "(?:[Uu](?:LL?|ll?|Z|z)?|(?:LL?|ll?|Z|z)[Uu]?)?";
             const std::string int_binary  = "0[Bb][01](?:'?[01])*" + optional_integer_suffix;
@@ -221,49 +203,7 @@ namespace libassert::detail {
             // char and string literals
             const std::string escapes = R"(\\[0-7]{1,3}|\\x[\da-fA-F]+|\\.)";
             const std::string char_literal = R"((?:u8|[UuL])?'(?:)" + escapes + R"(|[^\n'])*')";
-            const std::string string_literal = R"((?:u8|[UuL])?"(?:)" + escapes + R"(|[^\n"])*")";
-                                 // \2 because the first capture is the match without the rest of the file
-            const std::string raw_string_literal = R"((?:u8|[UuL])?R"([^ ()\\t\r\v\n]*)\((?:(?!\)\2\").)*\)\2")";
             escapes_re = std::regex(escapes);
-            // final rule set
-            // rules must be sequenced as a topological sort adhering to:
-            // keyword > identifier
-            // number > punctuation (for .1f)
-            // float > int (for 1.5 and hex floats)
-            // hex int > decimal int
-            // named_literal > identifier
-            // string > identifier (for R"(foobar)")
-            // punctuation > identifier (for "not" and other alternative operators)
-            const std::pair<token_e, std::string> rules_raw[] = {
-                { token_e::keyword    , keywords_re },
-                { token_e::number     , union_regexes({
-                    float_decimal,
-                    float_hex,
-                    int_binary,
-                    int_octal,
-                    int_hex,
-                    int_decimal
-                }) },
-                { token_e::punctuation, punctuators_re },
-                // nullopt added deliberately
-                { token_e::named_literal, "true|false|nullptr|nullopt" },
-                { token_e::string     , union_regexes({
-                    char_literal,
-                    raw_string_literal,
-                    string_literal
-                }) },
-                { token_e::identifier , R"((?!\d+)(?:[\da-zA-Z_\$]|\\u[\da-fA-F]{4}|\\U[\da-fA-F]{8})+)" },
-                { token_e::whitespace , R"(\s+)" }
-            };
-            rules.resize(std::size(rules_raw));
-            for(size_t i = 0; i < std::size(rules_raw); i++) {
-                                // [^] instead of . because . does not match newlines
-                const std::string str = stringf("^(%s)[^]*", rules_raw[i].second.c_str());
-                #ifdef _0_DEBUG_ASSERT_LEXER_RULES
-                 fprintf(stderr, "%s : %s\n", rules_raw[i].first.c_str(), str.c_str());
-                #endif
-                rules[i] = { rules_raw[i].first, std::regex(str) };
-            }
             // setup literal format rules
             literal_formats = {
                 { std::regex(int_binary),    literal_format::integer_binary },
@@ -325,45 +265,12 @@ namespace libassert::detail {
         }
 
         LIBASSERT_ATTR_COLD
-        std::vector<token_t> tokenize(std::string_view expression, bool decompose_shr = false) {
-            std::vector<token_t> tokens;
-            size_t i = 0;
-            while(i < expression.length()) {
-                std::cmatch match;
-                bool at_least_one_matched = false;
-                for(const auto& [ type, re ] : rules) {
-                    // std::string_view::iterator is const char* on libc++ and libstdc++, but in msvc it's a class.
-                    // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-                    if(std::regex_match(expression.data() + i, expression.data() + expression.size(), match, re)) {
-                        #ifdef _0_DEBUG_ASSERT_TOKENIZATION
-                         fprintf(stderr, "%s\n", match[1].str().c_str());
-                         fflush(stdout);
-                        #endif
-                        if(decompose_shr && match[1].str() == ">>") { // Do >> decomposition now for templates
-                            tokens.push_back({ type, ">" });
-                            tokens.push_back({ type, ">" });
-                        } else {
-                            tokens.push_back({ type, match[1].str() });
-                        }
-                        i += match[1].length();
-                        at_least_one_matched = true;
-                        break;
-                    }
-                }
-                if(!at_least_one_matched) {
-                    throw std::logic_error("error: invalid token");
-                }
-            }
-            return tokens;
-        }
-
-        LIBASSERT_ATTR_COLD
-        std::vector<highlight_block> highlight_string(const std::string& str, color_scheme scheme) const {
+        std::vector<highlight_block> highlight_string(std::string_view str, color_scheme scheme) const {
             std::vector<highlight_block> output;
-            std::smatch match;
+            std::cmatch match;
             std::size_t i = 0;
             // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-            while(std::regex_search(str.cbegin() + i, str.cend(), match, escapes_re)) {
+            while(std::regex_search(str.data() + i, str.data() + str.size(), match, escapes_re)) {
                 // add string part
                 // TODO: I don't know why this assert was added, I might have done it in dev on a whim. Re-evaluate.
                 // LIBASSERT_PRIMITIVE_ASSERT(match.position() > 0);
@@ -390,7 +297,7 @@ namespace libassert::detail {
                 // Peek next non-whitespace token, return empty whitespace token if end is reached
                 const auto peek = [i, &tokens](size_t j = 1) {
                     for(size_t k = 1; j > 0 && i + k < tokens.size(); k++) {
-                        if(tokens[i + k].token_type != token_e::whitespace) {
+                        if(tokens[i + k].type != token_e::whitespace) {
                             if(--j == 0) {
                                 return tokens[i + k];
                             }
@@ -399,7 +306,7 @@ namespace libassert::detail {
                     LIBASSERT_PRIMITIVE_ASSERT(j != 0);
                     return token_t { token_e::whitespace, "" };
                 };
-                switch(token.token_type) {
+                switch(token.type) {
                     case token_e::keyword:
                         output.push_back({scheme.keyword, token.str});
                         break;
@@ -434,6 +341,9 @@ namespace libassert::detail {
                     case token_e::whitespace:
                         output.push_back({"", token.str});
                         break;
+                    case token_e::unknown:
+                        output.push_back({scheme.unknown, token.str});
+                        break;
                 }
             }
             return output;
@@ -455,7 +365,7 @@ namespace libassert::detail {
         static token_t find_last_non_ws(const std::vector<token_t>& tokens, size_t i) {
             // returns empty token_e::whitespace on failure
             while(i--) {
-                if(tokens[i].token_type != token_e::whitespace) {
+                if(tokens[i].type != token_e::whitespace) {
                     return tokens[i];
                 }
             }
@@ -517,7 +427,7 @@ namespace libassert::detail {
                             if(count-- == 0) {
                                 break;
                             }
-                        } else if(tokens[i].token_type != token_e::whitespace) {
+                        } else if(tokens[i].type != token_e::whitespace) {
                             empty = false;
                         }
                     }
@@ -526,7 +436,7 @@ namespace libassert::detail {
                     }
                     return empty;
                 };
-                switch(token.token_type) {
+                switch(token.type) {
                     case token_e::punctuation:
                         if(operators.count(token.str)) {
                             if(state == expecting_term) {
@@ -534,7 +444,7 @@ namespace libassert::detail {
                             } else {
                                 // template can only open with a < token, no need to check << or <<=
                                 // also must be preceeded by an identifier
-                                if(token.str == "<" && find_last_non_ws(tokens, i).token_type == token_e::identifier) {
+                                if(token.str == "<" && find_last_non_ws(tokens, i).type == token_e::identifier) {
                                     // branch 1: this is a template opening
                                     const bool success = pseudoparse(
                                         tokens,
@@ -620,6 +530,7 @@ namespace libassert::detail {
                     case token_e::number:
                     case token_e::string:
                     case token_e::identifier:
+                    case token_e::unknown:
                         state = expecting_operator;
                     case token_e::whitespace:
                         break;
@@ -707,11 +618,11 @@ namespace libassert::detail {
                 std::vector<std::string> right_strings;
                 const size_t m = *candidates.begin();
                 for(size_t i = 0; i < m; i++) {
-                    left_strings.push_back(tokens[i].str);
+                    left_strings.push_back(std::string(tokens[i].str));
                 }
                 // >> is decomposed and requires special handling (m will be the index of the first > token)
                 for(size_t i = m + 1 + (target_op == ">>" ? 1 : 0); i < tokens.size(); i++) {
-                    right_strings.push_back(tokens[i].str);
+                    right_strings.push_back(std::string(tokens[i].str));
                 }
                 return {
                     std::string(trim(join(left_strings, ""))),

--- a/src/analysis.hpp
+++ b/src/analysis.hpp
@@ -11,6 +11,7 @@ namespace libassert::detail {
     struct highlight_block {
         std::string_view color;
         std::string content;
+        highlight_block(std::string_view color_, std::string_view content_) : color(color_), content(content_) {}
     };
 
     LIBASSERT_ATTR_COLD LIBASSERT_EXPORT /* FIXME */

--- a/src/assert.cpp
+++ b/src/assert.cpp
@@ -376,6 +376,7 @@ namespace libassert {
         BASIC_YELLOW, /* scope_resolution_identifier */
         BASIC_BLUE, /* identifier */
         BASIC_BLUE, /* accent */
+        BASIC_RED, /* unknown */
         RESET
     };
 
@@ -390,6 +391,7 @@ namespace libassert {
         RGB_YELLOW, /* scope_resolution_identifier */
         RGB_BLUE, /* identifier */
         RGB_BLUE, /* accent */
+        RGB_RED, /* unknown */
         RESET
     };
 

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -34,7 +34,7 @@ namespace libassert {
             return 0;
         }
         #if IS_WINDOWS
-         DWORD windows_handle = detail::small_static_map(fd).lookup(
+         DWORD windows_handle = detail::needle(fd).lookup(
              STDIN_FILENO, STD_INPUT_HANDLE,
              STDOUT_FILENO, STD_OUTPUT_HANDLE,
              STDERR_FILENO, STD_ERROR_HANDLE

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -1,0 +1,431 @@
+#include "tokenizer.hpp"
+
+#include <array>
+#include <cctype>
+#include <string_view>
+#include <vector>
+#include <optional>
+#include <unordered_set>
+
+#include "utils.hpp"
+
+namespace libassert::detail {
+
+    // http://eel.is/c++draft/lex.name#nt:identifier
+    bool is_identifier_start(char c) {
+        return isalpha(c) || c == '$' || c == '_';
+    }
+    bool is_identifier_continue(char c) {
+        return isdigit(c) || is_identifier_start(c);
+    }
+    bool is_hex_digit(char c) {
+        // codegen is ok https://godbolt.org/z/sEnGPszao
+        return isdigit(c) || needle(c).is_in('a', 'b', 'c', 'd', 'e', 'f', 'A', 'B', 'C', 'D', 'E', 'F');
+    }
+    bool is_octal_digit(char c) {
+        // codegen is ok https://godbolt.org/z/sEnGPszao
+        return needle(c).is_in('0', '1', '2', '3', '4', '5', '6', '7');
+    }
+
+    // http://eel.is/c++draft/lex.operators#nt:operator-or-punctuator
+
+    constexpr std::array punctuators_and_operators = []() constexpr {
+        std::array arr = to_array<std::string_view>({
+            "{",        "}",        "[",        "]",        "(",        ")",
+            "<:",       ":>",       "<%",       "%>",       ";",        ":",        "...",
+            "?",        "::",       ".",        ".*",       "->",       "->*",      "~",
+            "!",        "+",        "-",        "*",        "/",        "%",        "^",        "&",        "|",
+            "=",        "+=",       "-=",       "*=",       "/=",       "%=",       "^=",       "&=",       "|=",
+            "==",       "!=",       "<",        ">",        "<=",       ">=",       "<=>",      "&&",       "||",
+            "<<",       ">>",       "<<=",      ">>=",      "++",       "--",       ",",
+            "and",      "or",       "xor",      "not",      "bitand",   "bitor",    "compl",
+            "and_eq",   "or_eq",    "xor_eq",   "not_eq",
+        });
+        constexpr_sort(arr, [](std::string_view a, std::string_view b) { return a.size() < b.size(); });
+        return arr;
+    } ();
+
+    // constexpr std::array punctuators = []() constexpr {
+    //     std::array arr = to_array<std::string_view>({
+    //         "{",        "}",        "[",        "]",        "(",        ")",
+    //         "<:",       ":>",       "<%",       "%>",       ";",        ":",        "...",
+    //         "?",        "::",       ".",        ".*",       "->",       "->*",      ","
+    //     });
+    //     constexpr_sort(arr, [](std::string_view a, std::string_view b) { return a.size() < b.size(); });
+    //     return arr;
+    // } ();
+
+    // constexpr std::array operators = []() constexpr {
+    //     std::array arr = to_array<std::string_view>({
+    //         "~",
+    //         "!",        "+",        "-",        "*",        "/",        "%",        "^",        "&",        "|",
+    //         "=",        "+=",       "-=",       "*=",       "/=",       "%=",       "^=",       "&=",       "|=",
+    //         "==",       "!=",       "<",        ">",        "<=",       ">=",       "<=>",      "&&",       "||",
+    //         "<<",       ">>",       "<<=",      ">>=",      "++",       "--",
+    //         "and",      "or",       "xor",      "not",      "bitand",   "bitor",    "compl",
+    //         "and_eq",   "or_eq",    "xor_eq",   "not_eq"
+    //     });
+    //     constexpr_sort(arr, [](std::string_view a, std::string_view b) { return a.size() < b.size(); });
+    //     return arr;
+    // } ();
+
+    // key#nt:keyword
+    // [...temp0.querySelectorAll("span.keyword, span.literal")].map(node => `"${node.innerHTML.replace(`<span class="shy"></span>`, "")}",`).join("\n")
+    std::unordered_set<std::string_view> keywords {
+        "alignas",
+        "constinit",
+        // "false",
+        "public",
+        // "true",
+        "alignof",
+        "const_cast",
+        "float",
+        "register",
+        "try",
+        "asm",
+        "continue",
+        "for",
+        "reinterpret_cast",
+        "typedef",
+        "auto",
+        "co_await",
+        "friend",
+        "requires",
+        "typeid",
+        "bool",
+        "co_return",
+        "goto",
+        "return",
+        "typename",
+        "break",
+        "co_yield",
+        "if",
+        "short",
+        "union",
+        "case",
+        "decltype",
+        "inline",
+        "signed",
+        "unsigned",
+        "catch",
+        "default",
+        "int",
+        "sizeof",
+        "using",
+        "char",
+        "delete",
+        "long",
+        "static",
+        "virtual",
+        "char8_t",
+        "do",
+        "mutable",
+        "static_assert",
+        "void",
+        "char16_t",
+        "double",
+        "namespace",
+        "static_cast",
+        "volatile",
+        "char32_t",
+        "dynamic_cast",
+        "new",
+        "struct",
+        "wchar_t",
+        "class",
+        "else",
+        "noexcept",
+        "switch",
+        "while",
+        "concept",
+        "enum",
+        // "nullptr",
+        "template",
+        "const",
+        "explicit",
+        "operator",
+        "this",
+        "consteval",
+        "export",
+        "private",
+        "thread_local",
+        "constexpr",
+        "extern",
+        "protected",
+        "throw"
+    };
+
+    class tokenizer {
+        std::string_view source;
+        std::string_view::iterator it;
+    public:
+        tokenizer(std::string_view source_) : source(source_), it(source.begin()) {}
+        std::vector<token_t> tokenize(bool decompose_shr = false) {
+            std::vector<token_t> tokens;
+            while(!end()) {
+                // Blanks, horizontal and vertical tabs, newlines, formfeeds, and comments (collectively, “whitespace”), as
+                // described below, are ignored except as they serve to separate tokens.
+                // http://eel.is/c++draft/lex.token#1.sentence-2
+                if(isspace(peek())) {
+                    tokens.push_back(read_whitespace());
+                } else if(peek("//")) { // comments can't show up here but may as well
+                    read_comment();
+                } else if(peek("/*")) {
+                    read_multi_line_comment();
+                }
+                // There are five kinds of tokens: identifiers, keywords, literals, operators, and other separators
+                // http://eel.is/c++draft/lex.token#1.sentence-1
+                // check in the following order:
+                // 1. punctuators    must come before identifiers due to and/or/not/bitand/etc
+                // 2. literals       must come before identifiers due to R"()" and stuff
+                // 3. identifiers and keywords
+                else if(auto punctuator = peek_any(punctuators_and_operators)) {
+                    advance(punctuator->size());
+                    // handle <:: edge case https://eel.is/c++draft/lex.pptoken#3.2
+                    if(punctuator == "<:" && peek() == ':' && !needle(peek(1)).is_in(':', '>')) {
+                        rollback(1);
+                        tokens.push_back({token_e::punctuation, "<"});
+                    }
+                    // handle >> decomposition for templates
+                    else if(decompose_shr && punctuator == ">>") {
+                        tokens.push_back({token_e::punctuation, ">"});
+                        tokens.push_back({token_e::punctuation, ">"});
+                    } else {
+                        tokens.push_back({token_e::punctuation, *punctuator});
+                    }
+                }
+                // 2. literals
+                //      integer-literal          all start with digits
+                //      character-literal        a prefix (u8  u  U  L) followed by ''
+                //      floating-point-literal   all start with digits
+                //      string-literal           a prefix (u8  u  U  L) followed by "", or R"...(...)..."
+                //      boolean-literal          true/false
+                //      pointer-literal          nullptr
+                //      user-defined-literal     integer/float/string/char literal followed by a ud-suffix
+                else if(auto named_literal = peek_any(to_array<std::string_view>({"false", "true", "nullptr"}))) {
+                    advance(named_literal->size());
+                    tokens.push_back({token_e::named_literal, *named_literal});
+                }
+                else if( // char literals
+                    auto prefix = peek_any(to_array<std::string_view>({"u8", "u", "U", "L"}));
+                    peek(prefix.value_or("").size()) == '\''
+                ) {
+                    auto begin = pos();
+                    advance(prefix.value_or("").size());
+                    read_char_literal();
+                    auto end = pos();
+                    tokens.push_back({token_e::string, std::string_view(source.data() + begin, end - begin)});
+                }
+                else if( // string literals
+                    // reusing same prefix from last if
+                    peek(prefix.value_or("").size()) == '"'
+                        || (peek(prefix.value_or("").size()) == 'R' && peek(prefix.value_or("").size() + 1) == '"')
+                ) {
+                    auto begin = pos();
+                    advance(prefix.value_or("").size());
+                    if(peek() == 'R') {
+                        read_raw_string_literal();
+                    } else {
+                        read_string_literal();
+                    }
+                    auto end = pos();
+                    tokens.push_back({token_e::string, std::string_view(source.data() + begin, end - begin)});
+                }
+                else if(isdigit(peek())) { // integer, float, or UDL
+                    auto begin = pos();
+                    read_numeric_literal();
+                    auto end = pos();
+                    tokens.push_back({token_e::number, std::string_view(source.data() + begin, end - begin)});
+                }
+                // 3. identifiers
+                else if(is_identifier_start(peek())) {
+                    auto begin = pos();
+                    read_identifier_or_keyword();
+                    auto end = pos();
+                    std::string_view contents = std::string_view(source.data() + begin, end - begin);
+                    tokens.push_back({
+                        keywords.find(contents) == keywords.end() ? token_e::identifier : token_e::keyword,
+                        contents
+                    });
+                } else {
+                    // we don't know....
+                    tokens.push_back({token_e::unknown, std::string_view(source.data(), 1)});
+                    advance();
+                }
+
+                // // universal character escapes like \U0001F60A get stringified so we have to handle them
+                // // http://eel.is/c++draft/lex#charset-3
+                // // fortunately we don't have to worry about unicode spellings of basic character set characters
+                // // http://eel.is/c++draft/lex#charset-6.sentence-1
+                // else if(peek() == '\\' && needle(peek(1)).is_in('u', 'U', 'N')) {
+                //     // tokens.push_back(read_universal_character_name());
+                // }
+            }
+            return tokens;
+        }
+    private:
+        token_t read_whitespace() {
+            auto begin = pos();
+            std::size_t count = 0;
+            while(isspace(peek())) {
+                advance();
+                count++;
+            }
+            return {token_e::whitespace, std::string_view(source.data() + begin, count)};
+        }
+        void read_comment() {
+            while(!end() && peek() != '\n') advance();
+        }
+        void read_multi_line_comment() {
+            while(!end() && peek() != '*' && peek(1) != '/') advance();
+        }
+        void read_identifier_or_keyword() {
+            while(!end() && is_identifier_continue(peek())) advance();
+        }
+        void read_char_literal() {
+            // http://eel.is/c++draft/lex.ccon
+            expect('\'');
+            while(peek() != '\'') {
+                if(peek() == '\\') {
+                    read_escape_sequence();
+                } else {
+                    advance();
+                }
+            }
+            expect('\'');
+        }
+        void read_string_literal() {
+            // string#nt:string-literal
+            expect('"');
+            while(peek() != '"') {
+                if(peek() == '\\') {
+                    read_escape_sequence();
+                } else {
+                    advance();
+                }
+            }
+            expect('"');
+        }
+        void read_raw_string_literal() {
+            // string#nt:string-literal
+            expect('R');
+            expect('"');
+            // read d-char sequence
+            // we'll be much more permissive about what is allowed as a d-char, we'll allow anything that's not a (
+            auto d_begin = pos();
+            while(peek() != '(') {
+                advance();
+            }
+            auto d_char_sequence = std::string_view(source.data() + d_begin, pos() - d_begin);
+            // read r-char sequence
+            while(!end()) {
+                if(peek() == ')' && peek(d_char_sequence, 1) && peek(1 + d_char_sequence.size()) == '"') {
+                    // end of string
+                    advance(1 + d_char_sequence.size() + 1);
+                } else {
+                    advance();
+                }
+            }
+            expect('"');
+        }
+        void read_escape_sequence() {
+            // http://eel.is/c++draft/lex.ccon#nt:escape-sequence
+            // escape-sequence:
+            //   simple-escape-sequence
+            //   numeric-escape-sequence
+            //   conditional-escape-sequence
+            expect('\\');
+            // the only escape sequences we really need to parse are those that could contain ' or "
+            if(peek() == 'N' && peek(1) == '{') {
+                advance();
+                read_braced_sequence();
+            } else {
+                // read it as though it's a simple-escape-sequence
+                advance();
+            }
+        }
+        void read_numeric_literal() {
+            // since we can assume a valid token, and we'll treat it as a pp-number....
+            // http://eel.is/c++draft/lex.ppnumber
+            // just read [0-9a-zA-Z'\.]+, essentially, with special handling for exponents/sign
+            while(isdigit(peek()) || isalpha(peek()) || peek() == '\'' ||  peek() == '.') {
+                if(needle(peek()).is_in('e', 'E', 'p', 'P') && needle(peek(1)).is_in('-', '+')) {
+                    advance(2);
+                } else {
+                    advance();
+                }
+            }
+        }
+        // reads a {...}
+        void read_braced_sequence() {
+            expect('{');
+            while(peek() != '}') {
+                advance();
+            }
+            expect('}');
+        }
+    private:
+        std::size_t pos() const {
+            return it - source.begin();
+        }
+        char peek(std::size_t count = 0) const {
+            auto pos = it - source.begin();
+            if(pos + count < source.size()) {
+                return *(it + count);
+            } else {
+                return 0;
+            }
+        }
+        bool peek(std::string_view pattern, std::size_t offset = 0) const {
+            for(std::size_t i = 0; i < pattern.size(); i++) {
+                if(peek(offset + i) != pattern[i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        template<std::size_t N>
+        std::optional<std::string_view> peek_any(const std::array<std::string_view, N>& candidates) const {
+            for(auto entry : candidates) {
+                if(peek(entry)) {
+                    return entry;
+                }
+            }
+            return std::nullopt;
+        }
+        char advance() {
+            if(it != source.end()) {
+                return *it++;
+            } else {
+                return 0;
+            }
+        }
+        void advance(std::size_t count) {
+            while(it != source.end() && count--) {
+                it++;
+            }
+        }
+        void rollback(std::size_t count) {
+            while(count--) {
+                internal_verify(it != source.begin(), "Tokenizer rollback() failed, please report this bug");
+                it--;
+            }
+        }
+        void expect(char c) {
+            internal_verify(peek() == c, "Tokenizer expect() failed, please report this bug");
+            advance();
+        }
+        bool end() const {
+            return it == source.end();
+        }
+    };
+
+    std::vector<token_t> tokenize(std::string_view source, bool decompose_shr) {
+        // try {
+            return tokenizer(source).tokenize(decompose_shr);
+        // } catch(...) {
+            // return {};
+        // }
+    }
+
+}

--- a/src/tokenizer.hpp
+++ b/src/tokenizer.hpp
@@ -1,0 +1,30 @@
+#ifndef TOKENIZER_HPP
+#define TOKENIZER_HPP
+
+#include <string_view>
+#include <vector>
+
+namespace libassert::detail {
+    enum class token_e {
+        keyword,
+        punctuation,
+        number,
+        string,
+        named_literal,
+        identifier,
+        whitespace,
+        unknown
+    };
+
+    struct token_t {
+        token_e type;
+        std::string_view str;
+        token_t(token_e type_, std::string_view str_) : type(type_), str(str_) {}
+    };
+
+    // lifetime notes: token_t's store string_views to data with at least the same lifetime as the source string_view's
+    // data
+    std::vector<token_t> tokenize(std::string_view source, bool decompose_shr = false);
+}
+
+#endif


### PR DESCRIPTION
This PR removes a lot of the previous regex-based lexer implementation and implement a more proper lexer. In the process it resolves #15. The lexer is rather rudimentary because it only needs to do a rather rudimentary tokenization of C++. For the most part if there is an error it tries to continue as best it can.