### PR TITLE
auto-detect the presence of the std::format & {fmt} libraries in the C++ code.

### DIFF
--- a/include/libassert/platform.hpp
+++ b/include/libassert/platform.hpp
@@ -275,8 +275,18 @@ LIBASSERT_END_NAMESPACE
  #define LIBASSERT_BREAKPOINT()
 #endif
 
-#if !defined(LIBASSERT_NO_STD_FORMAT) && defined(__has_include) && __has_include(<format>) && defined(__cpp_lib_format)
- #define LIBASSERT_USE_STD_FORMAT
+// auto-detect libraries to use, when those have not yet been forcibly specified by the user to use
+
+#if !defined(LIBASSERT_USE_MAGIC_ENUM) && defined(__has_include) && (__has_include(<magic_enum/magic_enum.hpp>) || __has_include(<magic_enum.hpp>))
+#define LIBASSERT_USE_MAGIC_ENUM
+#endif
+
+#if !defined(LIBASSERT_USE_FMT) && !defined(LIBASSERT_USE_STD_FORMAT) && defined(__has_include) && __has_include(<fmt/format.h>)
+#define LIBASSERT_USE_FMT
+#endif
+
+#if !defined(LIBASSERT_NO_STD_FORMAT) && !defined(LIBASSERT_USE_FMT) && !defined(LIBASSERT_USE_STD_FORMAT) && defined(__has_include) && __has_include(<format.h>) && defined(__cpp_lib_format)
+#define LIBASSERT_USE_STD_FORMAT
 #endif
 
 #endif

--- a/include/libassert/stringification.hpp
+++ b/include/libassert/stringification.hpp
@@ -24,7 +24,7 @@
  #endif
 #endif
 
-#ifdef LIBASSERT_USE_FMT
+#if defined(LIBASSERT_USE_FMT) && !defined(LIBASSERT_USE_STD_FORMAT)
  #include <fmt/format.h>
 #endif
 
@@ -32,7 +32,7 @@
  #include <compare>
 #endif
 
-#ifdef LIBASSERT_USE_STD_FORMAT
+#if defined(LIBASSERT_USE_STD_FORMAT) && !defined(LIBASSERT_USE_FMT)
  #include <format>
 #endif
 

--- a/tests/unit/fmt-test.cpp
+++ b/tests/unit/fmt-test.cpp
@@ -1,5 +1,8 @@
 #include <libassert/assert-gtest.hpp>
 
+
+#if defined(LIBASSERT_USE_STD_FORMAT) || defined(LIBASSERT_USE_FMT)
+
 #include <fmt/format.h>
 
 struct S {
@@ -67,3 +70,5 @@ TEST(LibassertFmt, FmtContainers) {
     std::vector<fmtable> fvec{{{2}, {3}}};
     ASSERT(libassert::detail::generate_stringification(fvec) == "std::vector<fmtable>: [{2}, {3}]");
 }
+
+#endif


### PR DESCRIPTION
auto-detect the presence of the std::format & {fmt} libraries by checking for their header files (in platform). This automatically sets up the LIBASSERT_USE_FMT & LIBASSERT_USE_STD_FORMAT defines.

---

At least this is useful to me as we don't use CMake; when the include paths are set up to point at those libraries, this should pick them up across the build.