### PR TITLE
fix(gcc): ignore warning for already handled null pointer

### DIFF
--- a/include/libassert/stringification.hpp
+++ b/include/libassert/stringification.hpp
@@ -370,7 +370,10 @@ namespace libassert::detail {
                     return "nullptr";
                 }
             }
+            #pragma GCC diagnostic push
+            #pragma GCC diagnostic ignored "-Wnonnull"
             return stringification::stringify(std::string_view(v));
+            #pragma GCC diagnostic pop
         } else if constexpr(std::is_pointer_v<T> || std::is_function_v<T>) {
             return stringification::stringify_pointer_value(reinterpret_cast<const void*>(v));
         } else if constexpr(is_smart_pointer<T>) {

--- a/include/libassert/stringification.hpp
+++ b/include/libassert/stringification.hpp
@@ -370,10 +370,14 @@ namespace libassert::detail {
                     return "nullptr";
                 }
             }
-            #pragma GCC diagnostic push
-            #pragma GCC diagnostic ignored "-Wnonnull"
+            #if LIBASSERT_IS_GCC
+                #pragma GCC diagnostic push
+                #pragma GCC diagnostic ignored "-Wnonnull"
+            #endif
             return stringification::stringify(std::string_view(v));
-            #pragma GCC diagnostic pop
+            #if LIBASSERT_IS_GCC
+                #pragma GCC diagnostic pop
+            #endif
         } else if constexpr(std::is_pointer_v<T> || std::is_function_v<T>) {
             return stringification::stringify_pointer_value(reinterpret_cast<const void*>(v));
         } else if constexpr(is_smart_pointer<T>) {


### PR DESCRIPTION
[fix: ignore warning for already handled null pointer](https://github.com/jeremy-rifkin/libassert/commit/c185bd7b3efb195f1e0f17286a24bb13d94cc85b)

GCC 13.3 and GCC 14.1 both seem to incorrectly parse the stringification
condition incorrectly, and will warn about null pointers that have
already been returned early from.

---

Unsure if this is the best strategy to solve this, open to revise it. Followed the same pattern as [how old-style ASSERT(foo && "Message")](https://github.com/jeremy-rifkin/libassert/blob/aff047da702316b10219a967f78da352f847b8d0/include/libassert/expression-decomposition.hpp#L120-L132) was implemented.