### PR TITLE
Support gcc 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,32 @@ jobs:
       working-directory: build
       run: |
            CTEST_OUTPUT_ON_FAILURE=1 make test
+  test-linux-gcc-8:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [g++-8]
+        target: [Debug]
+    steps:
+    - uses: actions/checkout@v2
+    - name: dependencies
+      run: |
+           sudo apt install gcc-8 g++-8 libgcc-8-dev
+           python3 -m pip install git+https://github.com/jeffkaufman/icdiff.git
+    - name: build
+      run: |
+           mkdir -p build
+           cd build
+           cmake .. \
+            -DCMAKE_BUILD_TYPE=${{matrix.target}} \
+            -DCMAKE_CXX_COMPILER=${{matrix.compiler}} \
+            -DLIBASSERT_BUILD_TESTING=On
+           make -j
+    - name: test
+      working-directory: build
+      run: |
+           CTEST_OUTPUT_ON_FAILURE=1 make test
   test-macos:
     runs-on: macos-14
     strategy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ if(LIBASSERT_SANITIZER_BUILD)
 endif()
 
 if(LIBASSERT_BUILD_TESTING) # TODO: Maybe remove
-  set(LIBASSERT_USE_MAGIC_ENUM ON)
+  # set(LIBASSERT_USE_MAGIC_ENUM ON)
 endif()
 
 # add pre-processor definitions corresponding to CMake options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,8 +163,14 @@ if(LIBASSERT_SANITIZER_BUILD)
   add_link_options(-fsanitize=address)
 endif()
 
-# add pre-processor definitions corresponding to CMake options
-# fixme: supposedly generator expressions should work for this
+if(
+  LIBASSERT_BUILD_TESTING AND NOT (
+    "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 9.0
+  )
+)
+  set(LIBASSERT_USE_MAGIC_ENUM ON)
+endif()
+
 if(LIBASSERT_USE_MAGIC_ENUM)
   set(MAGIC_ENUM_OPT_INSTALL ON)
   if(LIBASSERT_USE_EXTERNAL_MAGIC_ENUM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,10 +163,6 @@ if(LIBASSERT_SANITIZER_BUILD)
   add_link_options(-fsanitize=address)
 endif()
 
-if(LIBASSERT_BUILD_TESTING) # TODO: Maybe remove
-  # set(LIBASSERT_USE_MAGIC_ENUM ON)
-endif()
-
 # add pre-processor definitions corresponding to CMake options
 # fixme: supposedly generator expressions should work for this
 if(LIBASSERT_USE_MAGIC_ENUM)

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -97,15 +97,14 @@ namespace libassert::detail {
         }
     };
 
