### PR TITLE
fix: MSVC2022 was a bit intolerant about the `[[nodiscard]]` modifier being placed *past* the function name

### DIFF
--- a/include/libassert/assert.hpp
+++ b/include/libassert/assert.hpp
@@ -457,7 +457,7 @@ LIBASSERT_END_NAMESPACE
 
     // TODO: Re-evaluate benefit of this at all in non-cold path code
     template<typename A, typename B, typename C, typename... Args>
-    LIBASSERT_ATTR_COLD LIBASSERT_ATTR_NOINLINE [[nodiscard]]
+    [[nodiscard]] LIBASSERT_ATTR_COLD LIBASSERT_ATTR_NOINLINE
     expression_decomposer<A, B, C> process_assert_fail_m(
         expression_decomposer<A, B, C> decomposer,
         const assert_static_parameters* params,

--- a/src/assert.cpp
+++ b/src/assert.cpp
@@ -743,7 +743,7 @@ LIBASSERT_BEGIN_NAMESPACE
 LIBASSERT_END_NAMESPACE
 
 LIBASSERT_BEGIN_NAMESPACE
-    LIBASSERT_ATTR_COLD LIBASSERT_ATTR_NOINLINE [[nodiscard]]
+    [[nodiscard]] LIBASSERT_ATTR_COLD LIBASSERT_ATTR_NOINLINE
     std::string stacktrace(int width, const color_scheme& scheme, std::size_t skip) {
         auto trace = cpptrace::generate_trace(skip + 1);
         detail::identity_path_handler handler;


### PR DESCRIPTION
fix: MSVC2022 was a bit intolerant about the `[[nodiscard]]` modifier being placed *past* the function name instead of *before* it.