-    // copied from cppref
-    template<typename T, std::size_t N, std::size_t... I>
-    constexpr std::array<std::remove_cv_t<T>, N> to_array_impl(T(&&a)[N], std::index_sequence<I...>) {
+    // note: the use of U here is mainly to workaround a gcc 8 issue https://godbolt.org/z/bdsWhdGj3
+    template<typename T, typename U, std::size_t N, std::size_t... I>
+    constexpr std::array<std::remove_cv_t<T>, N> to_array_impl(U(&&a)[N], std::index_sequence<I...>) {
         return {{std::move(a[I])...}};
     }
-
-    template<typename T, std::size_t N>
-    constexpr std::array<std::remove_cv_t<T>, N> to_array(T(&&a)[N]) {
-        return to_array_impl(std::move(a), std::make_index_sequence<N>{});
+    template<typename T, typename U, std::size_t N>
+    constexpr std::array<std::remove_cv_t<T>, N> to_array(U(&&a)[N]) {
+        return to_array_impl<T>(std::move(a), std::make_index_sequence<N>{});
     }
 
     template<typename A, typename B>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,60 +10,62 @@ if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     endif()
     include(CTest)
 
-    # set(
-    #   demo_sources
-    #   tests/demo/bar.cpp
-    #   tests/demo/baz/demo.cpp
-    #   tests/demo/demo.cpp
-    #   tests/demo/foo.cpp
-    # )
-    # add_executable(demo ${demo_sources})
-    # target_link_libraries(demo PRIVATE libassert-lib)
-    # target_compile_options(
-    #   demo
-    #   PRIVATE
-    #   "-DLIBASSERT_USE_MAGIC_ENUM"
-    #   "-DLIBASSERT_LOWERCASE"
-    # )
-    # target_compile_features(
-    #   demo
-    #   PUBLIC cxx_std_20
-    # )
-    # target_compile_definitions(
-    #   demo
-    #   PUBLIC LIBASSERT_SAFE_COMPARISONS
-    # )
+    add_executable(
+      demo
+      tests/demo/bar.cpp
+      tests/demo/baz/demo.cpp
+      tests/demo/demo.cpp
+      tests/demo/foo.cpp
+    )
+    target_link_libraries(demo PRIVATE libassert-lib)
+    target_compile_definitions(demo PRIVATE LIBASSERT_LOWERCASE)
+    if(NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 9.0))
+     target_compile_definitions(demo PRIVATE LIBASSERT_USE_MAGIC_ENUM)
+    endif()
+    target_compile_features(
+      demo
+      PUBLIC cxx_std_20
+    )
+    target_compile_definitions(
+      demo
+      PUBLIC LIBASSERT_SAFE_COMPARISONS
+    )
 
-    # add_executable(integration tests/integration/integration.cpp tests/integration/a.cpp tests/integration/x/a.cpp)
-    # # Temporary workaround for Visual Studio 2022 bug with __builtin_LINE() and __builtin_FILE()
-    # # https://developercommunity.visualstudio.com/t/__builtin_LINE-function-is-reporting-w/10439054?space=62&q=__builtin_function
-    # # TODO: Workaround in the header for end users?
-    # target_compile_features(integration PUBLIC cxx_std_20)
-    # target_link_libraries(integration PRIVATE libassert-lib)
-    # target_compile_options(
-    #   integration
-    #   PRIVATE
-    #   "-DLIBASSERT_USE_MAGIC_ENUM"
-    #   "-DLIBASSERT_LOWERCASE"
-    #   "-DLIBASSERT_SAFE_COMPARISONS"
-    # )
-    # add_test(
-    #   NAME integration
-    #   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests
-    #   COMMAND
-    #   python3 run-tests.py $<TARGET_FILE:integration> ${CMAKE_BUILD_TYPE} ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_STANDARD}
-    # )
+    if(NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 9.0))
+     add_executable(integration tests/integration/integration.cpp tests/integration/a.cpp tests/integration/x/a.cpp)
+     # Temporary workaround for Visual Studio 2022 bug with __builtin_LINE() and __builtin_FILE()
+     # https://developercommunity.visualstudio.com/t/__builtin_LINE-function-is-reporting-w/10439054?space=62&q=__builtin_function
+     # TODO: Workaround in the header for end users?
+     target_compile_features(integration PUBLIC cxx_std_20)
+     target_link_libraries(integration PRIVATE libassert-lib)
+     target_compile_definitions(
+       integration
+       PRIVATE
+       LIBASSERT_USE_MAGIC_ENUM
+       LIBASSERT_LOWERCASE
+       LIBASSERT_SAFE_COMPARISONS
+     )
+     add_test(
+       NAME integration
+       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests
+       COMMAND
+       python3 run-tests.py $<TARGET_FILE:integration> ${CMAKE_BUILD_TYPE} ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_STANDARD}
+     )
+     set(integration_target integration)
+    else()
+     set(integration_target)
+    endif()
 
     set(
       dsym_targets
       demo
-      # integration
+      ${integration_target}
     )
 
     set(
       all_targets
       demo
-      # integration
+      ${integration_target}
     )
 
     include(FetchContent)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,7 +19,7 @@ if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     )
     target_link_libraries(demo PRIVATE libassert-lib)
     target_compile_definitions(demo PRIVATE LIBASSERT_LOWERCASE)
-    if(NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 9.0))
+    if(LIBASSERT_USE_MAGIC_ENUM)
      target_compile_definitions(demo PRIVATE LIBASSERT_USE_MAGIC_ENUM)
     endif()
     target_compile_features(
@@ -31,7 +31,7 @@ if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
       PUBLIC LIBASSERT_SAFE_COMPARISONS
     )
 
-    if(NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 9.0))
+    if(LIBASSERT_USE_MAGIC_ENUM)
      add_executable(integration tests/integration/integration.cpp tests/integration/a.cpp tests/integration/x/a.cpp)
      # Temporary workaround for Visual Studio 2022 bug with __builtin_LINE() and __builtin_FILE()
      # https://developercommunity.visualstudio.com/t/__builtin_LINE-function-is-reporting-w/10439054?space=62&q=__builtin_function

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,60 +10,60 @@ if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     endif()
     include(CTest)
 
-    set(
-      demo_sources
-      tests/demo/bar.cpp
-      tests/demo/baz/demo.cpp
-      tests/demo/demo.cpp
-      tests/demo/foo.cpp
-    )
-    add_executable(demo ${demo_sources})
-    target_link_libraries(demo PRIVATE libassert-lib)
-    target_compile_options(
-      demo
-      PRIVATE
-      "-DLIBASSERT_USE_MAGIC_ENUM"
-      "-DLIBASSERT_LOWERCASE"
-    )
-    target_compile_features(
-      demo
-      PUBLIC cxx_std_20
-    )
-    target_compile_definitions(
-      demo
-      PUBLIC LIBASSERT_SAFE_COMPARISONS
-    )
+    # set(
+    #   demo_sources
+    #   tests/demo/bar.cpp
+    #   tests/demo/baz/demo.cpp
+    #   tests/demo/demo.cpp
+    #   tests/demo/foo.cpp
+    # )
+    # add_executable(demo ${demo_sources})
+    # target_link_libraries(demo PRIVATE libassert-lib)
+    # target_compile_options(
+    #   demo
+    #   PRIVATE
+    #   "-DLIBASSERT_USE_MAGIC_ENUM"
+    #   "-DLIBASSERT_LOWERCASE"
+    # )
+    # target_compile_features(
+    #   demo
+    #   PUBLIC cxx_std_20
+    # )
+    # target_compile_definitions(
+    #   demo
+    #   PUBLIC LIBASSERT_SAFE_COMPARISONS
+    # )
 
-    add_executable(integration tests/integration/integration.cpp tests/integration/a.cpp tests/integration/x/a.cpp)
-    # Temporary workaround for Visual Studio 2022 bug with __builtin_LINE() and __builtin_FILE()
-    # https://developercommunity.visualstudio.com/t/__builtin_LINE-function-is-reporting-w/10439054?space=62&q=__builtin_function
-    # TODO: Workaround in the header for end users?
-    target_compile_features(integration PUBLIC cxx_std_20)
-    target_link_libraries(integration PRIVATE libassert-lib)
-    target_compile_options(
-      integration
-      PRIVATE
-      "-DLIBASSERT_USE_MAGIC_ENUM"
-      "-DLIBASSERT_LOWERCASE"
-      "-DLIBASSERT_SAFE_COMPARISONS"
-    )
-    add_test(
-      NAME integration
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests
-      COMMAND
-      python3 run-tests.py $<TARGET_FILE:integration> ${CMAKE_BUILD_TYPE} ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_STANDARD}
-    )
+    # add_executable(integration tests/integration/integration.cpp tests/integration/a.cpp tests/integration/x/a.cpp)
+    # # Temporary workaround for Visual Studio 2022 bug with __builtin_LINE() and __builtin_FILE()
+    # # https://developercommunity.visualstudio.com/t/__builtin_LINE-function-is-reporting-w/10439054?space=62&q=__builtin_function
+    # # TODO: Workaround in the header for end users?
+    # target_compile_features(integration PUBLIC cxx_std_20)
+    # target_link_libraries(integration PRIVATE libassert-lib)
+    # target_compile_options(
+    #   integration
+    #   PRIVATE
+    #   "-DLIBASSERT_USE_MAGIC_ENUM"
+    #   "-DLIBASSERT_LOWERCASE"
+    #   "-DLIBASSERT_SAFE_COMPARISONS"
+    # )
+    # add_test(
+    #   NAME integration
+    #   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests
+    #   COMMAND
+    #   python3 run-tests.py $<TARGET_FILE:integration> ${CMAKE_BUILD_TYPE} ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_STANDARD}
+    # )
 
     set(
       dsym_targets
       demo
-      integration
+      # integration
     )
 
     set(
       all_targets
       demo
-      integration
+      # integration
     )
 
     include(FetchContent)

--- a/tests/unit/assertion_tests.cpp
+++ b/tests/unit/assertion_tests.cpp
@@ -727,7 +727,7 @@ TEST(LibassertBasic, EnumHandling) {
         DEBUG_ASSERT(b != bar_e::A),
         R"XX(
         |Debug Assertion failed at <LOCATION>:
-        |    DEBUG_ASSERT(b != bar::A);
+        |    DEBUG_ASSERT(b != bar_e::A);
         |    Where:
         |        b        => A
         |        bar_e::A => A

--- a/tests/unit/assertion_tests.cpp
+++ b/tests/unit/assertion_tests.cpp
@@ -708,10 +708,11 @@ TEST(LibassertBasic, LvalueForwarding) {
     EXPECT_EQ(x, 0);
 }
 
+#ifdef LIBASSERT_USE_MAGIC_ENUM
+enum foo_e { A, B };
+enum class bar_e { A, B };
 TEST(LibassertBasic, EnumHandling) {
-    enum foo { A, B };
-    enum class bar { A, B };
-    foo a = A;
+    foo_e a = A;
     CHECK(
         DEBUG_ASSERT(a != A),
         R"XX(
@@ -721,18 +722,47 @@ TEST(LibassertBasic, EnumHandling) {
         |        a => A
         )XX"
     );
-    bar b = bar::A;
+    bar_e b = bar_e::A;
     CHECK(
-        DEBUG_ASSERT(b != bar::A),
+        DEBUG_ASSERT(b != bar_e::A),
         R"XX(
         |Debug Assertion failed at <LOCATION>:
         |    DEBUG_ASSERT(b != bar::A);
         |    Where:
-        |        b      => A
-        |        bar::A => A
+        |        b        => A
+        |        bar_e::A => A
         )XX"
     );
 }
+#else
+// TODO: Also test this outside of gcc 8
+enum foo_e { A, B };
+enum class bar_e { A, B };
+TEST(LibassertBasic, EnumHandling) {
+    foo_e a = A;
+    CHECK(
+        DEBUG_ASSERT(a != A),
+        R"XX(
+        |Debug Assertion failed at <LOCATION>:
+        |    DEBUG_ASSERT(a != A);
+        |    Where:
+        |        a => enum foo_e: 0
+        |        A => enum foo_e: 0
+        )XX"
+    );
+    bar_e b = bar_e::A;
+    CHECK(
+        DEBUG_ASSERT(b != bar_e::A),
+        R"XX(
+        |Debug Assertion failed at <LOCATION>:
+        |    DEBUG_ASSERT(b != bar_e::A);
+        |    Where:
+        |        b        => enum bar_e: 0
+        |        bar_e::A => enum bar_e: 0
+        )XX"
+    );
+}
+#endif
 
 TEST(LibassertBasic, Containers) {
     std::set<int> a = { 2, 2, 4, 6, 10 };


### PR DESCRIPTION
Turns out it's basically just magic enum that can't support gcc 8. Closes #95.