### PR TITLE
Pass decomposition expr to a lambda instead of storing it to a local

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,93 @@
+---
+AccessModifierOffset: -2
+AlignAfterOpenBracket: BlockIndent
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: DontAlign
+AlignOperands: false
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: AfterColon
+BreakInheritanceList: AfterColon
+BreakStringLiterals: false
+ColumnLimit: 100
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+FixNamespaceComments: true
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex:           '^<proxsuite/.*\.h(pp)?>'
+    Priority:        0
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<(Eigen|fmt|libassert|catch2).*>'
+    Priority:        1
+    SortPriority:    2
+    CaseSensitive:   false
+  - Regex:           '^<.*>'
+    Priority:        2
+    SortPriority:    1
+    CaseSensitive:   false
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: BeforeHash
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: Inner
+PointerAlignment: Left
+ReferenceAlignment: Left
+ReflowComments: false
+SeparateDefinitionBlocks: Always
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+UseTab: ForContinuationAndIndentation
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+IndentWidth: 2
+TabWidth: 2
+Macros:
+ - PROXSUITE_REQUIRES(a0, a1, a2, a3, a4, a5, a6, a7)=requires(a0, a1, a2, a3, a4, a5, a6, a7)
+ - PROXSUITE_REQUIRES(a0, a1, a2, a3, a4, a5, a6)=requires(a0, a1, a2, a3, a4, a5, a6)
+ - PROXSUITE_REQUIRES(a0, a1, a2, a3, a4, a5)=requires(a0, a1, a2, a3, a4, a5)
+ - PROXSUITE_REQUIRES(a0, a1, a2, a3, a4)=requires(a0, a1, a2, a3, a4)
+ - PROXSUITE_REQUIRES(a0, a1, a2, a3)=requires(a0, a1, a2, a3)
+ - PROXSUITE_REQUIRES(a0, a1, a2)=requires(a0, a1, a2)
+ - PROXSUITE_REQUIRES(a0, a1)=requires(a0, a1)
+ - PROXSUITE_REQUIRES(a0)=requires(a0)
+...

--- a/include/libassert/assert-catch2-macros.hpp
+++ b/include/libassert/assert-catch2-macros.hpp
@@ -4,63 +4,73 @@
 #include <catch2/catch_version_macros.hpp>
 
 #define LIBASSERT_PREFIX_ASSERTIONS
-#include <libassert/assert-macros.hpp>
-
 #include <stdexcept>
 
+#include <libassert/assert-macros.hpp>
+
 #if defined(_MSVC_TRADITIONAL) && _MSVC_TRADITIONAL
- #error "Libassert integration does not work with MSVC's non-conformant preprocessor. /Zc:preprocessor must be used."
+	#error \
+		"Libassert integration does not work with MSVC's non-conformant preprocessor. /Zc:preprocessor must be used."
 #endif
 // TODO: CHECK/REQUIRE?
-#define ASSERT(...) do { try { LIBASSERT_ASSERT(__VA_ARGS__); SUCCEED(); } catch(std::exception& e) { FAIL(e.what()); } } while(0)
+#define ASSERT(...) \
+	do { \
+		try { \
+			LIBASSERT_ASSERT(__VA_ARGS__); \
+			SUCCEED(); \
+		} catch (std::exception & e) { \
+			FAIL(e.what()); \
+		} \
+	} while (0)
 
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    // catch line wrapping can't handle ansi sequences before 3.6 https://github.com/catchorg/Catch2/issues/2833
-    inline constexpr bool use_color = CATCH_VERSION_MAJOR > 3 || (CATCH_VERSION_MAJOR == 3 && CATCH_VERSION_MINOR >= 6);
+// catch line wrapping can't handle ansi sequences before 3.6 https://github.com/catchorg/Catch2/issues/2833
+inline constexpr bool use_color =
+	CATCH_VERSION_MAJOR > 3 || (CATCH_VERSION_MAJOR == 3 && CATCH_VERSION_MINOR >= 6);
 
-    inline void catch2_failure_handler(const assertion_info& info) {
-        if(use_color) {
-            enable_virtual_terminal_processing_if_needed();
-        }
-        auto scheme = use_color ? color_scheme::ansi_rgb : color_scheme::blank;
-        std::string message = std::string(info.action()) + " at " + info.location() + ":";
-        if(info.message) {
-            message += " " + *info.message;
-        }
-        message += "\n";
-        message += info.statement(scheme)
-                + info.print_binary_diagnostics(CATCH_CONFIG_CONSOLE_WIDTH, scheme)
-                + info.print_extra_diagnostics(CATCH_CONFIG_CONSOLE_WIDTH, scheme);
-        throw std::runtime_error(std::move(message));
-    }
-
-    inline auto pre_main = [] () {
-        set_failure_handler(catch2_failure_handler);
-        return 1;
-    } ();
+inline void catch2_failure_handler(const assertion_info& info) {
+	if (use_color) {
+		enable_virtual_terminal_processing_if_needed();
+	}
+	auto scheme = use_color ? color_scheme::ansi_rgb : color_scheme::blank;
+	std::string message = std::string(info.action()) + " at " + info.location() + ":";
+	if (info.message) {
+		message += " " + *info.message;
+	}
+	message += "\n";
+	message += info.statement(scheme)
+		+ info.print_binary_diagnostics(CATCH_CONFIG_CONSOLE_WIDTH, scheme)
+		+ info.print_extra_diagnostics(CATCH_CONFIG_CONSOLE_WIDTH, scheme);
+	throw std::runtime_error(std::move(message));
 }
+
+inline auto pre_main = []() {
+	set_failure_handler(catch2_failure_handler);
+	return 1;
+}();
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE
 
 // Some testing utilities
 
 #define REQUIRE_ASSERT(expr) \
-    do { \
-        auto handler = ::libassert::get_failure_handler(); \
-        ::libassert::set_failure_handler([] (const ::libassert::assertion_info& info) { \
-            throw info; \
-        }); \
-        bool did_assert = false; \
-        try { \
-            (expr); \
-        } catch(const ::libassert::assertion_info& info) { \
-            did_assert = true; \
-            SUCCEED(); \
-        } \
-        if(!did_assert) { \
-            FAIL("Expected assertion failure from " #expr " however none happened"); \
-        } \
-        ::libassert::set_failure_handler(handler); \
-    } while(0)
+	do { \
+		auto handler = ::libassert::get_failure_handler(); \
+		::libassert::set_failure_handler([](const ::libassert::assertion_info& info) { throw info; }); \
+		bool did_assert = false; \
+		try { \
+			(expr); \
+		} catch (const ::libassert::assertion_info& info) { \
+			did_assert = true; \
+			SUCCEED(); \
+		} \
+		if (!did_assert) { \
+			FAIL("Expected assertion failure from " #expr " however none happened"); \
+		} \
+		::libassert::set_failure_handler(handler); \
+	} while (0)
 
 #endif

--- a/include/libassert/assert-catch2.hpp
+++ b/include/libassert/assert-catch2.hpp
@@ -4,7 +4,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #define LIBASSERT_PREFIX_ASSERTIONS
-#include <libassert/assert.hpp>
 #include <libassert/assert-catch2-macros.hpp>
+#include <libassert/assert.hpp>
 
 #endif

--- a/include/libassert/assert-gtest-macros.hpp
+++ b/include/libassert/assert-gtest-macros.hpp
@@ -2,38 +2,56 @@
 #define LIBASSERT_GTEST_MACROS_HPP
 
 #define LIBASSERT_PREFIX_ASSERTIONS
-#include <libassert/assert-macros.hpp>
-
 #include <stdexcept>
 
+#include <libassert/assert-macros.hpp>
+
 #if defined(_MSVC_TRADITIONAL) && _MSVC_TRADITIONAL
- #error "Libassert integration does not work with MSVC's non-conformant preprocessor. /Zc:preprocessor must be used."
+	#error \
+		"Libassert integration does not work with MSVC's non-conformant preprocessor. /Zc:preprocessor must be used."
 #endif
-#define ASSERT(...) do { try { LIBASSERT_ASSERT(__VA_ARGS__); SUCCEED(); } catch(std::exception& e) { FAIL() << e.what(); } } while(0)
-#define EXPECT(...) do { try { LIBASSERT_ASSERT(__VA_ARGS__); SUCCEED(); } catch(std::exception& e) { ADD_FAILURE() << e.what(); } } while(0)
+#define ASSERT(...) \
+	do { \
+		try { \
+			LIBASSERT_ASSERT(__VA_ARGS__); \
+			SUCCEED(); \
+		} catch (std::exception & e) { \
+			FAIL() << e.what(); \
+		} \
+	} while (0)
+#define EXPECT(...) \
+	do { \
+		try { \
+			LIBASSERT_ASSERT(__VA_ARGS__); \
+			SUCCEED(); \
+		} catch (std::exception & e) { \
+			ADD_FAILURE() << e.what(); \
+		} \
+	} while (0)
 
 LIBASSERT_BEGIN_NAMESPACE
-namespace detail {
-    inline void gtest_failure_handler(const assertion_info& info) {
-        enable_virtual_terminal_processing_if_needed(); // for terminal colors on windows
-        auto width = terminal_width(stderr_fileno);
-        const auto& scheme = isatty(stderr_fileno) ? get_color_scheme() : color_scheme::blank;
-        std::string message = std::string(info.action()) + " at " + info.location() + ":";
-        if(info.message) {
-            message += " " + *info.message;
-        }
-        message += "\n";
-        message += info.statement()
-                + info.print_binary_diagnostics(width, scheme)
-                + info.print_extra_diagnostics(width, scheme);
-        throw std::runtime_error(std::move(message));
-    }
 
-    inline auto pre_main = [] () {
-        set_failure_handler(gtest_failure_handler);
-        return 1;
-    } ();
+namespace detail {
+inline void gtest_failure_handler(const assertion_info& info) {
+	enable_virtual_terminal_processing_if_needed(); // for terminal colors on windows
+	auto width = terminal_width(stderr_fileno);
+	const auto& scheme = isatty(stderr_fileno) ? get_color_scheme() : color_scheme::blank;
+	std::string message = std::string(info.action()) + " at " + info.location() + ":";
+	if (info.message) {
+		message += " " + *info.message;
+	}
+	message += "\n";
+	message += info.statement() + info.print_binary_diagnostics(width, scheme)
+		+ info.print_extra_diagnostics(width, scheme);
+	throw std::runtime_error(std::move(message));
 }
+
+inline auto pre_main = []() {
+	set_failure_handler(gtest_failure_handler);
+	return 1;
+}();
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE
 
 #endif

--- a/include/libassert/assert-gtest.hpp
+++ b/include/libassert/assert-gtest.hpp
@@ -4,7 +4,7 @@
 #include <gtest/gtest.h>
 
 #define LIBASSERT_PREFIX_ASSERTIONS
-#include <libassert/assert.hpp>
 #include <libassert/assert-gtest-macros.hpp>
+#include <libassert/assert.hpp>
 
 #endif

--- a/include/libassert/assert-macros.hpp
+++ b/include/libassert/assert-macros.hpp
@@ -4,103 +4,196 @@
 // Copyright (c) 2021-2025 Jeremy Rifkin under the MIT license
 // https://github.com/jeremy-rifkin/libassert
 
-#include <libassert/platform.hpp>
-
 #include <string_view>
 
+#include <libassert/platform.hpp>
+
 #if LIBASSERT_IS_CLANG || LIBASSERT_IS_GCC || !LIBASSERT_NON_CONFORMANT_MSVC_PREPROCESSOR
- // Macro mapping utility by William Swanson https://github.com/swansontec/map-macro/blob/master/map.h
- #define LIBASSERT_EVAL0(...) __VA_ARGS__
- #define LIBASSERT_EVAL1(...) LIBASSERT_EVAL0(LIBASSERT_EVAL0(LIBASSERT_EVAL0(__VA_ARGS__)))
- #define LIBASSERT_EVAL2(...) LIBASSERT_EVAL1(LIBASSERT_EVAL1(LIBASSERT_EVAL1(__VA_ARGS__)))
- #define LIBASSERT_EVAL3(...) LIBASSERT_EVAL2(LIBASSERT_EVAL2(LIBASSERT_EVAL2(__VA_ARGS__)))
- #define LIBASSERT_EVAL4(...) LIBASSERT_EVAL3(LIBASSERT_EVAL3(LIBASSERT_EVAL3(__VA_ARGS__)))
- #define LIBASSERT_EVAL(...)  LIBASSERT_EVAL4(LIBASSERT_EVAL4(LIBASSERT_EVAL4(__VA_ARGS__)))
- #define LIBASSERT_MAP_END(...)
- #define LIBASSERT_MAP_OUT
- #define LIBASSERT_MAP_COMMA ,
- #define LIBASSERT_MAP_GET_END2() 0, LIBASSERT_MAP_END
- #define LIBASSERT_MAP_GET_END1(...) LIBASSERT_MAP_GET_END2
- #define LIBASSERT_MAP_GET_END(...) LIBASSERT_MAP_GET_END1
- #define LIBASSERT_MAP_NEXT0(test, next, ...) next LIBASSERT_MAP_OUT
- #define LIBASSERT_MAP_NEXT1(test, next) LIBASSERT_MAP_NEXT0(test, next, 0)
- #define LIBASSERT_MAP_NEXT(test, next)  LIBASSERT_MAP_NEXT1(LIBASSERT_MAP_GET_END test, next)
- #define LIBASSERT_MAP0(f, x, peek, ...) f(x) LIBASSERT_MAP_NEXT(peek, LIBASSERT_MAP1)(f, peek, __VA_ARGS__)
- #define LIBASSERT_MAP1(f, x, peek, ...) f(x) LIBASSERT_MAP_NEXT(peek, LIBASSERT_MAP0)(f, peek, __VA_ARGS__)
- #define LIBASSERT_MAP_LIST_NEXT1(test, next) LIBASSERT_MAP_NEXT0(test, LIBASSERT_MAP_COMMA next, 0)
- #define LIBASSERT_MAP_LIST_NEXT(test, next)  LIBASSERT_MAP_LIST_NEXT1(LIBASSERT_MAP_GET_END test, next)
- #define LIBASSERT_MAP_LIST0(f, x, peek, ...) \
-                                   f(x) LIBASSERT_MAP_LIST_NEXT(peek, LIBASSERT_MAP_LIST1)(f, peek, __VA_ARGS__)
- #define LIBASSERT_MAP_LIST1(f, x, peek, ...) \
-                                   f(x) LIBASSERT_MAP_LIST_NEXT(peek, LIBASSERT_MAP_LIST0)(f, peek, __VA_ARGS__)
- #define LIBASSERT_MAP(f, ...) LIBASSERT_EVAL(LIBASSERT_MAP1(f, __VA_ARGS__, ()()(), ()()(), ()()(), 0))
+	// Macro mapping utility by William Swanson https://github.com/swansontec/map-macro/blob/master/map.h
+	#define LIBASSERT_EVAL0(...) __VA_ARGS__
+	#define LIBASSERT_EVAL1(...) LIBASSERT_EVAL0(LIBASSERT_EVAL0(LIBASSERT_EVAL0(__VA_ARGS__)))
+	#define LIBASSERT_EVAL2(...) LIBASSERT_EVAL1(LIBASSERT_EVAL1(LIBASSERT_EVAL1(__VA_ARGS__)))
+	#define LIBASSERT_EVAL3(...) LIBASSERT_EVAL2(LIBASSERT_EVAL2(LIBASSERT_EVAL2(__VA_ARGS__)))
+	#define LIBASSERT_EVAL4(...) LIBASSERT_EVAL3(LIBASSERT_EVAL3(LIBASSERT_EVAL3(__VA_ARGS__)))
+	#define LIBASSERT_EVAL(...) LIBASSERT_EVAL4(LIBASSERT_EVAL4(LIBASSERT_EVAL4(__VA_ARGS__)))
+	#define LIBASSERT_MAP_END(...)
+	#define LIBASSERT_MAP_OUT
+	#define LIBASSERT_MAP_COMMA ,
+	#define LIBASSERT_MAP_GET_END2() 0, LIBASSERT_MAP_END
+	#define LIBASSERT_MAP_GET_END1(...) LIBASSERT_MAP_GET_END2
+	#define LIBASSERT_MAP_GET_END(...) LIBASSERT_MAP_GET_END1
+	#define LIBASSERT_MAP_NEXT0(test, next, ...) next LIBASSERT_MAP_OUT
+	#define LIBASSERT_MAP_NEXT1(test, next) LIBASSERT_MAP_NEXT0(test, next, 0)
+	#define LIBASSERT_MAP_NEXT(test, next) LIBASSERT_MAP_NEXT1(LIBASSERT_MAP_GET_END test, next)
+	#define LIBASSERT_MAP0(f, x, peek, ...) \
+		f(x) LIBASSERT_MAP_NEXT(peek, LIBASSERT_MAP1)(f, peek, __VA_ARGS__)
+	#define LIBASSERT_MAP1(f, x, peek, ...) \
+		f(x) LIBASSERT_MAP_NEXT(peek, LIBASSERT_MAP0)(f, peek, __VA_ARGS__)
+	#define LIBASSERT_MAP_LIST_NEXT1(test, next) \
+		LIBASSERT_MAP_NEXT0(test, LIBASSERT_MAP_COMMA next, 0)
+	#define LIBASSERT_MAP_LIST_NEXT(test, next) \
+		LIBASSERT_MAP_LIST_NEXT1(LIBASSERT_MAP_GET_END test, next)
+	#define LIBASSERT_MAP_LIST0(f, x, peek, ...) \
+		f(x) LIBASSERT_MAP_LIST_NEXT(peek, LIBASSERT_MAP_LIST1)(f, peek, __VA_ARGS__)
+	#define LIBASSERT_MAP_LIST1(f, x, peek, ...) \
+		f(x) LIBASSERT_MAP_LIST_NEXT(peek, LIBASSERT_MAP_LIST0)(f, peek, __VA_ARGS__)
+	#define LIBASSERT_MAP(f, ...) \
+		LIBASSERT_EVAL(LIBASSERT_MAP1(f, __VA_ARGS__, ()()(), ()()(), ()()(), 0))
 #else
- // https://stackoverflow.com/a/29474124/15675011
- #define LIBASSERT_PLUS_TEXT_(x,y) x ## y
- #define LIBASSERT_PLUS_TEXT(x, y) LIBASSERT_PLUS_TEXT_(x, y)
- #define LIBASSERT_ARG_1(_1, ...) _1
- #define LIBASSERT_ARG_2(_1, _2, ...) _2
- #define LIBASSERT_ARG_3(_1, _2, _3, ...) _3
- #define LIBASSERT_ARG_40( _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, \
-                 _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, \
-                 _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, \
-                 _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, \
-                 ...) _39
- #define LIBASSERT_OTHER_1(_1, ...) __VA_ARGS__
- #define LIBASSERT_OTHER_3(_1, _2, _3, ...) __VA_ARGS__
- #define LIBASSERT_EVAL0(...) __VA_ARGS__
- #define LIBASSERT_EVAL1(...) LIBASSERT_EVAL0(LIBASSERT_EVAL0(LIBASSERT_EVAL0(__VA_ARGS__)))
- #define LIBASSERT_EVAL2(...) LIBASSERT_EVAL1(LIBASSERT_EVAL1(LIBASSERT_EVAL1(__VA_ARGS__)))
- #define LIBASSERT_EVAL3(...) LIBASSERT_EVAL2(LIBASSERT_EVAL2(LIBASSERT_EVAL2(__VA_ARGS__)))
- #define LIBASSERT_EVAL4(...) LIBASSERT_EVAL3(LIBASSERT_EVAL3(LIBASSERT_EVAL3(__VA_ARGS__)))
- #define LIBASSERT_EVAL(...) LIBASSERT_EVAL4(LIBASSERT_EVAL4(LIBASSERT_EVAL4(__VA_ARGS__)))
- #define LIBASSERT_EXPAND(x) x
- #define LIBASSERT_MAP_SWITCH(...) \
-     LIBASSERT_EXPAND(LIBASSERT_ARG_40(__VA_ARGS__, 2, 2, 2, 2, 2, 2, 2, 2, 2, \
-             2, 2, 2, 2, 2, 2, 2, 2, 2, 2, \
-             2, 2, 2, 2, 2, 2, 2, 2, 2, \
-             2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0))
- #define LIBASSERT_MAP_A(...) LIBASSERT_PLUS_TEXT(LIBASSERT_MAP_NEXT_, \
-                                            LIBASSERT_MAP_SWITCH(0, __VA_ARGS__)) (LIBASSERT_MAP_B, __VA_ARGS__)
- #define LIBASSERT_MAP_B(...) LIBASSERT_PLUS_TEXT(LIBASSERT_MAP_NEXT_, \
-                                            LIBASSERT_MAP_SWITCH(0, __VA_ARGS__)) (LIBASSERT_MAP_A, __VA_ARGS__)
- #define LIBASSERT_MAP_CALL(fn, Value) LIBASSERT_EXPAND(fn(Value))
- #define LIBASSERT_MAP_OUT
- #define LIBASSERT_MAP_NEXT_2(...) \
-     LIBASSERT_MAP_CALL(LIBASSERT_EXPAND(LIBASSERT_ARG_2(__VA_ARGS__)), \
-     LIBASSERT_EXPAND(LIBASSERT_ARG_3(__VA_ARGS__))) \
-     LIBASSERT_EXPAND(LIBASSERT_ARG_1(__VA_ARGS__)) \
-     LIBASSERT_MAP_OUT \
-     (LIBASSERT_EXPAND(LIBASSERT_ARG_2(__VA_ARGS__)), LIBASSERT_EXPAND(LIBASSERT_OTHER_3(__VA_ARGS__)))
- #define LIBASSERT_MAP_NEXT_0(...)
- #define LIBASSERT_MAP(...)    LIBASSERT_EVAL(LIBASSERT_MAP_A(__VA_ARGS__))
+	// https://stackoverflow.com/a/29474124/15675011
+	#define LIBASSERT_PLUS_TEXT_(x, y) x##y
+	#define LIBASSERT_PLUS_TEXT(x, y) LIBASSERT_PLUS_TEXT_(x, y)
+	#define LIBASSERT_ARG_1(_1, ...) _1
+	#define LIBASSERT_ARG_2(_1, _2, ...) _2
+	#define LIBASSERT_ARG_3(_1, _2, _3, ...) _3
+	#define LIBASSERT_ARG_40( \
+		_0, \
+		_1, \
+		_2, \
+		_3, \
+		_4, \
+		_5, \
+		_6, \
+		_7, \
+		_8, \
+		_9, \
+		_10, \
+		_11, \
+		_12, \
+		_13, \
+		_14, \
+		_15, \
+		_16, \
+		_17, \
+		_18, \
+		_19, \
+		_20, \
+		_21, \
+		_22, \
+		_23, \
+		_24, \
+		_25, \
+		_26, \
+		_27, \
+		_28, \
+		_29, \
+		_30, \
+		_31, \
+		_32, \
+		_33, \
+		_34, \
+		_35, \
+		_36, \
+		_37, \
+		_38, \
+		_39, \
+		... \
+	) \
+		_39
+	#define LIBASSERT_OTHER_1(_1, ...) __VA_ARGS__
+	#define LIBASSERT_OTHER_3(_1, _2, _3, ...) __VA_ARGS__
+	#define LIBASSERT_EVAL0(...) __VA_ARGS__
+	#define LIBASSERT_EVAL1(...) LIBASSERT_EVAL0(LIBASSERT_EVAL0(LIBASSERT_EVAL0(__VA_ARGS__)))
+	#define LIBASSERT_EVAL2(...) LIBASSERT_EVAL1(LIBASSERT_EVAL1(LIBASSERT_EVAL1(__VA_ARGS__)))
+	#define LIBASSERT_EVAL3(...) LIBASSERT_EVAL2(LIBASSERT_EVAL2(LIBASSERT_EVAL2(__VA_ARGS__)))
+	#define LIBASSERT_EVAL4(...) LIBASSERT_EVAL3(LIBASSERT_EVAL3(LIBASSERT_EVAL3(__VA_ARGS__)))
+	#define LIBASSERT_EVAL(...) LIBASSERT_EVAL4(LIBASSERT_EVAL4(LIBASSERT_EVAL4(__VA_ARGS__)))
+	#define LIBASSERT_EXPAND(x) x
+	#define LIBASSERT_MAP_SWITCH(...) \
+		LIBASSERT_EXPAND(LIBASSERT_ARG_40( \
+			__VA_ARGS__, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			2, \
+			0, \
+			0 \
+		))
+	#define LIBASSERT_MAP_A(...) \
+		LIBASSERT_PLUS_TEXT(LIBASSERT_MAP_NEXT_, LIBASSERT_MAP_SWITCH(0, __VA_ARGS__))( \
+			LIBASSERT_MAP_B, \
+			__VA_ARGS__ \
+		)
+	#define LIBASSERT_MAP_B(...) \
+		LIBASSERT_PLUS_TEXT(LIBASSERT_MAP_NEXT_, LIBASSERT_MAP_SWITCH(0, __VA_ARGS__))( \
+			LIBASSERT_MAP_A, \
+			__VA_ARGS__ \
+		)
+	#define LIBASSERT_MAP_CALL(fn, Value) LIBASSERT_EXPAND(fn(Value))
+	#define LIBASSERT_MAP_OUT
+	#define LIBASSERT_MAP_NEXT_2(...) \
+		LIBASSERT_MAP_CALL( \
+			LIBASSERT_EXPAND(LIBASSERT_ARG_2(__VA_ARGS__)), \
+			LIBASSERT_EXPAND(LIBASSERT_ARG_3(__VA_ARGS__)) \
+		) \
+		LIBASSERT_EXPAND(LIBASSERT_ARG_1(__VA_ARGS__)) \
+		LIBASSERT_MAP_OUT( \
+			LIBASSERT_EXPAND(LIBASSERT_ARG_2(__VA_ARGS__)), \
+			LIBASSERT_EXPAND(LIBASSERT_OTHER_3(__VA_ARGS__)) \
+		)
+	#define LIBASSERT_MAP_NEXT_0(...)
+	#define LIBASSERT_MAP(...) LIBASSERT_EVAL(LIBASSERT_MAP_A(__VA_ARGS__))
 #endif
 
 #define LIBASSERT_STRINGIFY(x) #x,
 #define LIBASSERT_COMMA ,
 
 #if LIBASSERT_IS_CLANG || LIBASSERT_IS_GCC
- #if LIBASSERT_IS_GCC
-  #define LIBASSERT_EXPRESSION_DECOMP_WARNING_PRAGMA \
-     _Pragma("GCC diagnostic ignored \"-Wparentheses\"") \
-     _Pragma("GCC diagnostic ignored \"-Wc++20-extensions\"") \
-     _Pragma("GCC diagnostic ignored \"-Wuseless-cast\"") // #49
- #else
-  #define LIBASSERT_EXPRESSION_DECOMP_WARNING_PRAGMA \
-     _Pragma("GCC diagnostic ignored \"-Wparentheses\"") \
-     _Pragma("GCC diagnostic ignored \"-Wc++20-extensions\"") \
-     _Pragma("GCC diagnostic ignored \"-Woverloaded-shift-op-parentheses\"")
- #endif
+	#if LIBASSERT_IS_GCC
+		#define LIBASSERT_EXPRESSION_DECOMP_WARNING_PRAGMA \
+			_Pragma("GCC diagnostic ignored \"-Wparentheses\"") \
+				_Pragma("GCC diagnostic ignored \"-Wc++20-extensions\"") \
+					_Pragma("GCC diagnostic ignored \"-Wuseless-cast\"") // #49
+	#else
+		#define LIBASSERT_EXPRESSION_DECOMP_WARNING_PRAGMA \
+			_Pragma("GCC diagnostic ignored \"-Wparentheses\"") \
+				_Pragma("GCC diagnostic ignored \"-Wc++20-extensions\"") \
+					_Pragma("GCC diagnostic ignored \"-Woverloaded-shift-op-parentheses\"")
+	#endif
 #else
- // NOTE: If this is changed, LIBASSERT_ASSERT_STMT_EXPR below will need to be updated for MSVC
- #define LIBASSERT_EXPRESSION_DECOMP_WARNING_PRAGMA
+	// NOTE: If this is changed, LIBASSERT_ASSERT_STMT_EXPR below will need to be updated for MSVC
+	#define LIBASSERT_EXPRESSION_DECOMP_WARNING_PRAGMA
 #endif
 
 LIBASSERT_BEGIN_NAMESPACE
-    inline void ERROR_ASSERTION_FAILURE_IN_CONSTEXPR_CONTEXT() {
-        // This non-constexpr method is called from an assertion in a constexpr context if a failure occurs. It is
-        // intentionally a no-op.
-    }
+inline void ERROR_ASSERTION_FAILURE_IN_CONSTEXPR_CONTEXT() {
+	// This non-constexpr method is called from an assertion in a constexpr context if a failure occurs. It is
+	// intentionally a no-op.
+}
+
 LIBASSERT_END_NAMESPACE
 
 // __PRETTY_FUNCTION__ used because __builtin_FUNCTION() used in source_location (like __FUNCTION__) is just the method
@@ -109,185 +202,176 @@ LIBASSERT_END_NAMESPACE
 // in constexpr functions pre-C++23.
 // TODO: Try to do a hybrid in C++20 with std::is_constant_evaluated?
 #if defined(__cpp_constexpr) && __cpp_constexpr >= 202211L
-// Can just use static constexpr everywhere
-#define LIBASSERT_STATIC_DATA(name, type, expr_str, ...) \
-    /* extra string here because of extra comma from map, also serves as terminator */ \
-    /* LIBASSERT_STRINGIFY LIBASSERT_VA_ARGS because msvc */ \
-    /* Trailing return type here to work around a gcc <= 9.2 bug */ \
-    /* Oddly only affecting builds under -DNDEBUG https://godbolt.org/z/5Treozc4q */ \
-    using libassert_params_t = libassert::detail::assert_static_parameters; \
-    /* NOLINTNEXTLINE(*-avoid-c-arrays) */ \
-    static constexpr std::string_view libassert_arg_strings[] = { \
-        LIBASSERT_MAP(LIBASSERT_STRINGIFY LIBASSERT_VA_ARGS(__VA_ARGS__)) "" \
-    }; \
-    static constexpr libassert_params_t _libassert_params = { \
-        name LIBASSERT_COMMA \
-        type LIBASSERT_COMMA \
-        expr_str LIBASSERT_COMMA \
-        {} LIBASSERT_COMMA \
-        {libassert_arg_strings, sizeof(libassert_arg_strings) / sizeof(std::string_view)} LIBASSERT_COMMA \
-    }; \
-    const libassert_params_t* libassert_params = &_libassert_params;
+	// Can just use static constexpr everywhere
+	#define LIBASSERT_STATIC_DATA(name, type, expr_str, ...) \
+		/* extra string here because of extra comma from map, also serves as terminator */ \
+		/* LIBASSERT_STRINGIFY LIBASSERT_VA_ARGS because msvc */ \
+		/* Trailing return type here to work around a gcc <= 9.2 bug */ \
+		/* Oddly only affecting builds under -DNDEBUG https://godbolt.org/z/5Treozc4q */ \
+		using libassert_params_t = libassert::detail::assert_static_parameters; \
+		/* NOLINTNEXTLINE(*-avoid-c-arrays) */ \
+		static constexpr std::string_view libassert_arg_strings[] = { \
+			LIBASSERT_MAP(LIBASSERT_STRINGIFY LIBASSERT_VA_ARGS(__VA_ARGS__)) "" \
+		}; \
+		static constexpr libassert_params_t _libassert_params = { \
+			name LIBASSERT_COMMA type LIBASSERT_COMMA expr_str LIBASSERT_COMMA {} LIBASSERT_COMMA { \
+				libassert_arg_strings, \
+				sizeof(libassert_arg_strings) / sizeof(std::string_view) \
+			} LIBASSERT_COMMA \
+		}; \
+		const libassert_params_t* libassert_params = &_libassert_params;
 #else
-#define LIBASSERT_STATIC_DATA(name, type, expr_str, ...) \
-    using libassert_params_t = libassert::detail::assert_static_parameters; \
-    /* NOLINTNEXTLINE(*-avoid-c-arrays) */ \
-    const libassert_params_t* libassert_params = []() -> const libassert_params_t* { \
-        static constexpr std::string_view libassert_arg_strings[] = { \
-            LIBASSERT_MAP(LIBASSERT_STRINGIFY LIBASSERT_VA_ARGS(__VA_ARGS__)) "" \
-        }; \
-        static constexpr libassert_params_t _libassert_params = { \
-            name LIBASSERT_COMMA \
-            type LIBASSERT_COMMA \
-            expr_str LIBASSERT_COMMA \
-            {} LIBASSERT_COMMA \
-            {libassert_arg_strings, sizeof(libassert_arg_strings) / sizeof(std::string_view)} LIBASSERT_COMMA \
-        }; \
-        return &_libassert_params; \
-    }();
+	#define LIBASSERT_STATIC_DATA(name, type, expr_str, ...) \
+		using libassert_params_t = libassert::detail::assert_static_parameters; \
+		/* NOLINTNEXTLINE(*-avoid-c-arrays) */ \
+		const libassert_params_t* libassert_params = []() -> const libassert_params_t* { \
+			static constexpr std::string_view libassert_arg_strings[] = { \
+				LIBASSERT_MAP(LIBASSERT_STRINGIFY LIBASSERT_VA_ARGS(__VA_ARGS__)) "" \
+			}; \
+			static constexpr libassert_params_t _libassert_params = { \
+				name LIBASSERT_COMMA type LIBASSERT_COMMA expr_str LIBASSERT_COMMA {} LIBASSERT_COMMA { \
+					libassert_arg_strings, \
+					sizeof(libassert_arg_strings) / sizeof(std::string_view) \
+				} LIBASSERT_COMMA \
+			}; \
+			return &_libassert_params; \
+		}();
 #endif
 
-#define LIBASSERT_PRETTY_FUNCTION_ARG ,libassert_pretty_function_arg
+#define LIBASSERT_PRETTY_FUNCTION_ARG , libassert_pretty_function_arg
 
 #define LIBASSERT_BREAKPOINT_IF_DEBUGGING() \
-    do \
-        if(libassert::is_debugger_present()) { \
-            LIBASSERT_BREAKPOINT(); \
-        } \
-    while(0)
+	do \
+		if (libassert::is_debugger_present()) { \
+			LIBASSERT_BREAKPOINT(); \
+		} \
+	while (0)
 
 #ifdef LIBASSERT_BREAK_ON_FAIL
- #define LIBASSERT_BREAKPOINT_IF_DEBUGGING_ON_FAIL() LIBASSERT_BREAKPOINT_IF_DEBUGGING()
+	#define LIBASSERT_BREAKPOINT_IF_DEBUGGING_ON_FAIL() LIBASSERT_BREAKPOINT_IF_DEBUGGING()
 #else
- #define LIBASSERT_BREAKPOINT_IF_DEBUGGING_ON_FAIL()
+	#define LIBASSERT_BREAKPOINT_IF_DEBUGGING_ON_FAIL()
 #endif
 
 // ifndef here to allow a library like rsl-test to use this as a customization point for fancy instrumentation
 #ifndef LIBASSERT_ASSERT_MAIN_BODY
- #define LIBASSERT_ASSERT_MAIN_BODY(expr, name, type, failaction, decomposer_name, condition_value, pretty_function_arg, ...) \
-     if(LIBASSERT_STRONG_EXPECT(!(condition_value), 0)) { \
-         libassert::ERROR_ASSERTION_FAILURE_IN_CONSTEXPR_CONTEXT(); \
-         LIBASSERT_BREAKPOINT_IF_DEBUGGING_ON_FAIL(); \
-         failaction \
-         LIBASSERT_STATIC_DATA(name, libassert::assert_type::type, #expr, __VA_ARGS__) \
-         libassert::detail::process_assert_fail( \
-             decomposer_name, \
-             libassert_params \
-             LIBASSERT_VA_ARGS(__VA_ARGS__) pretty_function_arg \
-         ); \
-     }
+	#define LIBASSERT_ASSERT_MAIN_BODY( \
+		expr, \
+		name, \
+		type, \
+		failaction, \
+		decomposer_name, \
+		condition_value, \
+		pretty_function_arg, \
+		... \
+	) \
+		if (LIBASSERT_STRONG_EXPECT(!(condition_value), 0)) { \
+			libassert::ERROR_ASSERTION_FAILURE_IN_CONSTEXPR_CONTEXT(); \
+			LIBASSERT_BREAKPOINT_IF_DEBUGGING_ON_FAIL(); \
+			failaction LIBASSERT_STATIC_DATA(name, libassert::assert_type::type, #expr, __VA_ARGS__) \
+				libassert::detail::process_assert_fail( \
+					decomposer_name, \
+					libassert_params LIBASSERT_VA_ARGS(__VA_ARGS__) pretty_function_arg \
+				); \
+		}
 #endif
 #ifndef LIBASSERT_PANIC_MAIN_BODY
- #define LIBASSERT_PANIC_MAIN_BODY(name, type, pretty_function_arg, ...) \
-     libassert::ERROR_ASSERTION_FAILURE_IN_CONSTEXPR_CONTEXT(); \
-     LIBASSERT_BREAKPOINT_IF_DEBUGGING_ON_FAIL(); \
-     LIBASSERT_STATIC_DATA(name, libassert::assert_type::type, "", __VA_ARGS__) \
-     libassert::detail::process_panic( \
-         libassert_params \
-         LIBASSERT_VA_ARGS(__VA_ARGS__) pretty_function_arg \
-     );
+	#define LIBASSERT_PANIC_MAIN_BODY(name, type, pretty_function_arg, ...) \
+		libassert::ERROR_ASSERTION_FAILURE_IN_CONSTEXPR_CONTEXT(); \
+		LIBASSERT_BREAKPOINT_IF_DEBUGGING_ON_FAIL(); \
+		LIBASSERT_STATIC_DATA(name, libassert::assert_type::type, "", __VA_ARGS__) \
+		libassert::detail::process_panic( \
+			libassert_params LIBASSERT_VA_ARGS(__VA_ARGS__) pretty_function_arg \
+		);
 #endif
 
 #define LIBASSERT_INVOKE(expr, name, type, failaction, ...) \
-    ([&](auto libassert_pretty_function_arg) { \
-        LIBASSERT_WARNING_PRAGMA_PUSH \
-        LIBASSERT_EXPRESSION_DECOMP_WARNING_PRAGMA \
-        [&](auto libassert_decomposer) { \
-            LIBASSERT_ASSERT_MAIN_BODY( \
-                expr, \
-                name, \
-                type, \
-                failaction, \
-                libassert_decomposer, \
-                static_cast<bool>(libassert_decomposer.get_value()), \
-                LIBASSERT_PRETTY_FUNCTION_ARG, \
-                __VA_ARGS__ \
-            ) \
-        }( \
-            libassert::detail::expression_decomposer( \
-                libassert::detail::expression_decomposer{} << expr \
-            ) \
-        ); \
-        LIBASSERT_WARNING_PRAGMA_POP \
-    }(libassert::detail::pretty_function_name_wrapper{LIBASSERT_PFUNC}))
+	([&](auto libassert_pretty_function_arg) { \
+		LIBASSERT_WARNING_PRAGMA_PUSH \
+		LIBASSERT_EXPRESSION_DECOMP_WARNING_PRAGMA \
+		[&](auto libassert_decomposer) { \
+			LIBASSERT_ASSERT_MAIN_BODY( \
+				expr, \
+				name, \
+				type, \
+				failaction, \
+				libassert_decomposer, \
+				static_cast<bool>(libassert_decomposer.get_value()), \
+				LIBASSERT_PRETTY_FUNCTION_ARG, \
+				__VA_ARGS__ \
+			) \
+		}(libassert::detail::expression_decomposer( \
+			libassert::detail::expression_decomposer {} << expr \
+		)); \
+		LIBASSERT_WARNING_PRAGMA_POP \
+	}(libassert::detail::pretty_function_name_wrapper {LIBASSERT_PFUNC}))
 
 #define LIBASSERT_INVOKE_PANIC(name, type, ...) \
-    ([&](auto libassert_pretty_function_arg) { \
-        LIBASSERT_PANIC_MAIN_BODY( \
-            name, \
-            type, \
-            LIBASSERT_PRETTY_FUNCTION_ARG, \
-            __VA_ARGS__ \
-        ) \
-    }(libassert::detail::pretty_function_name_wrapper{LIBASSERT_PFUNC}))
+	([&](auto libassert_pretty_function_arg) { \
+		LIBASSERT_PANIC_MAIN_BODY(name, type, LIBASSERT_PRETTY_FUNCTION_ARG, __VA_ARGS__) \
+	}(libassert::detail::pretty_function_name_wrapper {LIBASSERT_PFUNC}))
 
 #if LIBASSERT_IS_CLANG || LIBASSERT_IS_GCC
- // Extra set of parentheses here because clang treats __extension__ as a low-precedence unary operator which interferes
- // with decltype(auto) in an expression like decltype(auto) x = __extension__ ({...}).y;
- // Surpress warnings here because of a clang bug: https://github.com/llvm/llvm-project/issues/63897
- #define LIBASSERT_ASSERT_STMT_EXPR(B, R) (__extension__ ({ \
-        LIBASSERT_WARNING_PRAGMA_PUSH \
-        LIBASSERT_EXPRESSION_DECOMP_WARNING_PRAGMA \
-        B \
-        LIBASSERT_WARNING_PRAGMA_POP \
-        R \
-    }))
- #define LIBASSERT_STATIC_CAST_TO_BOOL(x) static_cast<bool>(x)
+	// Extra set of parentheses here because clang treats __extension__ as a low-precedence unary operator which interferes
+	// with decltype(auto) in an expression like decltype(auto) x = __extension__ ({...}).y;
+	// Surpress warnings here because of a clang bug: https://github.com/llvm/llvm-project/issues/63897
+	#define LIBASSERT_ASSERT_STMT_EXPR(B, R) \
+		(__extension__({LIBASSERT_WARNING_PRAGMA_PUSH LIBASSERT_EXPRESSION_DECOMP_WARNING_PRAGMA B \
+											LIBASSERT_WARNING_PRAGMA_POP R}))
+	#define LIBASSERT_STATIC_CAST_TO_BOOL(x) static_cast<bool>(x)
 #else
- #define LIBASSERT_ASSERT_STMT_EXPR(B, R) [&](const char* libassert_msvc_pfunc) { B return R }(LIBASSERT_PFUNC)
- // Workaround for msvc bug
- #define LIBASSERT_STATIC_CAST_TO_BOOL(x) libassert::detail::static_cast_to_bool(x)
- LIBASSERT_BEGIN_NAMESPACE
- namespace detail {
-     template<typename T> constexpr bool static_cast_to_bool(T&& t) {
-         return static_cast<bool>(t);
-     }
- }
- LIBASSERT_END_NAMESPACE
+	#define LIBASSERT_ASSERT_STMT_EXPR(B, R) \
+		[&](const char* libassert_msvc_pfunc) { B return R }(LIBASSERT_PFUNC)
+	// Workaround for msvc bug
+	#define LIBASSERT_STATIC_CAST_TO_BOOL(x) libassert::detail::static_cast_to_bool(x)
+LIBASSERT_BEGIN_NAMESPACE
+
+namespace detail {
+template<typename T>
+constexpr bool static_cast_to_bool(T&& t) {
+	return static_cast<bool>(t);
+}
+} // namespace detail
+
+LIBASSERT_END_NAMESPACE
 #endif
 
 #define LIBASSERT_INVOKE_VAL(expr, check_expression, name, type, failaction, ...) \
-        ([&](auto libassert_pretty_function_arg) -> decltype(auto) { \
-            LIBASSERT_WARNING_PRAGMA_PUSH \
-            LIBASSERT_EXPRESSION_DECOMP_WARNING_PRAGMA \
-            return [&](auto libassert_decomposer) -> decltype(auto) { \
-                decltype(auto) libassert_value = libassert_decomposer.get_value(); \
-                constexpr bool libassert_ret_lhs = libassert_decomposer.ret_lhs(); \
-                if constexpr(check_expression) { \
-                    LIBASSERT_ASSERT_MAIN_BODY( \
-                        expr, \
-                        name, \
-                        type, \
-                        failaction, \
-                        libassert_decomposer, \
-                        /* For *some* godforsaken reason static_cast<bool> causes an ICE in MSVC here. Something very */ \
-                        /* specific about casting a decltype(auto) value inside a lambda. Workaround is to put it in a */ \
-                        /* wrapper. https://godbolt.org/z/Kq8Wb6q5j https://godbolt.org/z/nMnqnsMYx */ \
-                        LIBASSERT_STATIC_CAST_TO_BOOL(libassert_value), \
-                        LIBASSERT_PRETTY_FUNCTION_ARG, \
-                        __VA_ARGS__ \
-                    ) \
-                } \
-                /* Note: Relying on this call being inlined so inefficiency is eliminated */ \
-                return \
-                libassert::detail::get_expression_return_value< \
-                    libassert_ret_lhs LIBASSERT_COMMA \
-                    std::is_lvalue_reference_v<decltype(libassert_value)> \
-                >(libassert_value, libassert_decomposer); \
-            }( \
-                libassert::detail::expression_decomposer( \
-                    libassert::detail::expression_decomposer{} << expr \
-                ) \
-            ); \
-            LIBASSERT_WARNING_PRAGMA_POP \
-        }( \
-            libassert::detail::pretty_function_name_wrapper{LIBASSERT_PFUNC} \
-        )).value
+	([&](auto libassert_pretty_function_arg) -> decltype(auto) { \
+		LIBASSERT_WARNING_PRAGMA_PUSH \
+		LIBASSERT_EXPRESSION_DECOMP_WARNING_PRAGMA \
+		return [&](auto libassert_decomposer) -> decltype(auto) { \
+			decltype(auto) libassert_value = libassert_decomposer.get_value(); \
+			constexpr bool libassert_ret_lhs = libassert_decomposer.ret_lhs(); \
+			if constexpr (check_expression) { \
+				LIBASSERT_ASSERT_MAIN_BODY( \
+					expr, \
+					name, \
+					type, \
+					failaction, \
+					libassert_decomposer, /* For *some* godforsaken reason static_cast<bool> causes an ICE in MSVC here. Something very */ /* specific about casting a decltype(auto) value inside a lambda. Workaround is to put it in a */ /* wrapper. https://godbolt.org/z/Kq8Wb6q5j https://godbolt.org/z/nMnqnsMYx */ \
+					LIBASSERT_STATIC_CAST_TO_BOOL(libassert_value), \
+					LIBASSERT_PRETTY_FUNCTION_ARG, \
+					__VA_ARGS__ \
+				) \
+			} \
+			/* Note: Relying on this call being inlined so inefficiency is eliminated */ \
+			return libassert::detail::get_expression_return_value< \
+				libassert_ret_lhs LIBASSERT_COMMA std::is_lvalue_reference_v<decltype(libassert_value)>>( \
+				libassert_value, \
+				libassert_decomposer \
+			); \
+		}(libassert::detail::expression_decomposer( \
+																						libassert::detail::expression_decomposer {} << expr \
+																					)); \
+		LIBASSERT_WARNING_PRAGMA_POP \
+	}(libassert::detail::pretty_function_name_wrapper {LIBASSERT_PFUNC})) \
+		.value
 
 #ifdef NDEBUG
- #define LIBASSERT_ASSUME_ACTION LIBASSERT_UNREACHABLE_CALL();
+	#define LIBASSERT_ASSUME_ACTION LIBASSERT_UNREACHABLE_CALL();
 #else
- #define LIBASSERT_ASSUME_ACTION
+	#define LIBASSERT_ASSUME_ACTION
 #endif
 #define LIBASSERT_NOP_ACTION
 
@@ -295,85 +379,124 @@ LIBASSERT_END_NAMESPACE
 
 // Debug assert
 #ifndef NDEBUG
- #define LIBASSERT_DEBUG_ASSERT(expr, ...) LIBASSERT_INVOKE(expr, "DEBUG_ASSERT", debug_assertion, LIBASSERT_NOP_ACTION, __VA_ARGS__)
+	#define LIBASSERT_DEBUG_ASSERT(expr, ...) \
+		LIBASSERT_INVOKE(expr, "DEBUG_ASSERT", debug_assertion, LIBASSERT_NOP_ACTION, __VA_ARGS__)
 #else
- #define LIBASSERT_DEBUG_ASSERT(expr, ...) (void)0
+	#define LIBASSERT_DEBUG_ASSERT(expr, ...) (void)0
 #endif
 
 // Assert
-#define LIBASSERT_ASSERT(expr, ...) LIBASSERT_INVOKE(expr, "ASSERT", assertion, LIBASSERT_NOP_ACTION, __VA_ARGS__)
+#define LIBASSERT_ASSERT(expr, ...) \
+	LIBASSERT_INVOKE(expr, "ASSERT", assertion, LIBASSERT_NOP_ACTION, __VA_ARGS__)
 // lowercase version intentionally done outside of the include guard here
 
 // Assume
-#define LIBASSERT_ASSUME(expr, ...) LIBASSERT_INVOKE(expr, "ASSUME", assumption, LIBASSERT_ASSUME_ACTION, __VA_ARGS__)
+#define LIBASSERT_ASSUME(expr, ...) \
+	LIBASSERT_INVOKE(expr, "ASSUME", assumption, LIBASSERT_ASSUME_ACTION, __VA_ARGS__)
 
 // Panic
 #define LIBASSERT_PANIC(...) LIBASSERT_INVOKE_PANIC("PANIC", panic, __VA_ARGS__)
 
 // Unreachable
 #ifndef NDEBUG
- #define LIBASSERT_UNREACHABLE(...) LIBASSERT_INVOKE_PANIC("UNREACHABLE", unreachable, __VA_ARGS__)
+	#define LIBASSERT_UNREACHABLE(...) LIBASSERT_INVOKE_PANIC("UNREACHABLE", unreachable, __VA_ARGS__)
 #else
- #define LIBASSERT_UNREACHABLE(...) LIBASSERT_UNREACHABLE_CALL()
+	#define LIBASSERT_UNREACHABLE(...) LIBASSERT_UNREACHABLE_CALL()
 #endif
 
 // value variants
 
 #ifndef NDEBUG
- #define LIBASSERT_DEBUG_ASSERT_VAL(expr, ...) LIBASSERT_INVOKE_VAL(expr, true, "DEBUG_ASSERT_VAL", debug_assertion, LIBASSERT_NOP_ACTION, __VA_ARGS__)
+	#define LIBASSERT_DEBUG_ASSERT_VAL(expr, ...) \
+		LIBASSERT_INVOKE_VAL( \
+			expr, \
+			true, \
+			"DEBUG_ASSERT_VAL", \
+			debug_assertion, \
+			LIBASSERT_NOP_ACTION, \
+			__VA_ARGS__ \
+		)
 #else
- #define LIBASSERT_DEBUG_ASSERT_VAL(expr, ...) LIBASSERT_INVOKE_VAL(expr, false, "DEBUG_ASSERT_VAL", debug_assertion, LIBASSERT_NOP_ACTION, __VA_ARGS__)
+	#define LIBASSERT_DEBUG_ASSERT_VAL(expr, ...) \
+		LIBASSERT_INVOKE_VAL( \
+			expr, \
+			false, \
+			"DEBUG_ASSERT_VAL", \
+			debug_assertion, \
+			LIBASSERT_NOP_ACTION, \
+			__VA_ARGS__ \
+		)
 #endif
 
-#define LIBASSERT_ASSUME_VAL(expr, ...) LIBASSERT_INVOKE_VAL(expr, true, "ASSUME_VAL", assumption, LIBASSERT_ASSUME_ACTION, __VA_ARGS__)
+#define LIBASSERT_ASSUME_VAL(expr, ...) \
+	LIBASSERT_INVOKE_VAL(expr, true, "ASSUME_VAL", assumption, LIBASSERT_ASSUME_ACTION, __VA_ARGS__)
 
-#define LIBASSERT_ASSERT_VAL(expr, ...) LIBASSERT_INVOKE_VAL(expr, true, "ASSERT_VAL", assertion, LIBASSERT_NOP_ACTION, __VA_ARGS__)
+#define LIBASSERT_ASSERT_VAL(expr, ...) \
+	LIBASSERT_INVOKE_VAL(expr, true, "ASSERT_VAL", assertion, LIBASSERT_NOP_ACTION, __VA_ARGS__)
 
 // non-prefixed versions
 
 #ifndef LIBASSERT_PREFIX_ASSERTIONS
- #if LIBASSERT_IS_CLANG || LIBASSERT_IS_GCC || !LIBASSERT_NON_CONFORMANT_MSVC_PREPROCESSOR
-  #define DEBUG_ASSERT(...) LIBASSERT_DEBUG_ASSERT(__VA_ARGS__)
-  #define ASSERT(...) LIBASSERT_ASSERT(__VA_ARGS__)
-  #define ASSUME(...) LIBASSERT_ASSUME(__VA_ARGS__)
-  #define PANIC(...) LIBASSERT_PANIC(__VA_ARGS__)
-  #define UNREACHABLE(...) LIBASSERT_UNREACHABLE(__VA_ARGS__)
-  #define DEBUG_ASSERT_VAL(...) LIBASSERT_DEBUG_ASSERT_VAL(__VA_ARGS__)
-  #define ASSUME_VAL(...) LIBASSERT_ASSUME_VAL(__VA_ARGS__)
-  #define ASSERT_VAL(...) LIBASSERT_ASSERT_VAL(__VA_ARGS__)
- #else
-  // because of course msvc
-  #define DEBUG_ASSERT LIBASSERT_DEBUG_ASSERT
-  #define ASSERT LIBASSERT_ASSERT
-  #define ASSUME LIBASSERT_ASSUME
-  #define PANIC LIBASSERT_PANIC
-  #define UNREACHABLE LIBASSERT_UNREACHABLE
-  #define DEBUG_ASSERT_VAL LIBASSERT_DEBUG_ASSERT_VAL
-  #define ASSUME_VAL LIBASSERT_ASSUME_VAL
-  #define ASSERT_VAL LIBASSERT_ASSERT_VAL
- #endif
+	#if LIBASSERT_IS_CLANG || LIBASSERT_IS_GCC || !LIBASSERT_NON_CONFORMANT_MSVC_PREPROCESSOR
+		#define DEBUG_ASSERT(...) LIBASSERT_DEBUG_ASSERT(__VA_ARGS__)
+		#define ASSERT(...) LIBASSERT_ASSERT(__VA_ARGS__)
+		#define ASSUME(...) LIBASSERT_ASSUME(__VA_ARGS__)
+		#define PANIC(...) LIBASSERT_PANIC(__VA_ARGS__)
+		#define UNREACHABLE(...) LIBASSERT_UNREACHABLE(__VA_ARGS__)
+		#define DEBUG_ASSERT_VAL(...) LIBASSERT_DEBUG_ASSERT_VAL(__VA_ARGS__)
+		#define ASSUME_VAL(...) LIBASSERT_ASSUME_VAL(__VA_ARGS__)
+		#define ASSERT_VAL(...) LIBASSERT_ASSERT_VAL(__VA_ARGS__)
+	#else
+		// because of course msvc
+		#define DEBUG_ASSERT LIBASSERT_DEBUG_ASSERT
+		#define ASSERT LIBASSERT_ASSERT
+		#define ASSUME LIBASSERT_ASSUME
+		#define PANIC LIBASSERT_PANIC
+		#define UNREACHABLE LIBASSERT_UNREACHABLE
+		#define DEBUG_ASSERT_VAL LIBASSERT_DEBUG_ASSERT_VAL
+		#define ASSUME_VAL LIBASSERT_ASSUME_VAL
+		#define ASSERT_VAL LIBASSERT_ASSERT_VAL
+	#endif
 #endif
 
 // Lowercase variants
 
 #ifdef LIBASSERT_LOWERCASE
- #ifndef NDEBUG
-  #define debug_assert(expr, ...) LIBASSERT_INVOKE(expr, "debug_assert", debug_assertion, LIBASSERT_NOP_ACTION, __VA_ARGS__)
- #else
-  #define debug_assert(expr, ...) (void)0
- #endif
+	#ifndef NDEBUG
+		#define debug_assert(expr, ...) \
+			LIBASSERT_INVOKE(expr, "debug_assert", debug_assertion, LIBASSERT_NOP_ACTION, __VA_ARGS__)
+	#else
+		#define debug_assert(expr, ...) (void)0
+	#endif
 #endif
 
 #ifdef LIBASSERT_LOWERCASE
- #ifndef NDEBUG
-  #define debug_assert_val(expr, ...) LIBASSERT_INVOKE_VAL(expr, true, "debug_assert_val", debug_assertion, LIBASSERT_NOP_ACTION, __VA_ARGS__)
- #else
-  #define debug_assert_val(expr, ...) LIBASSERT_INVOKE_VAL(expr, false, "debug_assert_val", debug_assertion, LIBASSERT_NOP_ACTION, __VA_ARGS__)
- #endif
+	#ifndef NDEBUG
+		#define debug_assert_val(expr, ...) \
+			LIBASSERT_INVOKE_VAL( \
+				expr, \
+				true, \
+				"debug_assert_val", \
+				debug_assertion, \
+				LIBASSERT_NOP_ACTION, \
+				__VA_ARGS__ \
+			)
+	#else
+		#define debug_assert_val(expr, ...) \
+			LIBASSERT_INVOKE_VAL( \
+				expr, \
+				false, \
+				"debug_assert_val", \
+				debug_assertion, \
+				LIBASSERT_NOP_ACTION, \
+				__VA_ARGS__ \
+			)
+	#endif
 #endif
 
 #ifdef LIBASSERT_LOWERCASE
- #define assert_val(expr, ...) LIBASSERT_INVOKE_VAL(expr, true, "assert_val", assertion, LIBASSERT_NOP_ACTION, __VA_ARGS__)
+	#define assert_val(expr, ...) \
+		LIBASSERT_INVOKE_VAL(expr, true, "assert_val", assertion, LIBASSERT_NOP_ACTION, __VA_ARGS__)
 #endif
 
 #endif // LIBASSERT_HPP
@@ -381,12 +504,14 @@ LIBASSERT_END_NAMESPACE
 // Intentionally done outside the include guard. Libc++ leaks `assert` (among other things), so the include for
 // assert.hpp should go after other includes when using -DLIBASSERT_LOWERCASE.
 #ifdef LIBASSERT_LOWERCASE
- #ifdef assert
-  #undef assert
- #endif
- #ifndef NDEBUG
-  #define assert(expr, ...) LIBASSERT_INVOKE(expr, "assert", assertion, LIBASSERT_NOP_ACTION, __VA_ARGS__)
- #else
-  #define assert(expr, ...) LIBASSERT_INVOKE(expr, "assert", assertion, LIBASSERT_NOP_ACTION, __VA_ARGS__)
- #endif
+#ifdef assert
+	#undef assert
+#endif
+#ifndef NDEBUG
+	#define assert(expr, ...) \
+		LIBASSERT_INVOKE(expr, "assert", assertion, LIBASSERT_NOP_ACTION, __VA_ARGS__)
+#else
+	#define assert(expr, ...) \
+		LIBASSERT_INVOKE(expr, "assert", assertion, LIBASSERT_NOP_ACTION, __VA_ARGS__)
+#endif
 #endif

--- a/include/libassert/assert-macros.hpp
+++ b/include/libassert/assert-macros.hpp
@@ -83,10 +83,12 @@
  #if LIBASSERT_IS_GCC
   #define LIBASSERT_EXPRESSION_DECOMP_WARNING_PRAGMA \
      _Pragma("GCC diagnostic ignored \"-Wparentheses\"") \
+     _Pragma("GCC diagnostic ignored \"-Wc++20-extensions\"") \
      _Pragma("GCC diagnostic ignored \"-Wuseless-cast\"") // #49
  #else
   #define LIBASSERT_EXPRESSION_DECOMP_WARNING_PRAGMA \
      _Pragma("GCC diagnostic ignored \"-Wparentheses\"") \
+     _Pragma("GCC diagnostic ignored \"-Wc++20-extensions\"") \
      _Pragma("GCC diagnostic ignored \"-Woverloaded-shift-op-parentheses\"")
  #endif
 #else
@@ -145,24 +147,7 @@ LIBASSERT_END_NAMESPACE
     }();
 #endif
 
-// Note about statement expressions: These are needed for two reasons. The first is putting the arg string array and
-// source location structure in .rodata rather than on the stack, the second is a _Pragma for warnings which isn't
-// allowed in the middle of an expression by GCC. The semantics are similar to a function return:
-// Given M m; in parent scope, ({ m; }) is an rvalue M&& rather than an lvalue
-// ({ M m; m; }) doesn't move, it copies
-// ({ M{}; }) does move
-// Of relevance to this: in foo(__extension__ ({ M{1} + M{1}; })); the lifetimes of the M{1} objects end during the
-// statement expression but the lifetime of the returned object is extend to the end of the full foo() expression.
-// A wrapper struct is used here to return an lvalue reference from a gcc statement expression.
-// Note: There is a current issue with tarnaries: auto x = assert(b ? y : y); must copy y. This can be fixed with
-// lambdas but that's potentially very expensive compile-time wise. Need to investigate further.
-// Note: libassert::detail::expression_decomposer(libassert::detail::expression_decomposer{} << expr) done for ternary
-#if LIBASSERT_IS_MSVC
- #define LIBASSERT_INVOKE_VAL_PRETTY_FUNCTION_ARG ,libassert::detail::pretty_function_name_wrapper{libassert_msvc_pfunc}
-#else
- #define LIBASSERT_INVOKE_VAL_PRETTY_FUNCTION_ARG ,libassert::detail::pretty_function_name_wrapper{LIBASSERT_PFUNC}
-#endif
-#define LIBASSERT_PRETTY_FUNCTION_ARG ,libassert::detail::pretty_function_name_wrapper{LIBASSERT_PFUNC}
+#define LIBASSERT_PRETTY_FUNCTION_ARG ,libassert_pretty_function_arg
 
 #define LIBASSERT_BREAKPOINT_IF_DEBUGGING() \
     do \
@@ -204,34 +189,37 @@ LIBASSERT_END_NAMESPACE
 #endif
 
 #define LIBASSERT_INVOKE(expr, name, type, failaction, ...) \
-    do { \
+    ([&](auto libassert_pretty_function_arg) { \
         LIBASSERT_WARNING_PRAGMA_PUSH \
         LIBASSERT_EXPRESSION_DECOMP_WARNING_PRAGMA \
-        auto libassert_decomposer = libassert::detail::expression_decomposer( \
-            libassert::detail::expression_decomposer{} << expr \
+        [&](auto libassert_decomposer) { \
+            LIBASSERT_ASSERT_MAIN_BODY( \
+                expr, \
+                name, \
+                type, \
+                failaction, \
+                libassert_decomposer, \
+                static_cast<bool>(libassert_decomposer.get_value()), \
+                LIBASSERT_PRETTY_FUNCTION_ARG, \
+                __VA_ARGS__ \
+            ) \
+        }( \
+            libassert::detail::expression_decomposer( \
+                libassert::detail::expression_decomposer{} << expr \
+            ) \
         ); \
         LIBASSERT_WARNING_PRAGMA_POP \
-        LIBASSERT_ASSERT_MAIN_BODY( \
-            expr, \
-            name, \
-            type, \
-            failaction, \
-            libassert_decomposer, \
-            static_cast<bool>(libassert_decomposer.get_value()), \
-            LIBASSERT_PRETTY_FUNCTION_ARG, \
-            __VA_ARGS__ \
-        ) \
-    } while(0) \
+    }(libassert::detail::pretty_function_name_wrapper{LIBASSERT_PFUNC}))
 
 #define LIBASSERT_INVOKE_PANIC(name, type, ...) \
-    do { \
+    ([&](auto libassert_pretty_function_arg) { \
         LIBASSERT_PANIC_MAIN_BODY( \
             name, \
             type, \
             LIBASSERT_PRETTY_FUNCTION_ARG, \
             __VA_ARGS__ \
         ) \
-    } while(0)
+    }(libassert::detail::pretty_function_name_wrapper{LIBASSERT_PFUNC}))
 
 #if LIBASSERT_IS_CLANG || LIBASSERT_IS_GCC
  // Extra set of parentheses here because clang treats __extension__ as a low-precedence unary operator which interferes
@@ -259,33 +247,42 @@ LIBASSERT_END_NAMESPACE
 #endif
 
 #define LIBASSERT_INVOKE_VAL(expr, check_expression, name, type, failaction, ...) \
-    LIBASSERT_ASSERT_STMT_EXPR( \
-        auto libassert_decomposer = libassert::detail::expression_decomposer( \
-            libassert::detail::expression_decomposer{} << expr \
-        ); \
-        decltype(auto) libassert_value = libassert_decomposer.get_value(); \
-        constexpr bool libassert_ret_lhs = libassert_decomposer.ret_lhs(); \
-        if constexpr(check_expression) { \
-            LIBASSERT_ASSERT_MAIN_BODY( \
-                expr, \
-                name, \
-                type, \
-                failaction, \
-                libassert_decomposer, \
-                /* For *some* godforsaken reason static_cast<bool> causes an ICE in MSVC here. Something very */ \
-                /* specific about casting a decltype(auto) value inside a lambda. Workaround is to put it in a */ \
-                /* wrapper. https://godbolt.org/z/Kq8Wb6q5j https://godbolt.org/z/nMnqnsMYx */ \
-                LIBASSERT_STATIC_CAST_TO_BOOL(libassert_value), \
-                LIBASSERT_INVOKE_VAL_PRETTY_FUNCTION_ARG, \
-                __VA_ARGS__ \
-            ) \
-        }, \
-        /* Note: Relying on this call being inlined so inefficiency is eliminated */ \
-        libassert::detail::get_expression_return_value< \
-            libassert_ret_lhs LIBASSERT_COMMA \
-            std::is_lvalue_reference_v<decltype(libassert_value)> \
-        >(libassert_value, libassert_decomposer); \
-    ).value
+        ([&](auto libassert_pretty_function_arg) -> decltype(auto) { \
+            LIBASSERT_WARNING_PRAGMA_PUSH \
+            LIBASSERT_EXPRESSION_DECOMP_WARNING_PRAGMA \
+            return [&](auto libassert_decomposer) -> decltype(auto) { \
+                decltype(auto) libassert_value = libassert_decomposer.get_value(); \
+                constexpr bool libassert_ret_lhs = libassert_decomposer.ret_lhs(); \
+                if constexpr(check_expression) { \
+                    LIBASSERT_ASSERT_MAIN_BODY( \
+                        expr, \
+                        name, \
+                        type, \
+                        failaction, \
+                        libassert_decomposer, \
+                        /* For *some* godforsaken reason static_cast<bool> causes an ICE in MSVC here. Something very */ \
+                        /* specific about casting a decltype(auto) value inside a lambda. Workaround is to put it in a */ \
+                        /* wrapper. https://godbolt.org/z/Kq8Wb6q5j https://godbolt.org/z/nMnqnsMYx */ \
+                        LIBASSERT_STATIC_CAST_TO_BOOL(libassert_value), \
+                        LIBASSERT_PRETTY_FUNCTION_ARG, \
+                        __VA_ARGS__ \
+                    ) \
+                } \
+                /* Note: Relying on this call being inlined so inefficiency is eliminated */ \
+                return \
+                libassert::detail::get_expression_return_value< \
+                    libassert_ret_lhs LIBASSERT_COMMA \
+                    std::is_lvalue_reference_v<decltype(libassert_value)> \
+                >(libassert_value, libassert_decomposer); \
+            }( \
+                libassert::detail::expression_decomposer( \
+                    libassert::detail::expression_decomposer{} << expr \
+                ) \
+            ); \
+            LIBASSERT_WARNING_PRAGMA_POP \
+        }( \
+            libassert::detail::pretty_function_name_wrapper{LIBASSERT_PFUNC} \
+        )).value
 
 #ifdef NDEBUG
  #define LIBASSERT_ASSUME_ACTION LIBASSERT_UNREACHABLE_CALL();

--- a/include/libassert/assert.hpp
+++ b/include/libassert/assert.hpp
@@ -9,30 +9,30 @@
 #include <memory>
 #include <new>
 #include <optional>
-#include <string_view>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
-#include <libassert/platform.hpp>
-#include <libassert/utilities.hpp>
-#include <libassert/stringification.hpp>
-#include <libassert/expression-decomposition.hpp>
 #include <libassert/assert-macros.hpp>
+#include <libassert/expression-decomposition.hpp>
+#include <libassert/platform.hpp>
+#include <libassert/stringification.hpp>
+#include <libassert/utilities.hpp>
 
 #if defined(__has_include) && __has_include(<cpptrace/forward.hpp>)
- #include <cpptrace/forward.hpp>
+	#include <cpptrace/forward.hpp>
 #else
- #include <cpptrace/cpptrace.hpp>
+	#include <cpptrace/cpptrace.hpp>
 #endif
 
 #if LIBASSERT_IS_MSVC
- #pragma warning(push)
- // warning C4251: using non-dll-exported type in dll-exported type, firing on std::vector<frame_ptr> and others for
- // some reason
- // 4275 is the same thing but for base classes
- #pragma warning(disable: 4251; disable: 4275)
+	#pragma warning(push)
+	// warning C4251: using non-dll-exported type in dll-exported type, firing on std::vector<frame_ptr> and others for
+	// some reason
+	// 4275 is the same thing but for base classes
+	#pragma warning(disable : 4251; disable : 4275)
 #endif
 
 // =====================================================================================================================
@@ -40,258 +40,263 @@
 // =====================================================================================================================
 
 LIBASSERT_BEGIN_NAMESPACE
-    // returns the width of the terminal represented by fd, will be 0 on error
-    [[nodiscard]] LIBASSERT_EXPORT int terminal_width(int fd);
+// returns the width of the terminal represented by fd, will be 0 on error
+[[nodiscard]] LIBASSERT_EXPORT int terminal_width(int fd);
 
-    // Enable virtual terminal processing on windows terminals
-    LIBASSERT_EXPORT void enable_virtual_terminal_processing_if_needed();
+// Enable virtual terminal processing on windows terminals
+LIBASSERT_EXPORT void enable_virtual_terminal_processing_if_needed();
 
-    inline constexpr int stdin_fileno = 0;
-    inline constexpr int stdout_fileno = 1;
-    inline constexpr int stderr_fileno = 2;
+inline constexpr int stdin_fileno = 0;
+inline constexpr int stdout_fileno = 1;
+inline constexpr int stderr_fileno = 2;
 
-    LIBASSERT_EXPORT bool isatty(int fd);
+LIBASSERT_EXPORT bool isatty(int fd);
 
-    LIBASSERT_EXPORT bool is_debugger_present() noexcept;
-    enum class debugger_check_mode {
-        check_once,
-        check_every_time,
-    };
-    LIBASSERT_EXPORT void set_debugger_check_mode(debugger_check_mode mode) noexcept;
+LIBASSERT_EXPORT bool is_debugger_present() noexcept;
+enum class debugger_check_mode {
+	check_once,
+	check_every_time,
+};
+LIBASSERT_EXPORT void set_debugger_check_mode(debugger_check_mode mode) noexcept;
 
-    // returns the type name of T
-    template<typename T>
-    [[nodiscard]] std::string_view type_name() noexcept {
-        return detail::type_name<T>();
-    }
+// returns the type name of T
+template<typename T>
+[[nodiscard]] std::string_view type_name() noexcept {
+	return detail::type_name<T>();
+}
 
-    // returns the prettified type name for T
-    template<typename T> // TODO: Use this above....
-    [[nodiscard]] std::string pretty_type_name() noexcept {
-        return detail::prettify_type(std::string(detail::type_name<T>()));
-    }
+// returns the prettified type name for T
+template<typename T> // TODO: Use this above....
+[[nodiscard]] std::string pretty_type_name() noexcept {
+	return detail::prettify_type(std::string(detail::type_name<T>()));
+}
 
-    // returns a debug stringification of t
-    template<typename T>
-    [[nodiscard]] std::string stringify(const T& t) {
-        return detail::generate_stringification(t);
-    }
+// returns a debug stringification of t
+template<typename T>
+[[nodiscard]] std::string stringify(const T& t) {
+	return detail::generate_stringification(t);
+}
 
-    // NOTE: string view underlying data should have static storage duration, or otherwise live as long as the scheme
-    // is in use
-    struct color_scheme {
-        std::string_view string;
-        std::string_view escape;
-        std::string_view keyword;
-        std::string_view named_literal;
-        std::string_view number;
-        std::string_view punctuation;
-        std::string_view operator_token;
-        std::string_view call_identifier;
-        std::string_view scope_resolution_identifier;
-        std::string_view identifier;
-        std::string_view accent;
-        std::string_view unknown;
-        std::string_view highlight_delete;
-        std::string_view highlight_insert;
-        std::string_view highlight_replace;
-        std::string_view reset;
-        LIBASSERT_EXPORT const static color_scheme ansi_basic;
-        LIBASSERT_EXPORT const static color_scheme ansi_rgb;
-        LIBASSERT_EXPORT const static color_scheme blank;
-    };
+// NOTE: string view underlying data should have static storage duration, or otherwise live as long as the scheme
+// is in use
+struct color_scheme {
+	std::string_view string;
+	std::string_view escape;
+	std::string_view keyword;
+	std::string_view named_literal;
+	std::string_view number;
+	std::string_view punctuation;
+	std::string_view operator_token;
+	std::string_view call_identifier;
+	std::string_view scope_resolution_identifier;
+	std::string_view identifier;
+	std::string_view accent;
+	std::string_view unknown;
+	std::string_view highlight_delete;
+	std::string_view highlight_insert;
+	std::string_view highlight_replace;
+	std::string_view reset;
+	LIBASSERT_EXPORT const static color_scheme ansi_basic;
+	LIBASSERT_EXPORT const static color_scheme ansi_rgb;
+	LIBASSERT_EXPORT const static color_scheme blank;
+};
 
-    LIBASSERT_EXPORT void set_color_scheme(const color_scheme&);
-    LIBASSERT_EXPORT const color_scheme& get_color_scheme();
+LIBASSERT_EXPORT void set_color_scheme(const color_scheme&);
+LIBASSERT_EXPORT const color_scheme& get_color_scheme();
 
-    LIBASSERT_EXPORT void set_diff_highlighting(bool);
+LIBASSERT_EXPORT void set_diff_highlighting(bool);
 
-    // set separator used for diagnostics, by default it is "=>"
-    // note: not thread-safe
-    LIBASSERT_EXPORT void set_separator(std::string_view separator);
+// set separator used for diagnostics, by default it is "=>"
+// note: not thread-safe
+LIBASSERT_EXPORT void set_separator(std::string_view separator);
 
-    std::string highlight(std::string_view expression, const color_scheme& scheme = get_color_scheme());
+std::string highlight(std::string_view expression, const color_scheme& scheme = get_color_scheme());
 
-    template<typename T>
-    [[nodiscard]] std::string highlight_stringify(const T& t, const color_scheme& scheme = get_color_scheme()) {
-        return highlight(stringify(t), scheme);
-    }
+template<typename T>
+[[nodiscard]] std::string
+highlight_stringify(const T& t, const color_scheme& scheme = get_color_scheme()) {
+	return highlight(stringify(t), scheme);
+}
 
-    enum class literal_format : unsigned {
-        // integers and floats are decimal by default, chars are of course chars, and everything else only has one
-        // format that makes sense
-        default_format = 0,
-        integer_hex = 1,
-        integer_octal = 2,
-        integer_binary = 4,
-        integer_character = 8, // format integers as characters and characters as integers
-        float_hex = 16,
-    };
+enum class literal_format : unsigned {
+	// integers and floats are decimal by default, chars are of course chars, and everything else only has one
+	// format that makes sense
+	default_format = 0,
+	integer_hex = 1,
+	integer_octal = 2,
+	integer_binary = 4,
+	integer_character = 8, // format integers as characters and characters as integers
+	float_hex = 16,
+};
 
-    [[nodiscard]] constexpr literal_format operator|(literal_format a, literal_format b) {
-        return static_cast<literal_format>(
-            static_cast<std::underlying_type<literal_format>::type>(a) |
-            static_cast<std::underlying_type<literal_format>::type>(b)
-        );
-    }
+[[nodiscard]] constexpr literal_format operator|(literal_format a, literal_format b) {
+	return static_cast<literal_format>(
+		static_cast<std::underlying_type<literal_format>::type>(a)
+		| static_cast<std::underlying_type<literal_format>::type>(b)
+	);
+}
 
-    enum class literal_format_mode {
-        infer, // infer literal formats based on the assertion condition
-        no_variations, // don't do any literal format variations, just default
-        fixed_variations // use a fixed set of formats always; note the default format will always be used
-    };
+enum class literal_format_mode {
+	infer, // infer literal formats based on the assertion condition
+	no_variations, // don't do any literal format variations, just default
+	fixed_variations // use a fixed set of formats always; note the default format will always be used
+};
 
-    // NOTE: Should not be called during handling of an assertion in the current thread
-    LIBASSERT_EXPORT void set_literal_format_mode(literal_format_mode);
+// NOTE: Should not be called during handling of an assertion in the current thread
+LIBASSERT_EXPORT void set_literal_format_mode(literal_format_mode);
 
-    // NOTE: Should not be called during handling of an assertion in the current thread
-    // set a fixed literal format configuration, automatically changes the literal_format_mode; note that the default
-    // format will always be used along with others
-    LIBASSERT_EXPORT void set_fixed_literal_format(literal_format);
+// NOTE: Should not be called during handling of an assertion in the current thread
+// set a fixed literal format configuration, automatically changes the literal_format_mode; note that the default
+// format will always be used along with others
+LIBASSERT_EXPORT void set_fixed_literal_format(literal_format);
 
-    enum class path_mode {
-        // full path is used
-        full,
-        // only enough folders needed to disambiguate are provided
-        disambiguated, // TODO: Maybe just a bad idea...?
-        // only the file name is used
-        basename,
-    };
-    LIBASSERT_EXPORT void set_path_mode(path_mode mode);
-    LIBASSERT_EXPORT path_mode get_path_mode();
+enum class path_mode {
+	// full path is used
+	full,
+	// only enough folders needed to disambiguate are provided
+	disambiguated, // TODO: Maybe just a bad idea...?
+	// only the file name is used
+	basename,
+};
+LIBASSERT_EXPORT void set_path_mode(path_mode mode);
+LIBASSERT_EXPORT path_mode get_path_mode();
 
-    // generates a stack trace, formats to the given width
-    [[nodiscard]] LIBASSERT_ATTR_NOINLINE LIBASSERT_EXPORT
-    std::string stacktrace(int width = 0, const color_scheme& scheme = get_color_scheme(), std::size_t skip = 0);
+// generates a stack trace, formats to the given width
+[[nodiscard]] LIBASSERT_ATTR_NOINLINE LIBASSERT_EXPORT std::string
+stacktrace(int width = 0, const color_scheme& scheme = get_color_scheme(), std::size_t skip = 0);
 
-    // formats a stacktrace
-    [[nodiscard]] LIBASSERT_EXPORT
-    std::string print_stacktrace(
-        const cpptrace::stacktrace& trace,
-        int width = 0,
-        const color_scheme& scheme = get_color_scheme(),
-        path_mode = get_path_mode()
-    );
+// formats a stacktrace
+[[nodiscard]] LIBASSERT_EXPORT std::string print_stacktrace(
+	const cpptrace::stacktrace& trace,
+	int width = 0,
+	const color_scheme& scheme = get_color_scheme(),
+	path_mode = get_path_mode()
+);
 
-    enum class assert_type {
-        debug_assertion,
-        assertion,
-        assumption,
-        panic,
-        unreachable
-    };
+enum class assert_type { debug_assertion, assertion, assumption, panic, unreachable };
 
-    struct assertion_info;
+struct assertion_info;
 
-    [[noreturn]] LIBASSERT_EXPORT void default_failure_handler(const assertion_info& info);
+[[noreturn]] LIBASSERT_EXPORT void default_failure_handler(const assertion_info& info);
 
-    using handler_ptr = void(*)(const assertion_info&);
-    LIBASSERT_EXPORT handler_ptr get_failure_handler();
-    LIBASSERT_EXPORT void set_failure_handler(handler_ptr handler);
+using handler_ptr = void (*)(const assertion_info&);
+LIBASSERT_EXPORT handler_ptr get_failure_handler();
+LIBASSERT_EXPORT void set_failure_handler(handler_ptr handler);
 
-    struct LIBASSERT_EXPORT binary_diagnostics_descriptor {
-        std::string left_expression;
-        std::string right_expression;
-        std::string left_stringification;
-        std::string right_stringification;
-        bool multiple_formats;
-        binary_diagnostics_descriptor(); // = default; in the .cpp
-        binary_diagnostics_descriptor(
-            std::string_view left_expression,
-            std::string_view right_expression,
-            std::string&& left_stringification,
-            std::string&& right_stringification,
-            bool multiple_formats
-        );
-        ~binary_diagnostics_descriptor(); // = default; in the .cpp
-        binary_diagnostics_descriptor(const binary_diagnostics_descriptor&);
-        binary_diagnostics_descriptor(binary_diagnostics_descriptor&&) noexcept;
-        binary_diagnostics_descriptor& operator=(const binary_diagnostics_descriptor&);
-        binary_diagnostics_descriptor& operator=(binary_diagnostics_descriptor&&) noexcept(LIBASSERT_GCC_ISNT_STUPID);
-    };
+struct LIBASSERT_EXPORT binary_diagnostics_descriptor {
+	std::string left_expression;
+	std::string right_expression;
+	std::string left_stringification;
+	std::string right_stringification;
+	bool multiple_formats;
+	binary_diagnostics_descriptor(); // = default; in the .cpp
+	binary_diagnostics_descriptor(
+		std::string_view left_expression,
+		std::string_view right_expression,
+		std::string&& left_stringification,
+		std::string&& right_stringification,
+		bool multiple_formats
+	);
+	~binary_diagnostics_descriptor(); // = default; in the .cpp
+	binary_diagnostics_descriptor(const binary_diagnostics_descriptor&);
+	binary_diagnostics_descriptor(binary_diagnostics_descriptor&&) noexcept;
+	binary_diagnostics_descriptor& operator=(const binary_diagnostics_descriptor&);
+	binary_diagnostics_descriptor&
+	operator=(binary_diagnostics_descriptor&&) noexcept(LIBASSERT_GCC_ISNT_STUPID);
+};
 
-    namespace detail {
-        struct sv_span {
-            const std::string_view* data;
-            std::size_t size;
-        };
+namespace detail {
+struct sv_span {
+	const std::string_view* data;
+	std::size_t size;
+};
 
-        // collection of assertion data that can be put in static storage and all passed by a single pointer
-        struct LIBASSERT_EXPORT assert_static_parameters {
-            std::string_view macro_name;
-            assert_type type;
-            std::string_view expr_str;
-            source_location location;
-            sv_span args_strings;
-        };
-    }
+// collection of assertion data that can be put in static storage and all passed by a single pointer
+struct LIBASSERT_EXPORT assert_static_parameters {
+	std::string_view macro_name;
+	assert_type type;
+	std::string_view expr_str;
+	source_location location;
+	sv_span args_strings;
+};
+} // namespace detail
 
-    struct extra_diagnostic {
-        std::string_view expression;
-        std::string stringification;
-    };
+struct extra_diagnostic {
+	std::string_view expression;
+	std::string stringification;
+};
 
-    namespace detail {
-        class path_handler {
-        public:
-            virtual ~path_handler() = default;
-            virtual std::unique_ptr<detail::path_handler> clone() const = 0;
-            virtual std::string_view resolve_path(std::string_view) = 0;
-            virtual bool has_add_path() const;
-            virtual void add_path(std::string_view);
-            virtual void finalize();
-        };
-        struct trace_holder;
-        // deleter needed so unique ptr move/delete can work on the opaque pointer
-        struct LIBASSERT_EXPORT trace_holder_deleter {
-            void operator()(trace_holder*);
-        };
-        LIBASSERT_ATTR_NOINLINE LIBASSERT_EXPORT std::unique_ptr<trace_holder, trace_holder_deleter> generate_trace();
-    }
+namespace detail {
+class path_handler {
+public:
+	virtual ~path_handler() = default;
+	virtual std::unique_ptr<detail::path_handler> clone() const = 0;
+	virtual std::string_view resolve_path(std::string_view) = 0;
+	virtual bool has_add_path() const;
+	virtual void add_path(std::string_view);
+	virtual void finalize();
+};
+struct trace_holder;
 
-    struct LIBASSERT_EXPORT assertion_info {
-        std::string_view macro_name;
-        assert_type type;
-        std::string_view expression_string;
-        std::string_view file_name;
-        std::uint32_t line;
-        std::string_view function;
-        std::optional<std::string> message;
-        std::optional<binary_diagnostics_descriptor> binary_diagnostics;
-        std::vector<extra_diagnostic> extra_diagnostics;
-        size_t n_args;
-    private:
-        std::unique_ptr<detail::trace_holder> trace;
-        mutable std::unique_ptr<detail::path_handler> path_handler;
-        detail::path_handler* get_path_handler() const; // will get and setup the path handler
-    public:
-        assertion_info() = delete;
-        assertion_info(
-            const detail::assert_static_parameters* static_params,
-            std::unique_ptr<detail::trace_holder, detail::trace_holder_deleter> trace,
-            size_t n_args
-        );
-        ~assertion_info();
-        assertion_info(const assertion_info&);
-        assertion_info(assertion_info&&);
-        assertion_info& operator=(const assertion_info&);
-        assertion_info& operator=(assertion_info&&);
+// deleter needed so unique ptr move/delete can work on the opaque pointer
+struct LIBASSERT_EXPORT trace_holder_deleter {
+	void operator()(trace_holder*);
+};
 
-        std::string_view action() const;
+LIBASSERT_ATTR_NOINLINE LIBASSERT_EXPORT std::unique_ptr<trace_holder, trace_holder_deleter>
+generate_trace();
+} // namespace detail
 
-        const cpptrace::raw_trace& get_raw_trace() const;
-        const cpptrace::stacktrace& get_stacktrace() const;
+struct LIBASSERT_EXPORT assertion_info {
+	std::string_view macro_name;
+	assert_type type;
+	std::string_view expression_string;
+	std::string_view file_name;
+	std::uint32_t line;
+	std::string_view function;
+	std::optional<std::string> message;
+	std::optional<binary_diagnostics_descriptor> binary_diagnostics;
+	std::vector<extra_diagnostic> extra_diagnostics;
+	size_t n_args;
 
-        [[nodiscard]] std::string header(int width = 0, const color_scheme& scheme = get_color_scheme()) const;
-        [[nodiscard]] std::string tagline(const color_scheme& scheme = get_color_scheme()) const;
-        [[nodiscard]] std::string location() const;
-        [[nodiscard]] std::string statement(const color_scheme& scheme = get_color_scheme()) const;
-        [[nodiscard]] std::string print_binary_diagnostics(int width = 0, const color_scheme& scheme = get_color_scheme()) const;
-        [[nodiscard]] std::string print_extra_diagnostics(int width = 0, const color_scheme& scheme = get_color_scheme()) const;
-        [[nodiscard]] std::string print_stacktrace(int width = 0, const color_scheme& scheme = get_color_scheme()) const;
+private:
+	std::unique_ptr<detail::trace_holder> trace;
+	mutable std::unique_ptr<detail::path_handler> path_handler;
+	detail::path_handler* get_path_handler() const; // will get and setup the path handler
+public:
+	assertion_info() = delete;
+	assertion_info(
+		const detail::assert_static_parameters* static_params,
+		std::unique_ptr<detail::trace_holder, detail::trace_holder_deleter> trace,
+		size_t n_args
+	);
+	~assertion_info();
+	assertion_info(const assertion_info&);
+	assertion_info(assertion_info&&);
+	assertion_info& operator=(const assertion_info&);
+	assertion_info& operator=(assertion_info&&);
 
-        [[nodiscard]] std::string to_string(int width = 0, const color_scheme& scheme = get_color_scheme()) const;
-    };
+	std::string_view action() const;
+
+	const cpptrace::raw_trace& get_raw_trace() const;
+	const cpptrace::stacktrace& get_stacktrace() const;
+
+	[[nodiscard]] std::string
+	header(int width = 0, const color_scheme& scheme = get_color_scheme()) const;
+	[[nodiscard]] std::string tagline(const color_scheme& scheme = get_color_scheme()) const;
+	[[nodiscard]] std::string location() const;
+	[[nodiscard]] std::string statement(const color_scheme& scheme = get_color_scheme()) const;
+	[[nodiscard]] std::string
+	print_binary_diagnostics(int width = 0, const color_scheme& scheme = get_color_scheme()) const;
+	[[nodiscard]] std::string
+	print_extra_diagnostics(int width = 0, const color_scheme& scheme = get_color_scheme()) const;
+	[[nodiscard]] std::string
+	print_stacktrace(int width = 0, const color_scheme& scheme = get_color_scheme()) const;
+
+	[[nodiscard]] std::string
+	to_string(int width = 0, const color_scheme& scheme = get_color_scheme()) const;
+};
+
 LIBASSERT_END_NAMESPACE
 
 // =====================================================================================================================
@@ -299,207 +304,196 @@ LIBASSERT_END_NAMESPACE
 // =====================================================================================================================
 
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    /*
+/*
      * C++ syntax analysis and literal formatting
      */
 
-    // get current literal_format configuration for the thread
-    [[nodiscard]] LIBASSERT_EXPORT literal_format get_thread_current_literal_format();
+// get current literal_format configuration for the thread
+[[nodiscard]] LIBASSERT_EXPORT literal_format get_thread_current_literal_format();
 
-    // sets the current literal_format configuration for the thread
-    LIBASSERT_EXPORT void set_thread_current_literal_format(literal_format format);
+// sets the current literal_format configuration for the thread
+LIBASSERT_EXPORT void set_thread_current_literal_format(literal_format format);
 
-    LIBASSERT_EXPORT literal_format set_literal_format(
-        std::string_view left_expression,
-        std::string_view right_expression,
-        std::string_view op,
-        bool integer_character
-    );
-    LIBASSERT_EXPORT void restore_literal_format(literal_format);
-    // does the current literal format config have multiple formats
-    LIBASSERT_EXPORT bool has_multiple_formats();
+LIBASSERT_EXPORT literal_format set_literal_format(
+	std::string_view left_expression,
+	std::string_view right_expression,
+	std::string_view op,
+	bool integer_character
+);
+LIBASSERT_EXPORT void restore_literal_format(literal_format);
+// does the current literal format config have multiple formats
+LIBASSERT_EXPORT bool has_multiple_formats();
 
-    [[nodiscard]] LIBASSERT_EXPORT std::pair<std::string, std::string> decompose_expression(
-        std::string_view expression,
-        std::string_view target_op
-    );
+[[nodiscard]] LIBASSERT_EXPORT std::pair<std::string, std::string>
+decompose_expression(std::string_view expression, std::string_view target_op);
 
-    /*
+/*
      * assert diagnostics generation
      */
 
-    template<typename A, typename B>
-    LIBASSERT_ATTR_COLD [[nodiscard]]
-    binary_diagnostics_descriptor generate_binary_diagnostic(
-        const A& left,
-        const B& right,
-        std::string_view left_str,
-        std::string_view right_str,
-        std::string_view op
-    ) {
-        constexpr bool either_is_character = isa<A, char> || isa<B, char>;
-        constexpr bool either_is_arithmetic = is_arith_not_bool_char<A> || is_arith_not_bool_char<B>;
-        literal_format previous_format = set_literal_format(
-            left_str,
-            right_str,
-            op,
-            either_is_character && either_is_arithmetic
-        );
-        binary_diagnostics_descriptor descriptor(
-            left_str,
-            right_str,
-            generate_stringification(left),
-            generate_stringification(right),
-            has_multiple_formats()
-        );
-        restore_literal_format(previous_format);
-        return descriptor;
-    }
+template<typename A, typename B>
+LIBASSERT_ATTR_COLD [[nodiscard]]
+binary_diagnostics_descriptor generate_binary_diagnostic(
+	const A& left,
+	const B& right,
+	std::string_view left_str,
+	std::string_view right_str,
+	std::string_view op
+) {
+	constexpr bool either_is_character = isa<A, char> || isa<B, char>;
+	constexpr bool either_is_arithmetic = is_arith_not_bool_char<A> || is_arith_not_bool_char<B>;
+	literal_format previous_format =
+		set_literal_format(left_str, right_str, op, either_is_character && either_is_arithmetic);
+	binary_diagnostics_descriptor descriptor(
+		left_str,
+		right_str,
+		generate_stringification(left),
+		generate_stringification(right),
+		has_multiple_formats()
+	);
+	restore_literal_format(previous_format);
+	return descriptor;
+}
 
-    struct pretty_function_name_wrapper {
-        const char* pretty_function;
-    };
+struct pretty_function_name_wrapper {
+	const char* pretty_function;
+};
 
-    inline void process_arg( // TODO: Don't inline
+inline void process_arg( // TODO: Don't inline
         assertion_info& info,
         size_t,
         sv_span,
         const pretty_function_name_wrapper& t
     ) {
-        info.function = t.pretty_function;
-    }
-
-    LIBASSERT_EXPORT void set_message(assertion_info& info, const char* value);
-    LIBASSERT_EXPORT void set_message(assertion_info& info, std::string_view value);
-    // used to enable errno stuff
-    LIBASSERT_EXPORT extra_diagnostic make_extra_diagnostic(std::string_view expression, int value);
-
-    template<typename T>
-    LIBASSERT_ATTR_COLD
-    // TODO
-    // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-    void process_arg(assertion_info& info, size_t i, sv_span args_strings, const T& t) {
-        if constexpr(is_string_type<T>) {
-            if(i == 0) {
-                set_message(info, t);
-                return;
-            }
-        }
-        if constexpr(isa<T, int>) {
-            info.extra_diagnostics.push_back(make_extra_diagnostic(args_strings.data[i], t));
-        } else {
-            info.extra_diagnostics.push_back({ args_strings.data[i], generate_stringification(t) });
-        }
-    }
-
-    template<typename... Args>
-    LIBASSERT_ATTR_COLD
-    void process_args(assertion_info& info, sv_span args_strings, Args&... args) {
-        size_t i = 0;
-        (process_arg(info, i++, args_strings, args), ...);
-        (void)args_strings;
-    }
+	info.function = t.pretty_function;
 }
+
+LIBASSERT_EXPORT void set_message(assertion_info& info, const char* value);
+LIBASSERT_EXPORT void set_message(assertion_info& info, std::string_view value);
+// used to enable errno stuff
+LIBASSERT_EXPORT extra_diagnostic make_extra_diagnostic(std::string_view expression, int value);
+
+template<typename T>
+LIBASSERT_ATTR_COLD
+	// TODO
+	// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+	void process_arg(assertion_info& info, size_t i, sv_span args_strings, const T& t) {
+	if constexpr (is_string_type<T>) {
+		if (i == 0) {
+			set_message(info, t);
+			return;
+		}
+	}
+	if constexpr (isa<T, int>) {
+		info.extra_diagnostics.push_back(make_extra_diagnostic(args_strings.data[i], t));
+	} else {
+		info.extra_diagnostics.push_back({args_strings.data[i], generate_stringification(t)});
+	}
+}
+
+template<typename... Args>
+LIBASSERT_ATTR_COLD void process_args(assertion_info& info, sv_span args_strings, Args&... args) {
+	size_t i = 0;
+	(process_arg(info, i++, args_strings, args), ...);
+	(void)args_strings;
+}
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE
 
 /*
  * Actual top-level assertion processing
  */
 
- LIBASSERT_BEGIN_NAMESPACE
- namespace detail {
-    LIBASSERT_EXPORT void fail(const assertion_info& info);
+LIBASSERT_BEGIN_NAMESPACE
 
-    template<typename A, typename B, typename C, typename... Args>
-    LIBASSERT_ATTR_COLD LIBASSERT_ATTR_NOINLINE
-    // TODO: Re-evaluate forwarding here.
-    void process_assert_fail(
-        expression_decomposer<A, B, C>& decomposer,
-        const assert_static_parameters* params,
-        // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
-        Args&&... args
-    ) {
-        const size_t sizeof_extra_diagnostics = sizeof...(args) - 1; // - 1 for pretty function signature
-        LIBASSERT_PRIMITIVE_DEBUG_ASSERT(sizeof...(args) <= params->args_strings.size);
-        assertion_info info(params, detail::generate_trace(), sizeof_extra_diagnostics);
-        // process_args fills in the message, extra_diagnostics, and pretty_function
-        process_args(info, params->args_strings, args...);
-        // generate binary diagnostics
-        if constexpr(is_nothing<C>) {
-            static_assert(is_nothing<B> && !is_nothing<A>);
-            if constexpr(isa<A, bool>) {
-                (void)decomposer; // suppress warning in msvc
-            } else {
-                info.binary_diagnostics = generate_binary_diagnostic(
-                    decomposer.a,
-                    true,
-                    params->expr_str,
-                    "true",
-                    "=="
-                );
-            }
-        } else {
-            auto [left_expression, right_expression] = decompose_expression(params->expr_str, C::op_string);
-            info.binary_diagnostics = generate_binary_diagnostic(
-                decomposer.a,
-                decomposer.b,
-                left_expression,
-                right_expression,
-                C::op_string
-            );
-        }
-        // send off
-        fail(info);
-    }
+namespace detail {
+LIBASSERT_EXPORT void fail(const assertion_info& info);
 
-    template<typename... Args>
-    LIBASSERT_ATTR_COLD [[noreturn]] LIBASSERT_ATTR_NOINLINE
-    // TODO: Re-evaluate forwarding here.
-    void process_panic(
-        const assert_static_parameters* params,
-        // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
-        Args&&... args
-    ) {
-        const size_t sizeof_extra_diagnostics = sizeof...(args) - 1; // - 1 for pretty function signature
-        LIBASSERT_PRIMITIVE_DEBUG_ASSERT(sizeof...(args) <= params->args_strings.size);
-        assertion_info info(params, detail::generate_trace(), sizeof_extra_diagnostics);
-        // process_args fills in the message, extra_diagnostics, and pretty_function
-        process_args(info, params->args_strings, args...);
-        // send off
-        fail(info);
-        LIBASSERT_PRIMITIVE_PANIC("PANIC/UNREACHABLE failure handler returned");
-    }
-
-    template<typename T>
-    struct assert_value_wrapper {
-        T value;
-    };
-
-    template<
-        bool ret_lhs, bool value_is_lval_ref,
-        typename T, typename A, typename B, typename C
-    >
-    constexpr auto get_expression_return_value(T& value, expression_decomposer<A, B, C>& decomposer) {
-        if constexpr(ret_lhs) {
-            if constexpr(std::is_lvalue_reference_v<A>) {
-                return assert_value_wrapper<A>{decomposer.take_lhs()};
-            } else {
-                return assert_value_wrapper<A>{std::move(decomposer.take_lhs())};
-            }
-        } else {
-            if constexpr(value_is_lval_ref) {
-                return assert_value_wrapper<T&>{value};
-            } else {
-                return assert_value_wrapper<T>{std::move(value)};
-            }
-        }
-    }
+template<typename A, typename B, typename C, typename... Args>
+LIBASSERT_ATTR_COLD LIBASSERT_ATTR_NOINLINE
+	// TODO: Re-evaluate forwarding here.
+	void process_assert_fail(
+		expression_decomposer<A, B, C>& decomposer,
+		const assert_static_parameters* params,
+		// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
+		Args&&... args
+	) {
+	const size_t sizeof_extra_diagnostics = sizeof...(args) - 1; // - 1 for pretty function signature
+	LIBASSERT_PRIMITIVE_DEBUG_ASSERT(sizeof...(args) <= params->args_strings.size);
+	assertion_info info(params, detail::generate_trace(), sizeof_extra_diagnostics);
+	// process_args fills in the message, extra_diagnostics, and pretty_function
+	process_args(info, params->args_strings, args...);
+	// generate binary diagnostics
+	if constexpr (is_nothing<C>) {
+		static_assert(is_nothing<B> && !is_nothing<A>);
+		if constexpr (isa<A, bool>) {
+			(void)decomposer; // suppress warning in msvc
+		} else {
+			info.binary_diagnostics =
+				generate_binary_diagnostic(decomposer.a, true, params->expr_str, "true", "==");
+		}
+	} else {
+		auto [left_expression, right_expression] = decompose_expression(params->expr_str, C::op_string);
+		info.binary_diagnostics = generate_binary_diagnostic(
+			decomposer.a,
+			decomposer.b,
+			left_expression,
+			right_expression,
+			C::op_string
+		);
+	}
+	// send off
+	fail(info);
 }
+
+template<typename... Args>
+LIBASSERT_ATTR_COLD [[noreturn]] LIBASSERT_ATTR_NOINLINE
+	// TODO: Re-evaluate forwarding here.
+	void process_panic(
+		const assert_static_parameters* params,
+		// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
+		Args&&... args
+	) {
+	const size_t sizeof_extra_diagnostics = sizeof...(args) - 1; // - 1 for pretty function signature
+	LIBASSERT_PRIMITIVE_DEBUG_ASSERT(sizeof...(args) <= params->args_strings.size);
+	assertion_info info(params, detail::generate_trace(), sizeof_extra_diagnostics);
+	// process_args fills in the message, extra_diagnostics, and pretty_function
+	process_args(info, params->args_strings, args...);
+	// send off
+	fail(info);
+	LIBASSERT_PRIMITIVE_PANIC("PANIC/UNREACHABLE failure handler returned");
+}
+
+template<typename T>
+struct assert_value_wrapper {
+	T value;
+};
+
+template<bool ret_lhs, bool value_is_lval_ref, typename T, typename A, typename B, typename C>
+constexpr auto get_expression_return_value(T& value, expression_decomposer<A, B, C>& decomposer) {
+	if constexpr (ret_lhs) {
+		if constexpr (std::is_lvalue_reference_v<A>) {
+			return assert_value_wrapper<A> {decomposer.take_lhs()};
+		} else {
+			return assert_value_wrapper<A> {std::move(decomposer.take_lhs())};
+		}
+	} else {
+		if constexpr (value_is_lval_ref) {
+			return assert_value_wrapper<T&> {value};
+		} else {
+			return assert_value_wrapper<T> {std::move(value)};
+		}
+	}
+}
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE
 
 #if LIBASSERT_IS_MSVC
- #pragma warning(pop)
+	#pragma warning(pop)
 #endif
 
 #endif

--- a/include/libassert/expression-decomposition.hpp
+++ b/include/libassert/expression-decomposition.hpp
@@ -13,291 +13,316 @@
 // =====================================================================================================================
 
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    // Lots of boilerplate
-    // std:: implementations don't allow two separate types for lhs/rhs
-    // Note: is this macro potentially bad when it comes to debugging(?)
-    namespace ops {
-        #define LIBASSERT_GEN_OP_BOILERPLATE(name, op) struct name { \
-            static constexpr std::string_view op_string = #op; \
-            template<typename A, typename B> \
-            [[nodiscard]] \
-            constexpr decltype(auto) operator()(A&& lhs, B&& rhs) const { /* no need to forward ints */ \
-                return std::forward<A>(lhs) op std::forward<B>(rhs); \
-            } \
-        }
-        #define LIBASSERT_GEN_OP_BOILERPLATE_SPECIAL(name, op, cmp) struct name { \
-            static constexpr std::string_view op_string = #op; \
-            template<typename A, typename B> \
-            [[nodiscard]] \
-            constexpr decltype(auto) operator()(A&& lhs, B&& rhs) const { /* no need to forward ints */ \
-                if constexpr(is_integral_and_not_bool<A> && is_integral_and_not_bool<B>) return cmp(lhs, rhs); \
-                else return std::forward<A>(lhs) op std::forward<B>(rhs); \
-            } \
-        }
-        LIBASSERT_GEN_OP_BOILERPLATE(shl, <<);
-        LIBASSERT_GEN_OP_BOILERPLATE(shr, >>);
-        #if __cplusplus >= 202002L
-         LIBASSERT_GEN_OP_BOILERPLATE(spaceship, <=>);
-        #endif
-        #ifdef LIBASSERT_SAFE_COMPARISONS
-        // TODO: Make a SAFE() wrapper...
-        LIBASSERT_GEN_OP_BOILERPLATE_SPECIAL(eq,   ==, cmp_equal);
-        LIBASSERT_GEN_OP_BOILERPLATE_SPECIAL(neq,  !=, cmp_not_equal);
-        LIBASSERT_GEN_OP_BOILERPLATE_SPECIAL(gt,    >, cmp_greater);
-        LIBASSERT_GEN_OP_BOILERPLATE_SPECIAL(lt,    <, cmp_less);
-        LIBASSERT_GEN_OP_BOILERPLATE_SPECIAL(gteq, >=, cmp_greater_equal);
-        LIBASSERT_GEN_OP_BOILERPLATE_SPECIAL(lteq, <=, cmp_less_equal);
-        #else
-        LIBASSERT_GEN_OP_BOILERPLATE(eq,   ==);
-        LIBASSERT_GEN_OP_BOILERPLATE(neq,  !=);
-        LIBASSERT_GEN_OP_BOILERPLATE(gt,    >);
-        LIBASSERT_GEN_OP_BOILERPLATE(lt,    <);
-        LIBASSERT_GEN_OP_BOILERPLATE(gteq, >=);
-        LIBASSERT_GEN_OP_BOILERPLATE(lteq, <=);
-        #endif
-        LIBASSERT_GEN_OP_BOILERPLATE(band,   &);
-        LIBASSERT_GEN_OP_BOILERPLATE(bxor,   ^);
-        LIBASSERT_GEN_OP_BOILERPLATE(bor,    |);
-        #ifdef LIBASSERT_DECOMPOSE_BINARY_LOGICAL
-         struct land {
-             static constexpr std::string_view op_string = "&&";
-             template<typename A, typename B>
-             [[nodiscard]]
-             constexpr decltype(auto) operator()(A&& lhs, B&& rhs) const {
-                 // Go out of the way to support old-style ASSERT(foo && "Message")
-                 #if LIBASSERT_IS_GCC
-                  if constexpr(is_string_literal<B>) {
-                      #pragma GCC diagnostic push
-                      #pragma GCC diagnostic ignored "-Wnonnull-compare"
-                      return std::forward<A>(lhs) && std::forward<B>(rhs);
-                      #pragma GCC diagnostic pop
-                  } else {
-                      return std::forward<A>(lhs) && std::forward<B>(rhs);
-                  }
-                 #else
-                  return std::forward<A>(lhs) && std::forward<B>(rhs);
-                 #endif
-             }
-         };
-         LIBASSERT_GEN_OP_BOILERPLATE(lor,    ||);
-        #endif
-        LIBASSERT_GEN_OP_BOILERPLATE(assign, =);
-        LIBASSERT_GEN_OP_BOILERPLATE(add_assign,  +=);
-        LIBASSERT_GEN_OP_BOILERPLATE(sub_assign,  -=);
-        LIBASSERT_GEN_OP_BOILERPLATE(mul_assign,  *=);
-        LIBASSERT_GEN_OP_BOILERPLATE(div_assign,  /=);
-        LIBASSERT_GEN_OP_BOILERPLATE(mod_assign,  %=);
-        LIBASSERT_GEN_OP_BOILERPLATE(shl_assign,  <<=);
-        LIBASSERT_GEN_OP_BOILERPLATE(shr_assign,  >>=);
-        LIBASSERT_GEN_OP_BOILERPLATE(band_assign, &=);
-        LIBASSERT_GEN_OP_BOILERPLATE(bxor_assign, ^=);
-        LIBASSERT_GEN_OP_BOILERPLATE(bor_assign,  |=);
-        #undef LIBASSERT_GEN_OP_BOILERPLATE
-        #undef LIBASSERT_GEN_OP_BOILERPLATE_SPECIAL
+// Lots of boilerplate
+// std:: implementations don't allow two separate types for lhs/rhs
+// Note: is this macro potentially bad when it comes to debugging(?)
+namespace ops {
+#define LIBASSERT_GEN_OP_BOILERPLATE(name, op) \
+	struct name { \
+		static constexpr std::string_view op_string = #op; \
+		template<typename A, typename B> \
+		[[nodiscard]] \
+		constexpr decltype(auto) operator()(A&& lhs, B&& rhs) const { /* no need to forward ints */ \
+			return std::forward<A>(lhs) op std::forward<B>(rhs); \
+		} \
+	}
+#define LIBASSERT_GEN_OP_BOILERPLATE_SPECIAL(name, op, cmp) \
+	struct name { \
+		static constexpr std::string_view op_string = #op; \
+		template<typename A, typename B> \
+		[[nodiscard]] \
+		constexpr decltype(auto) operator()(A&& lhs, B&& rhs) const { /* no need to forward ints */ \
+			if constexpr (is_integral_and_not_bool<A> && is_integral_and_not_bool<B>) \
+				return cmp(lhs, rhs); \
+			else \
+				return std::forward<A>(lhs) op std::forward<B>(rhs); \
+		} \
+	}
+	LIBASSERT_GEN_OP_BOILERPLATE(shl, <<);
+	LIBASSERT_GEN_OP_BOILERPLATE(shr, >>);
+#if __cplusplus >= 202002L
+	LIBASSERT_GEN_OP_BOILERPLATE(spaceship, <=>);
+#endif
+#ifdef LIBASSERT_SAFE_COMPARISONS
+	// TODO: Make a SAFE() wrapper...
+	LIBASSERT_GEN_OP_BOILERPLATE_SPECIAL(eq, ==, cmp_equal);
+	LIBASSERT_GEN_OP_BOILERPLATE_SPECIAL(neq, !=, cmp_not_equal);
+	LIBASSERT_GEN_OP_BOILERPLATE_SPECIAL(gt, >, cmp_greater);
+	LIBASSERT_GEN_OP_BOILERPLATE_SPECIAL(lt, <, cmp_less);
+	LIBASSERT_GEN_OP_BOILERPLATE_SPECIAL(gteq, >=, cmp_greater_equal);
+	LIBASSERT_GEN_OP_BOILERPLATE_SPECIAL(lteq, <=, cmp_less_equal);
+#else
+	LIBASSERT_GEN_OP_BOILERPLATE(eq, ==);
+	LIBASSERT_GEN_OP_BOILERPLATE(neq, !=);
+	LIBASSERT_GEN_OP_BOILERPLATE(gt, >);
+	LIBASSERT_GEN_OP_BOILERPLATE(lt, <);
+	LIBASSERT_GEN_OP_BOILERPLATE(gteq, >=);
+	LIBASSERT_GEN_OP_BOILERPLATE(lteq, <=);
+#endif
+	LIBASSERT_GEN_OP_BOILERPLATE(band, &);
+	LIBASSERT_GEN_OP_BOILERPLATE(bxor, ^);
+	LIBASSERT_GEN_OP_BOILERPLATE(bor, |);
+#ifdef LIBASSERT_DECOMPOSE_BINARY_LOGICAL
+	struct land {
+		static constexpr std::string_view op_string = "&&";
 
-        inline constexpr bool ret_lhs(std::string_view op_string) {
-            // return LHS for the following types;
-            return op_string == "=="
-                || op_string == "!="
-                || op_string == "<"
-                || op_string == ">"
-                || op_string == "<="
-                || op_string == ">="
-                || op_string == "&&"
-                || op_string == "||";
-            // don't return LHS for << >> & ^ | and all assignments
-        }
-    }
+		template<typename A, typename B>
+		[[nodiscard]]
+		constexpr decltype(auto) operator()(A&& lhs, B&& rhs) const {
+	// Go out of the way to support old-style ASSERT(foo && "Message")
+	#if LIBASSERT_IS_GCC
+			if constexpr (is_string_literal<B>) {
+		#pragma GCC diagnostic push
+		#pragma GCC diagnostic ignored "-Wnonnull-compare"
+				return std::forward<A>(lhs) && std::forward<B>(rhs);
+		#pragma GCC diagnostic pop
+			} else {
+				return std::forward<A>(lhs) && std::forward<B>(rhs);
+			}
+	#else
+			return std::forward<A>(lhs) && std::forward<B>(rhs);
+	#endif
+		}
+	};
 
-    // I learned this automatic expression decomposition trick from lest:
-    // https://github.com/martinmoene/lest/blob/master/include/lest/lest.hpp#L829-L853
-    //
-    // I have improved upon the trick by supporting more operators and generally improving
-    // functionality.
-    //
-    // Some cases to test and consider:
-    //
-    // Expression   Parsed as
-    // Basic:
-    // false        << false
-    // a == b       (<< a) == b
-    //
-    // Equal precedence following:
-    // a << b       (<< a) << b
-    // a << b << c  ((<< a) << b) << c
-    // a << b + c   (<< a) << (b + c)
-    // a << b < c   ((<< a) << b) < c  // edge case
-    //
-    // Higher precedence following:
-    // a + b        << (a + b)
-    // a + b + c    << ((a + b) + c)
-    // a + b * c    << (a + (b * c))
-    // a + b < c    (<< (a + b)) < c
-    //
-    // Lower precedence following:
-    // a < b        (<< a) < b
-    // a < b < c    ((<< a) < b) < c
-    // a < b + c    (<< a) < (b + c)
-    // a < b == c   ((<< a) < b) == c // edge case
+	LIBASSERT_GEN_OP_BOILERPLATE(lor, ||);
+#endif
+	LIBASSERT_GEN_OP_BOILERPLATE(assign, =);
+	LIBASSERT_GEN_OP_BOILERPLATE(add_assign, +=);
+	LIBASSERT_GEN_OP_BOILERPLATE(sub_assign, -=);
+	LIBASSERT_GEN_OP_BOILERPLATE(mul_assign, *=);
+	LIBASSERT_GEN_OP_BOILERPLATE(div_assign, /=);
+	LIBASSERT_GEN_OP_BOILERPLATE(mod_assign, %=);
+	LIBASSERT_GEN_OP_BOILERPLATE(shl_assign, <<=);
+	LIBASSERT_GEN_OP_BOILERPLATE(shr_assign, >>=);
+	LIBASSERT_GEN_OP_BOILERPLATE(band_assign, &=);
+	LIBASSERT_GEN_OP_BOILERPLATE(bxor_assign, ^=);
+	LIBASSERT_GEN_OP_BOILERPLATE(bor_assign, |=);
+#undef LIBASSERT_GEN_OP_BOILERPLATE
+#undef LIBASSERT_GEN_OP_BOILERPLATE_SPECIAL
 
-    // Ownership logic:
-    //  One of two things can happen to this class
-    //   - Either it is composed with another operation
-    //         + The value of the subexpression represented by this is computed (either get_value()
-    //           or operator bool), either A& or C()(a, b)
-    //      + Or, just the lhs is moved B is nothing
-    //   - Or this class represents the whole expression
-    //      + The value is computed (either A& or C()(a, b))
-    //      + a and b are referenced freely
-    //      + Either the value is taken or a is moved out
-    // Ensuring the value is only computed once is left to the assert handler
+	inline constexpr bool ret_lhs(std::string_view op_string) {
+		// return LHS for the following types;
+		return op_string == "==" || op_string == "!=" || op_string == "<" || op_string == ">"
+			|| op_string == "<=" || op_string == ">=" || op_string == "&&" || op_string == "||";
+		// don't return LHS for << >> & ^ | and all assignments
+	}
+} // namespace ops
 
-    // expression_decomposer is a template of the left hand type, right hand type, and the operator (as a function
-    // object)
-    // Specialized for
-    //   empty, default-constructed base-case
-    //   just a left-hand value
-    //   full representation of a binary expression
+// I learned this automatic expression decomposition trick from lest:
+// https://github.com/martinmoene/lest/blob/master/include/lest/lest.hpp#L829-L853
+//
+// I have improved upon the trick by supporting more operators and generally improving
+// functionality.
+//
+// Some cases to test and consider:
+//
+// Expression   Parsed as
+// Basic:
+// false        << false
+// a == b       (<< a) == b
+//
+// Equal precedence following:
+// a << b       (<< a) << b
+// a << b << c  ((<< a) << b) << c
+// a << b + c   (<< a) << (b + c)
+// a << b < c   ((<< a) << b) < c  // edge case
+//
+// Higher precedence following:
+// a + b        << (a + b)
+// a + b + c    << ((a + b) + c)
+// a + b * c    << (a + (b * c))
+// a + b < c    (<< (a + b)) < c
+//
+// Lower precedence following:
+// a < b        (<< a) < b
+// a < b < c    ((<< a) < b) < c
+// a < b + c    (<< a) < (b + c)
+// a < b == c   ((<< a) < b) == c // edge case
 
-    template<typename A = nothing, typename B = nothing, typename C = nothing>
-    struct expression_decomposer;
+// Ownership logic:
+//  One of two things can happen to this class
+//   - Either it is composed with another operation
+//         + The value of the subexpression represented by this is computed (either get_value()
+//           or operator bool), either A& or C()(a, b)
+//      + Or, just the lhs is moved B is nothing
+//   - Or this class represents the whole expression
+//      + The value is computed (either A& or C()(a, b))
+//      + a and b are referenced freely
+//      + Either the value is taken or a is moved out
+// Ensuring the value is only computed once is left to the assert handler
 
-    // empty expression_decomposer
-    template<>
-    struct expression_decomposer<nothing, nothing, nothing> {
-        explicit constexpr expression_decomposer() = default;
+// expression_decomposer is a template of the left hand type, right hand type, and the operator (as a function
+// object)
+// Specialized for
+//   empty, default-constructed base-case
+//   just a left-hand value
+//   full representation of a binary expression
 
-        template<typename O> [[nodiscard]] constexpr auto operator<<(O&& operand) && {
-            return expression_decomposer<O, nothing, nothing>(std::forward<O>(operand));
-        }
-    };
+template<typename A = nothing, typename B = nothing, typename C = nothing>
+struct expression_decomposer;
 
-    #if __cplusplus >= 202002L
-    #define LIBASSERT_GEN_OP_BOILERPLATE_SPACESHIP LIBASSERT_GEN_OP_BOILERPLATE(ops::spaceship, <=>)
-    #else
-    #define LIBASSERT_GEN_OP_BOILERPLATE_SPACESHIP
-    #endif
+// empty expression_decomposer
+template<>
+struct expression_decomposer<nothing, nothing, nothing> {
+	explicit constexpr expression_decomposer() = default;
 
-    #ifdef LIBASSERT_DECOMPOSE_BINARY_LOGICAL
-    #define LIBASSERT_GEN_OP_BOILERPLATE_BINARY_LOGICAL \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::land, &&) \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::lor, ||)
-    #else
-    #define LIBASSERT_GEN_OP_BOILERPLATE_BINARY_LOGICAL
-    #endif
+	template<typename O>
+	[[nodiscard]] constexpr auto operator<<(O&& operand) && {
+		return expression_decomposer<O, nothing, nothing>(std::forward<O>(operand));
+	}
+};
 
-    #define LIBASSERT_DO_GEN_OP_BOILERPLATE \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::shl, <<) \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::shr, >>) \
-        LIBASSERT_GEN_OP_BOILERPLATE_SPACESHIP \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::eq, ==) \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::neq, !=) \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::gt, >) \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::lt, <) \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::gteq, >=) \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::lteq, <=) \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::band, &) \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::bxor, ^) \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::bor, |) \
-        LIBASSERT_GEN_OP_BOILERPLATE_BINARY_LOGICAL \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::assign, =) /* NOLINT(cppcoreguidelines-c-copy-assignment-signature, misc-unconventional-assign-operator) */ \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::add_assign, +=) \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::sub_assign, -=) \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::mul_assign, *=) \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::div_assign, /=) \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::mod_assign, %=) \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::shl_assign, <<=) \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::shr_assign, >>=) \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::band_assign, &=) \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::bxor_assign, ^=) \
-        LIBASSERT_GEN_OP_BOILERPLATE(ops::bor_assign, |=)
+#if __cplusplus >= 202002L
+	#define LIBASSERT_GEN_OP_BOILERPLATE_SPACESHIP LIBASSERT_GEN_OP_BOILERPLATE(ops::spaceship, <=>)
+#else
+	#define LIBASSERT_GEN_OP_BOILERPLATE_SPACESHIP
+#endif
 
-    // just a left-hand value
-    template<typename A>
-    struct expression_decomposer<A, nothing, nothing> {
-        A a;
-        explicit constexpr expression_decomposer() = delete;
-        template<typename U, typename std::enable_if_t<!isa<U, expression_decomposer>, int> = 0>
-        // NOLINTNEXTLINE(bugprone-forwarding-reference-overload) // TODO
-        explicit constexpr expression_decomposer(U&& _a) : a(std::forward<U>(_a)) {}
-        [[nodiscard]]
-        constexpr A& get_value() {
-            return a;
-        }
-        [[nodiscard]]
-        constexpr operator bool() { // for ternary support
-            return static_cast<bool>(get_value());
-        }
-        // return true if the lhs should be returned, false if full computed value should be
-        [[nodiscard]]
-        constexpr bool ret_lhs() {
-            // if there is no top-level binary operation, A is the only thing that can be returned
-            return true;
-        }
-        [[nodiscard]]
-        constexpr decltype(auto) take_lhs() { // should only be called if ret_lhs() == true
-            // This use of std::forward may look surprising as it's not the traditional use of forwarding a T&& in a
-            // template<typename T>. None the less, this still does what we want regarding forwarding lvalues as lvalues
-            // and rvalues as rvalues.
-            return std::forward<A>(a);
-        }
-        #define LIBASSERT_GEN_OP_BOILERPLATE(functor, op) \
-        template<typename O> [[nodiscard]] constexpr auto operator op(O&& operand) && { \
-            return expression_decomposer<A, O, functor>(std::forward<A>(a), std::forward<O>(operand)); \
-        }
-        LIBASSERT_DO_GEN_OP_BOILERPLATE
-        #undef LIBASSERT_GEN_OP_BOILERPLATE
-    };
+#ifdef LIBASSERT_DECOMPOSE_BINARY_LOGICAL
+	#define LIBASSERT_GEN_OP_BOILERPLATE_BINARY_LOGICAL \
+		LIBASSERT_GEN_OP_BOILERPLATE(ops::land, &&) \
+		LIBASSERT_GEN_OP_BOILERPLATE(ops::lor, ||)
+#else
+	#define LIBASSERT_GEN_OP_BOILERPLATE_BINARY_LOGICAL
+#endif
 
-    template<typename T> T deduce_type(T&&);
+#define LIBASSERT_DO_GEN_OP_BOILERPLATE \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::shl, <<) \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::shr, >>) \
+	LIBASSERT_GEN_OP_BOILERPLATE_SPACESHIP \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::eq, ==) \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::neq, !=) \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::gt, >) \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::lt, <) \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::gteq, >=) \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::lteq, <=) \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::band, &) \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::bxor, ^) \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::bor, |) \
+	LIBASSERT_GEN_OP_BOILERPLATE_BINARY_LOGICAL \
+	LIBASSERT_GEN_OP_BOILERPLATE( \
+		ops::assign, \
+		= \
+	) /* NOLINT(cppcoreguidelines-c-copy-assignment-signature, misc-unconventional-assign-operator) */ \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::add_assign, +=) \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::sub_assign, -=) \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::mul_assign, *=) \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::div_assign, /=) \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::mod_assign, %=) \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::shl_assign, <<=) \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::shr_assign, >>=) \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::band_assign, &=) \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::bxor_assign, ^=) \
+	LIBASSERT_GEN_OP_BOILERPLATE(ops::bor_assign, |=)
 
-    template<typename A, typename B, typename C>
-    struct expression_decomposer {
-        static_assert(!is_nothing<A> && !is_nothing<B> && !is_nothing<C>);
-        A a;
-        B b;
-        explicit constexpr expression_decomposer() = delete;
-        template<typename U, typename V>
-        explicit constexpr expression_decomposer(U&& _a, V&& _b) : a(std::forward<U>(_a)), b(std::forward<V>(_b)) {}
-        [[nodiscard]]
-        constexpr decltype(auto) get_value() {
-            return C()(a, b);
-        }
-        [[nodiscard]]
-        constexpr operator bool() { // for ternary support
-            return static_cast<bool>(get_value());
-        }
-        // return true if the lhs should be returned, false if full computed value should be
-        [[nodiscard]]
-        constexpr bool ret_lhs() {
-            return ops::ret_lhs(C::op_string);
-        }
-        [[nodiscard]]
-        constexpr decltype(auto) take_lhs() { // should only be called if ret_lhs() == true
-             // This use of std::forward may look surprising but it's correct
-            return std::forward<A>(a);
-        }
-        #define LIBASSERT_GEN_OP_BOILERPLATE(functor, op) \
-        template<typename O> [[nodiscard]] constexpr auto operator op(O&& operand) && { \
-            static_assert(!is_nothing<A>); \
-            using V = decltype(deduce_type(get_value())); /* deduce_type turns T&& into T while leaving T& as T& */ \
-            return expression_decomposer<V, O, functor>(get_value(), std::forward<O>(operand)); \
-        }
-        LIBASSERT_DO_GEN_OP_BOILERPLATE
-        #undef LIBASSERT_GEN_OP_BOILERPLATE
-    };
+// just a left-hand value
+template<typename A>
+struct expression_decomposer<A, nothing, nothing> {
+	A a;
+	explicit constexpr expression_decomposer() = delete;
 
-    #undef LIBASSERT_GEN_OP_BOILERPLATE_SPACESHIP
-    #undef LIBASSERT_GEN_OP_BOILERPLATE_BINARY_LOGICAL
-    #undef LIBASSERT_DO_GEN_OP_BOILERPLATE
+	template<typename U, typename std::enable_if_t<!isa<U, expression_decomposer>, int> = 0>
+	// NOLINTNEXTLINE(bugprone-forwarding-reference-overload) // TODO
+	explicit constexpr expression_decomposer(U&& _a) : a(std::forward<U>(_a)) {}
 
-    // for ternary support
-    template<typename U>
-    expression_decomposer(U&&) -> expression_decomposer<U>;
+	[[nodiscard]]
+	constexpr A& get_value() {
+		return a;
+	}
 
-    expression_decomposer() -> expression_decomposer<>;
-}
+	[[nodiscard]]
+	constexpr operator bool() { // for ternary support
+		return static_cast<bool>(get_value());
+	}
+
+	// return true if the lhs should be returned, false if full computed value should be
+	[[nodiscard]]
+	constexpr bool ret_lhs() {
+		// if there is no top-level binary operation, A is the only thing that can be returned
+		return true;
+	}
+
+	[[nodiscard]]
+	constexpr decltype(auto) take_lhs() { // should only be called if ret_lhs() == true
+		// This use of std::forward may look surprising as it's not the traditional use of forwarding a T&& in a
+		// template<typename T>. None the less, this still does what we want regarding forwarding lvalues as lvalues
+		// and rvalues as rvalues.
+		return std::forward<A>(a);
+	}
+
+#define LIBASSERT_GEN_OP_BOILERPLATE(functor, op) \
+	template<typename O> \
+	[[nodiscard]] constexpr auto operator op(O&& operand) && { \
+		return expression_decomposer<A, O, functor>(std::forward<A>(a), std::forward<O>(operand)); \
+	}
+	LIBASSERT_DO_GEN_OP_BOILERPLATE
+#undef LIBASSERT_GEN_OP_BOILERPLATE
+};
+
+template<typename T>
+T deduce_type(T&&);
+
+template<typename A, typename B, typename C>
+struct expression_decomposer {
+	static_assert(!is_nothing<A> && !is_nothing<B> && !is_nothing<C>);
+	A a;
+	B b;
+	explicit constexpr expression_decomposer() = delete;
+
+	template<typename U, typename V>
+	explicit constexpr expression_decomposer(U&& _a, V&& _b) :
+		a(std::forward<U>(_a)),
+		b(std::forward<V>(_b)) {}
+
+	[[nodiscard]]
+	constexpr decltype(auto) get_value() {
+		return C()(a, b);
+	}
+
+	[[nodiscard]]
+	constexpr operator bool() { // for ternary support
+		return static_cast<bool>(get_value());
+	}
+
+	// return true if the lhs should be returned, false if full computed value should be
+	[[nodiscard]]
+	constexpr bool ret_lhs() {
+		return ops::ret_lhs(C::op_string);
+	}
+
+	[[nodiscard]]
+	constexpr decltype(auto) take_lhs() { // should only be called if ret_lhs() == true
+		// This use of std::forward may look surprising but it's correct
+		return std::forward<A>(a);
+	}
+
+#define LIBASSERT_GEN_OP_BOILERPLATE(functor, op) \
+	template<typename O> \
+	[[nodiscard]] constexpr auto operator op(O&& operand) && { \
+		static_assert(!is_nothing<A>); \
+		using V = decltype(deduce_type( \
+			get_value() \
+		)); /* deduce_type turns T&& into T while leaving T& as T& */ \
+		return expression_decomposer<V, O, functor>(get_value(), std::forward<O>(operand)); \
+	}
+	LIBASSERT_DO_GEN_OP_BOILERPLATE
+#undef LIBASSERT_GEN_OP_BOILERPLATE
+};
+
+#undef LIBASSERT_GEN_OP_BOILERPLATE_SPACESHIP
+#undef LIBASSERT_GEN_OP_BOILERPLATE_BINARY_LOGICAL
+#undef LIBASSERT_DO_GEN_OP_BOILERPLATE
+
+// for ternary support
+template<typename U>
+expression_decomposer(U&&) -> expression_decomposer<U>;
+
+expression_decomposer() -> expression_decomposer<>;
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE
 
 #endif

--- a/include/libassert/platform.hpp
+++ b/include/libassert/platform.hpp
@@ -7,11 +7,11 @@
 #define LIBASSERT_ABI_NAMESPACE_TAG abiv2
 
 #define LIBASSERT_BEGIN_NAMESPACE \
-    namespace libassert { \
-    inline namespace LIBASSERT_ABI_NAMESPACE_TAG {
+	namespace libassert { \
+	inline namespace LIBASSERT_ABI_NAMESPACE_TAG {
 #define LIBASSERT_END_NAMESPACE \
-    } \
-    }
+	} \
+	}
 
 // =====================================================================================================================
 // || Preprocessor stuff                                                                                              ||
@@ -19,19 +19,19 @@
 
 // Set the C++ version number based on if we are on a dumb compiler like MSVC or not.
 #ifdef _MSVC_LANG
- #define LIBASSERT_CPLUSPLUS _MSVC_LANG
+	#define LIBASSERT_CPLUSPLUS _MSVC_LANG
 #else
- #define LIBASSERT_CPLUSPLUS __cplusplus
+	#define LIBASSERT_CPLUSPLUS __cplusplus
 #endif
 
 #if LIBASSERT_CPLUSPLUS >= 202302L
- #define LIBASSERT_STD_VER 23
+	#define LIBASSERT_STD_VER 23
 #elif LIBASSERT_CPLUSPLUS >= 202002L
- #define LIBASSERT_STD_VER 20
+	#define LIBASSERT_STD_VER 20
 #elif LIBASSERT_CPLUSPLUS >= 201703L
- #define LIBASSERT_STD_VER 17
+	#define LIBASSERT_STD_VER 17
 #else
- #error "libassert requires C++17 or newer"
+	#error "libassert requires C++17 or newer"
 #endif
 
 ///
@@ -39,39 +39,39 @@
 ///
 
 #if defined(__clang__) && !defined(__ibmxl__)
- #define LIBASSERT_IS_CLANG 1
- #define LIBASSERT_CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
+	#define LIBASSERT_IS_CLANG 1
+	#define LIBASSERT_CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
 #else
- #define LIBASSERT_IS_CLANG 0
- #define LIBASSERT_CLANG_VERSION 0
+	#define LIBASSERT_IS_CLANG 0
+	#define LIBASSERT_CLANG_VERSION 0
 #endif
 
 #if (defined(__GNUC__) || defined(__GNUG__)) && !defined(__clang__) && !defined(__INTEL_COMPILER)
- #define LIBASSERT_IS_GCC 1
- #define LIBASSERT_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
+	#define LIBASSERT_IS_GCC 1
+	#define LIBASSERT_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
 #else
- #define LIBASSERT_IS_GCC 0
- #define LIBASSERT_GCC_VERSION 0
+	#define LIBASSERT_IS_GCC 0
+	#define LIBASSERT_GCC_VERSION 0
 #endif
 
 #if defined(_MSC_VER) && !defined(__clang__) // clang on windows defines _MSC_VER
- #define LIBASSERT_IS_MSVC 1
- #define LIBASSERT_MSVC_VERSION _MSC_VER
+	#define LIBASSERT_IS_MSVC 1
+	#define LIBASSERT_MSVC_VERSION _MSC_VER
 #else
- #define LIBASSERT_IS_MSVC 0
- #define LIBASSERT_MSVC_VERSION 0
+	#define LIBASSERT_IS_MSVC 0
+	#define LIBASSERT_MSVC_VERSION 0
 #endif
 
 #ifdef __INTEL_COMPILER
- #define LIBASSERT_IS_ICC 1
+	#define LIBASSERT_IS_ICC 1
 #else
- #define LIBASSERT_IS_ICC 0
+	#define LIBASSERT_IS_ICC 0
 #endif
 
 #ifdef __INTEL_LLVM_COMPILER
- #define LIBASSERT_IS_ICX 1
+	#define LIBASSERT_IS_ICX 1
 #else
- #define LIBASSERT_IS_ICX 0
+	#define LIBASSERT_IS_ICX 0
 #endif
 
 ///
@@ -79,78 +79,78 @@
 ///
 
 #ifdef _WIN32
- #define LIBASSERT_EXPORT_ATTR __declspec(dllexport)
- #define LIBASSERT_IMPORT_ATTR __declspec(dllimport)
+	#define LIBASSERT_EXPORT_ATTR __declspec(dllexport)
+	#define LIBASSERT_IMPORT_ATTR __declspec(dllimport)
 #else
- #define LIBASSERT_EXPORT_ATTR __attribute__((visibility("default")))
- #define LIBASSERT_IMPORT_ATTR __attribute__((visibility("default")))
+	#define LIBASSERT_EXPORT_ATTR __attribute__((visibility("default")))
+	#define LIBASSERT_IMPORT_ATTR __attribute__((visibility("default")))
 #endif
 
 #ifdef LIBASSERT_STATIC_DEFINE
- #define LIBASSERT_EXPORT
- #define LIBASSERT_NO_EXPORT
+	#define LIBASSERT_EXPORT
+	#define LIBASSERT_NO_EXPORT
 #else
- #ifndef LIBASSERT_EXPORT
-  #ifdef libassert_lib_EXPORTS
-   /* We are building this library */
-   #define LIBASSERT_EXPORT LIBASSERT_EXPORT_ATTR
-  #else
-   /* We are using this library */
-   #define LIBASSERT_EXPORT LIBASSERT_IMPORT_ATTR
-  #endif
- #endif
+	#ifndef LIBASSERT_EXPORT
+		#ifdef libassert_lib_EXPORTS
+			/* We are building this library */
+			#define LIBASSERT_EXPORT LIBASSERT_EXPORT_ATTR
+		#else
+			/* We are using this library */
+			#define LIBASSERT_EXPORT LIBASSERT_IMPORT_ATTR
+		#endif
+	#endif
 #endif
 
 #if LIBASSERT_STD_VER >= 23
- #include <utility>
- #define LIBASSERT_UNREACHABLE_CALL() (::std::unreachable())
+	#include <utility>
+	#define LIBASSERT_UNREACHABLE_CALL() (::std::unreachable())
 #elif LIBASSERT_IS_CLANG || LIBASSERT_IS_GCC
- #define LIBASSERT_UNREACHABLE_CALL() __builtin_unreachable()
+	#define LIBASSERT_UNREACHABLE_CALL() __builtin_unreachable()
 #else
- #define LIBASSERT_UNREACHABLE_CALL() __assume(false)
+	#define LIBASSERT_UNREACHABLE_CALL() __assume(false)
 #endif
 
 #if LIBASSERT_IS_CLANG || LIBASSERT_IS_GCC
- #define LIBASSERT_PFUNC __extension__ __PRETTY_FUNCTION__
- #define LIBASSERT_ATTR_COLD     [[gnu::cold]]
- #define LIBASSERT_ATTR_NOINLINE [[gnu::noinline]]
+	#define LIBASSERT_PFUNC __extension__ __PRETTY_FUNCTION__
+	#define LIBASSERT_ATTR_COLD [[gnu::cold]]
+	#define LIBASSERT_ATTR_NOINLINE [[gnu::noinline]]
 #else
- #define LIBASSERT_PFUNC __FUNCSIG__
- #define LIBASSERT_ATTR_COLD
- #define LIBASSERT_ATTR_NOINLINE __declspec(noinline)
+	#define LIBASSERT_PFUNC __FUNCSIG__
+	#define LIBASSERT_ATTR_COLD
+	#define LIBASSERT_ATTR_NOINLINE __declspec(noinline)
 #endif
 
 #if LIBASSERT_IS_MSVC
- #define LIBASSERT_STRONG_EXPECT(expr, value) (expr)
+	#define LIBASSERT_STRONG_EXPECT(expr, value) (expr)
 #elif (defined(__clang__) && __clang_major__ >= 11) || __GNUC__ >= 9
- #define LIBASSERT_STRONG_EXPECT(expr, value) __builtin_expect_with_probability((expr), (value), 1)
+	#define LIBASSERT_STRONG_EXPECT(expr, value) __builtin_expect_with_probability((expr), (value), 1)
 #else
- #define LIBASSERT_STRONG_EXPECT(expr, value) __builtin_expect((expr), (value))
+	#define LIBASSERT_STRONG_EXPECT(expr, value) __builtin_expect((expr), (value))
 #endif
 
 // deal with gcc shenanigans
 // at one point their std::string's move assignment was not noexcept even in c++17
 // https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
 #if defined(_GLIBCXX_USE_CXX11_ABI)
- // NOLINTNEXTLINE(misc-include-cleaner)
- #define LIBASSERT_GCC_ISNT_STUPID _GLIBCXX_USE_CXX11_ABI
+	// NOLINTNEXTLINE(misc-include-cleaner)
+	#define LIBASSERT_GCC_ISNT_STUPID _GLIBCXX_USE_CXX11_ABI
 #else
- // assume others target new abi by default - homework
- #define LIBASSERT_GCC_ISNT_STUPID 1
+	// assume others target new abi by default - homework
+	#define LIBASSERT_GCC_ISNT_STUPID 1
 #endif
 
 #if defined(_MSVC_TRADITIONAL) && _MSVC_TRADITIONAL
- #define LIBASSERT_NON_CONFORMANT_MSVC_PREPROCESSOR 1
+	#define LIBASSERT_NON_CONFORMANT_MSVC_PREPROCESSOR 1
 #else
- #define LIBASSERT_NON_CONFORMANT_MSVC_PREPROCESSOR 0
+	#define LIBASSERT_NON_CONFORMANT_MSVC_PREPROCESSOR 0
 #endif
 
 #if (LIBASSERT_IS_GCC || LIBASSERT_STD_VER >= 20) && !LIBASSERT_NON_CONFORMANT_MSVC_PREPROCESSOR
- // __VA_OPT__ needed for GCC, https://gcc.gnu.org/bugzilla/show_bug.cgi?id=44317
- #define LIBASSERT_VA_ARGS(...) __VA_OPT__(,) __VA_ARGS__
+	// __VA_OPT__ needed for GCC, https://gcc.gnu.org/bugzilla/show_bug.cgi?id=44317
+	#define LIBASSERT_VA_ARGS(...) __VA_OPT__(, ) __VA_ARGS__
 #else
- // clang properly eats the comma with ##__VA_ARGS__
- #define LIBASSERT_VA_ARGS(...) , ##__VA_ARGS__
+	// clang properly eats the comma with ##__VA_ARGS__
+	#define LIBASSERT_VA_ARGS(...) , ##__VA_ARGS__
 #endif
 
 ///
@@ -158,74 +158,74 @@
 ///
 
 #ifdef __has_include
- #if __has_include(<version>)
-  #include <version>
-  #if !defined(LIBASSERT_NO_STD_FORMAT) && __has_include(<format>) && defined(__cpp_lib_format)
-   #define LIBASSERT_USE_STD_FORMAT
-  #endif
- #endif
+	#if __has_include(<version>)
+		#include <version>
+		#if !defined(LIBASSERT_NO_STD_FORMAT) && __has_include(<format>) && defined(__cpp_lib_format)
+			#define LIBASSERT_USE_STD_FORMAT
+		#endif
+	#endif
 #endif
 
 #if LIBASSERT_IS_CLANG || LIBASSERT_IS_GCC
-  #define LIBASSERT_WARNING_PRAGMA_PUSH _Pragma("GCC diagnostic push")
-  #define LIBASSERT_WARNING_PRAGMA_POP _Pragma("GCC diagnostic pop")
+	#define LIBASSERT_WARNING_PRAGMA_PUSH _Pragma("GCC diagnostic push")
+	#define LIBASSERT_WARNING_PRAGMA_POP _Pragma("GCC diagnostic pop")
 #elif LIBASSERT_IS_MSVC
-  #define LIBASSERT_WARNING_PRAGMA_PUSH _Pragma("warning(push)")
-  #define LIBASSERT_WARNING_PRAGMA_POP _Pragma("warning(pop)")
+	#define LIBASSERT_WARNING_PRAGMA_PUSH _Pragma("warning(push)")
+	#define LIBASSERT_WARNING_PRAGMA_POP _Pragma("warning(pop)")
 #endif
 
 #if LIBASSERT_IS_CLANG || LIBASSERT_IS_ICX
- // clang and icx support this as far back as this library could care
- #define LIBASSERT_BREAKPOINT() __builtin_debugtrap()
+	// clang and icx support this as far back as this library could care
+	#define LIBASSERT_BREAKPOINT() __builtin_debugtrap()
 #elif LIBASSERT_IS_MSVC || LIBASSERT_IS_ICC
- // msvc and icc support this as far back as this library could care
- #define LIBASSERT_BREAKPOINT() __debugbreak()
+	// msvc and icc support this as far back as this library could care
+	#define LIBASSERT_BREAKPOINT() __debugbreak()
 #elif LIBASSERT_IS_GCC
- #if LIBASSERT_GCC_VERSION >= 1200
-  #define LIBASSERT_IGNORE_CPP20_EXTENSION_WARNING _Pragma("GCC diagnostic ignored \"-Wc++20-extensions\"")
- #else
-  #define LIBASSERT_IGNORE_CPP20_EXTENSION_WARNING
- #endif
- #define LIBASSERT_ASM_BREAKPOINT(instruction) \
-  do { \
-   LIBASSERT_WARNING_PRAGMA_PUSH \
-   LIBASSERT_IGNORE_CPP20_EXTENSION_WARNING \
-   __asm__ __volatile__(instruction) \
-   ; \
-   LIBASSERT_WARNING_PRAGMA_POP \
-  } while(0)
- // precedence for these come from llvm's __builtin_debugtrap() implementation
- // arm: https://github.com/llvm/llvm-project/blob/e9954ec087d640809082f46d1c7e5ac1767b798d/llvm/lib/Target/ARM/ARMInstrInfo.td#L2393-L2394
- //  def : Pat<(debugtrap), (BKPT 0)>, Requires<[IsARM, HasV5T]>;
- //  def : Pat<(debugtrap), (UDF 254)>, Requires<[IsARM, NoV5T]>;
- // thumb: https://github.com/llvm/llvm-project/blob/e9954ec087d640809082f46d1c7e5ac1767b798d/llvm/lib/Target/ARM/ARMInstrThumb.td#L1444-L1445
- //  def : Pat<(debugtrap), (tBKPT 0)>, Requires<[IsThumb, HasV5T]>;
- //  def : Pat<(debugtrap), (tUDF 254)>, Requires<[IsThumb, NoV5T]>;
- // aarch64: https://github.com/llvm/llvm-project/blob/e9954ec087d640809082f46d1c7e5ac1767b798d/llvm/lib/Target/AArch64/AArch64FastISel.cpp#L3615-L3618
- //  case Intrinsic::debugtrap:
- //   BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, MIMD, TII.get(AArch64::BRK))
- //       .addImm(0xF000);
- //   return true;
- // x86: https://github.com/llvm/llvm-project/blob/e9954ec087d640809082f46d1c7e5ac1767b798d/llvm/lib/Target/X86/X86InstrSystem.td#L81-L84
- //  def : Pat<(debugtrap),
- //            (INT3)>, Requires<[NotPS]>;
- #if defined(__i386__) || defined(__x86_64__)
-  #define LIBASSERT_BREAKPOINT() LIBASSERT_ASM_BREAKPOINT("int3")
- #elif defined(__arm__) || defined(__thumb__)
-  #if __ARM_ARCH >= 5
-   #define LIBASSERT_BREAKPOINT() LIBASSERT_ASM_BREAKPOINT("bkpt #0")
-  #else
-   #define LIBASSERT_BREAKPOINT() LIBASSERT_ASM_BREAKPOINT("udf #0xfe")
-  #endif
- #elif defined(__aarch64__) || defined(_M_ARM64)
-  #define LIBASSERT_BREAKPOINT() LIBASSERT_ASM_BREAKPOINT("brk #0xf000")
- #else
-  // some architecture we aren't prepared for
-  #define LIBASSERT_BREAKPOINT()
- #endif
+	#if LIBASSERT_GCC_VERSION >= 1200
+		#define LIBASSERT_IGNORE_CPP20_EXTENSION_WARNING \
+			_Pragma("GCC diagnostic ignored \"-Wc++20-extensions\"")
+	#else
+		#define LIBASSERT_IGNORE_CPP20_EXTENSION_WARNING
+	#endif
+	#define LIBASSERT_ASM_BREAKPOINT(instruction) \
+		do { \
+			LIBASSERT_WARNING_PRAGMA_PUSH \
+			LIBASSERT_IGNORE_CPP20_EXTENSION_WARNING \
+			__asm__ __volatile__(instruction); \
+			LIBASSERT_WARNING_PRAGMA_POP \
+		} while (0)
+	// precedence for these come from llvm's __builtin_debugtrap() implementation
+	// arm: https://github.com/llvm/llvm-project/blob/e9954ec087d640809082f46d1c7e5ac1767b798d/llvm/lib/Target/ARM/ARMInstrInfo.td#L2393-L2394
+	//  def : Pat<(debugtrap), (BKPT 0)>, Requires<[IsARM, HasV5T]>;
+	//  def : Pat<(debugtrap), (UDF 254)>, Requires<[IsARM, NoV5T]>;
+	// thumb: https://github.com/llvm/llvm-project/blob/e9954ec087d640809082f46d1c7e5ac1767b798d/llvm/lib/Target/ARM/ARMInstrThumb.td#L1444-L1445
+	//  def : Pat<(debugtrap), (tBKPT 0)>, Requires<[IsThumb, HasV5T]>;
+	//  def : Pat<(debugtrap), (tUDF 254)>, Requires<[IsThumb, NoV5T]>;
+	// aarch64: https://github.com/llvm/llvm-project/blob/e9954ec087d640809082f46d1c7e5ac1767b798d/llvm/lib/Target/AArch64/AArch64FastISel.cpp#L3615-L3618
+	//  case Intrinsic::debugtrap:
+	//   BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, MIMD, TII.get(AArch64::BRK))
+	//       .addImm(0xF000);
+	//   return true;
+	// x86: https://github.com/llvm/llvm-project/blob/e9954ec087d640809082f46d1c7e5ac1767b798d/llvm/lib/Target/X86/X86InstrSystem.td#L81-L84
+	//  def : Pat<(debugtrap),
+	//            (INT3)>, Requires<[NotPS]>;
+	#if defined(__i386__) || defined(__x86_64__)
+		#define LIBASSERT_BREAKPOINT() LIBASSERT_ASM_BREAKPOINT("int3")
+	#elif defined(__arm__) || defined(__thumb__)
+		#if __ARM_ARCH >= 5
+			#define LIBASSERT_BREAKPOINT() LIBASSERT_ASM_BREAKPOINT("bkpt #0")
+		#else
+			#define LIBASSERT_BREAKPOINT() LIBASSERT_ASM_BREAKPOINT("udf #0xfe")
+		#endif
+	#elif defined(__aarch64__) || defined(_M_ARM64)
+		#define LIBASSERT_BREAKPOINT() LIBASSERT_ASM_BREAKPOINT("brk #0xf000")
+	#else
+		// some architecture we aren't prepared for
+		#define LIBASSERT_BREAKPOINT()
+	#endif
 #else
- // some compiler we aren't prepared for
- #define LIBASSERT_BREAKPOINT()
+	// some compiler we aren't prepared for
+	#define LIBASSERT_BREAKPOINT()
 #endif
 
 #endif

--- a/include/libassert/stringification.hpp
+++ b/include/libassert/stringification.hpp
@@ -12,36 +12,36 @@
 #include <libassert/utilities.hpp>
 
 #if defined(LIBASSERT_USE_ENCHANTUM) && defined(LIBASSERT_USE_MAGIC_ENUM)
- #error cannot use both enchantum and magic_enum at the same time
+	#error cannot use both enchantum and magic_enum at the same time
 #endif
 
 #ifdef LIBASSERT_USE_ENCHANTUM
- #include <enchantum/enchantum.hpp>
+	#include <enchantum/enchantum.hpp>
 #endif
 
 #ifdef LIBASSERT_USE_MAGIC_ENUM
- // relative include so that multiple library versions don't clash
- // e.g. if both libA and libB have different versions of libassert as a public
- // dependency, then any library that consumes both will have both sets of include
- // paths. this isn't an issue for #include <assert.hpp> but becomes an issue
- // for includes within the library (libA might include from libB)
- #if defined(__has_include) && __has_include(<magic_enum/magic_enum.hpp>)
-  #include <magic_enum/magic_enum.hpp>
- #else
-  #include <magic_enum.hpp>
- #endif
+	// relative include so that multiple library versions don't clash
+	// e.g. if both libA and libB have different versions of libassert as a public
+	// dependency, then any library that consumes both will have both sets of include
+	// paths. this isn't an issue for #include <assert.hpp> but becomes an issue
+	// for includes within the library (libA might include from libB)
+	#if defined(__has_include) && __has_include(<magic_enum/magic_enum.hpp>)
+		#include <magic_enum/magic_enum.hpp>
+	#else
+		#include <magic_enum.hpp>
+	#endif
 #endif
 
 #ifdef LIBASSERT_USE_FMT
- #include <fmt/format.h>
+	#include <fmt/format.h>
 #endif
 
 #if LIBASSERT_STD_VER >= 20
- #include <compare>
+	#include <compare>
 #endif
 
 #ifdef LIBASSERT_USE_STD_FORMAT
- #include <format>
+	#include <format>
 #endif
 
 // =====================================================================================================================
@@ -50,526 +50,511 @@
 // =====================================================================================================================
 
 LIBASSERT_BEGIN_NAMESPACE
-    // customization point
-    template<typename T> struct stringifier /*{
+// customization point
+template<typename T>
+struct stringifier /*{
         std::convertible_to<std::string> stringify(const T&);
-    }*/;
+    }*/
+	;
 LIBASSERT_END_NAMESPACE
 
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    // What can be stringified
-    // Base types:
-    //  - anything string-like
-    //  - arithmetic types
-    //  - pointers
-    //  - smart pointers
-    //  - nullptr_t
-    //  - std::error_code/std::error_condition
-    //  - orderings
-    //  - enum values
-    //  User-provided stringifications:
-    //   - std::ostream<< overloads
-    //   - std format
-    //   - fmt
-    //   - libassert::stringifier
-    // Containers:
-    //  - std::optional
-    //  - std::variant TODO
-    //  - std::expected TODO
-    //  - tuples and tuple-likes
-    //  - anything container-like (std::vector, std::array, std::unordered_map, C arrays, .....)
-    // Priorities:
-    //  - libassert::stringifier
-    //  - default formatters
-    //  - fmt
-    //  - std fmt
-    //  - osteam format
-    //  - instance of catch all
-    // Other logistics:
-    //  - Containers are only stringified if their value_type is stringifiable
-    // TODO Weak pointers?
+// What can be stringified
+// Base types:
+//  - anything string-like
+//  - arithmetic types
+//  - pointers
+//  - smart pointers
+//  - nullptr_t
+//  - std::error_code/std::error_condition
+//  - orderings
+//  - enum values
+//  User-provided stringifications:
+//   - std::ostream<< overloads
+//   - std format
+//   - fmt
+//   - libassert::stringifier
+// Containers:
+//  - std::optional
+//  - std::variant TODO
+//  - std::expected TODO
+//  - tuples and tuple-likes
+//  - anything container-like (std::vector, std::array, std::unordered_map, C arrays, .....)
+// Priorities:
+//  - libassert::stringifier
+//  - default formatters
+//  - fmt
+//  - std fmt
+//  - osteam format
+//  - instance of catch all
+// Other logistics:
+//  - Containers are only stringified if their value_type is stringifiable
+// TODO Weak pointers?
 
-    template<typename T>
-    [[nodiscard]]
-    std::string do_stringify(const T& v);
+template<typename T>
+[[nodiscard]]
+std::string do_stringify(const T& v);
 
-    namespace stringification {
-        //
-        // General traits
-        //
-        template<typename T, bool = (std::tuple_size<T>::value > 0)>
-        struct canonicalized_get_0 {
-            using type = decltype(std::get<0>(std::declval<T>()));
-        };
-        template<typename T>
-        struct canonicalized_get_0<T, false> {
-            using type = void;
-        };
+namespace stringification {
+	//
+	// General traits
+	//
+	template<typename T, bool = (std::tuple_size<T>::value > 0)>
+	struct canonicalized_get_0 {
+		using type = decltype(std::get<0>(std::declval<T>()));
+	};
 
-        template<typename T, typename = void>
-        inline constexpr bool is_tuple_like = false;
-        template<typename T>
-        inline constexpr bool is_tuple_like<
-            T,
-            std::void_t<
-                typename std::tuple_size<T>::type, // TODO: decltype(std::tuple_size_v<T>) ?
-                typename canonicalized_get_0<T>::type
-            >
-        > = true;
+	template<typename T>
+	struct canonicalized_get_0<T, false> {
+		using type = void;
+	};
 
-        namespace adl {
-            using std::begin, std::end; // ADL
-            template<typename T, typename = void>
-            inline constexpr bool is_container = false;
-            template<typename T>
-            inline constexpr bool is_container<
-                T,
-                std::void_t<
-                    decltype(begin(decllval<T>())),
-                    decltype(end(decllval<T>()))
-                >
-            > = true;
+	template<typename T, typename = void>
+	inline constexpr bool is_tuple_like = false;
+	template<typename T>
+	inline constexpr bool is_tuple_like<
+		T,
+		std::void_t<
+			typename std::tuple_size<T>::type, // TODO: decltype(std::tuple_size_v<T>) ?
+			typename canonicalized_get_0<T>::type>> = true;
 
-            template<typename T, typename = void>
-            inline constexpr bool is_begin_deref = false;
-            template<typename T>
-            inline constexpr bool is_begin_deref<
-                T,
-                std::void_t<
-                    decltype(*begin(decllval<T>()))
-                >
-            > = true;
-        }
+	namespace adl {
+		using std::begin, std::end; // ADL
+		template<typename T, typename = void>
+		inline constexpr bool is_container = false;
+		template<typename T>
+		inline constexpr bool
+			is_container<T, std::void_t<decltype(begin(decllval<T>())), decltype(end(decllval<T>()))>> =
+				true;
 
-        template<typename T, typename = void>
-        inline constexpr bool can_dereference = false;
-        template<typename T>
-        inline constexpr bool can_dereference<
-            T,
-            std::void_t<
-                decltype(*decllval<T>())
-            >
-        > = true;
+		template<typename T, typename = void>
+		inline constexpr bool is_begin_deref = false;
+		template<typename T>
+		inline constexpr bool is_begin_deref<T, std::void_t<decltype(*begin(decllval<T>()))>> = true;
+	} // namespace adl
 
-        template<typename T, typename = void>
-        inline constexpr bool has_ostream_overload = false;
-        template<typename T>
-        inline constexpr bool has_ostream_overload<
-            T,
-            std::void_t<decltype(std::declval<std::ostream&>() << std::declval<T>())>
-        > = true;
+	template<typename T, typename = void>
+	inline constexpr bool can_dereference = false;
+	template<typename T>
+	inline constexpr bool can_dereference<T, std::void_t<decltype(*decllval<T>())>> = true;
 
-        template<typename T, typename = void> inline constexpr bool has_stringifier = false;
-        template<typename T>
-        inline constexpr bool has_stringifier<
-            T,
-            std::void_t<decltype(stringifier<strip<T>>{}.stringify(std::declval<T>()))>
-        > = true;
+	template<typename T, typename = void>
+	inline constexpr bool has_ostream_overload = false;
+	template<typename T>
+	inline constexpr bool has_ostream_overload<
+		T,
+		std::void_t<decltype(std::declval<std::ostream&>() << std::declval<T>())>> = true;
 
-        // Following a pattern used in fmt: This is a heuristic to detect types that look like std::filesystem::path
-        // This is used so that libassert doesn't have to #include <filesystem>
-        template<typename T, typename = void>
-        inline constexpr bool is_std_filesystem_path_like = false;
-        template<typename T>
-        inline constexpr bool is_std_filesystem_path_like<
-            T,
-            std::void_t<
-                decltype(std::declval<T>().parent_path()),
-                decltype(std::declval<T>().is_absolute()),
-                decltype(std::declval<T>().filename())
-            >
-        > = std::is_convertible_v<decltype(std::declval<T>().string()), std::string_view>;
+	template<typename T, typename = void>
+	inline constexpr bool has_stringifier = false;
+	template<typename T>
+	inline constexpr bool has_stringifier<
+		T,
+		std::void_t<decltype(stringifier<strip<T>> {}.stringify(std::declval<T>()))>> = true;
 
-        //
-        // Catch all
-        //
+	// Following a pattern used in fmt: This is a heuristic to detect types that look like std::filesystem::path
+	// This is used so that libassert doesn't have to #include <filesystem>
+	template<typename T, typename = void>
+	inline constexpr bool is_std_filesystem_path_like = false;
+	template<typename T>
+	inline constexpr bool is_std_filesystem_path_like<
+		T,
+		std::void_t<
+			decltype(std::declval<T>().parent_path()),
+			decltype(std::declval<T>().is_absolute()),
+			decltype(std::declval<T>().filename())>> =
+		std::is_convertible_v<decltype(std::declval<T>().string()), std::string_view>;
 
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify_unknown(std::string_view type_name);
+	//
+	// Catch all
+	//
 
-        template<typename T>
-        [[nodiscard]] std::string stringify_unknown() {
-            return stringify_unknown(type_name<T>());
-        }
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify_unknown(std::string_view type_name);
 
-        //
-        // Basic types
-        //
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(std::string_view);
-        // without nullptr_t overload msvc (without /permissive-) will call stringify(bool) and mingw
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(std::nullptr_t);
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(char);
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(bool);
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(short);
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(int);
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(long);
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(long long);
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(unsigned short);
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(unsigned int);
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(unsigned long);
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(unsigned long long);
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(float);
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(double);
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(long double);
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(std::byte);
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(std::error_code ec);
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(std::error_condition ec);
-        #if __cplusplus >= 202002L
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(std::strong_ordering);
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(std::weak_ordering);
-        [[nodiscard]] LIBASSERT_EXPORT std::string stringify(std::partial_ordering);
-        #endif
-        [[nodiscard]] LIBASSERT_EXPORT
-        std::string stringify_pointer_value(const void*);
+	template<typename T>
+	[[nodiscard]] std::string stringify_unknown() {
+		return stringify_unknown(type_name<T>());
+	}
 
-        template<typename T>
-        [[nodiscard]]
-        std::string stringify_smart_ptr(const T& t) {
-            if(t) {
-                return do_stringify(*t);
-            } else {
-                return "nullptr";
-            }
-        }
+	//
+	// Basic types
+	//
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(std::string_view);
+	// without nullptr_t overload msvc (without /permissive-) will call stringify(bool) and mingw
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(std::nullptr_t);
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(char);
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(bool);
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(short);
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(int);
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(long);
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(long long);
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(unsigned short);
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(unsigned int);
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(unsigned long);
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(unsigned long long);
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(float);
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(double);
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(long double);
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(std::byte);
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(std::error_code ec);
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(std::error_condition ec);
+#if __cplusplus >= 202002L
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(std::strong_ordering);
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(std::weak_ordering);
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify(std::partial_ordering);
+#endif
+	[[nodiscard]] LIBASSERT_EXPORT std::string stringify_pointer_value(const void*);
 
-        [[nodiscard]] LIBASSERT_EXPORT
-        std::string stringify_by_ostream(const void*, void(*)(std::ostream&, const void*));
+	template<typename T>
+	[[nodiscard]]
+	std::string stringify_smart_ptr(const T& t) {
+		if (t) {
+			return do_stringify(*t);
+		} else {
+			return "nullptr";
+		}
+	}
 
-        template<typename T>
-        [[nodiscard]]
-        std::string stringify_by_ostream(const T& t) {
-            return stringify_by_ostream(
-                &t,
-                [] (std::ostream& os, const void* ptr) { os << *reinterpret_cast<const T*>(ptr); }
-            );
-        }
+	[[nodiscard]] LIBASSERT_EXPORT std::string
+	stringify_by_ostream(const void*, void (*)(std::ostream&, const void*));
 
-        [[nodiscard]] LIBASSERT_EXPORT
-        std::string stringify_enum(std::string_view type_name, std::string_view underlying_value);
+	template<typename T>
+	[[nodiscard]]
+	std::string stringify_by_ostream(const T& t) {
+		return stringify_by_ostream(&t, [](std::ostream& os, const void* ptr) {
+			os << *reinterpret_cast<const T*>(ptr);
+		});
+	}
 
-        template<typename E>
-        [[nodiscard]] std::string stringify_enum(E e) {
-            #if defined(LIBASSERT_USE_ENCHANTUM)
-             std::string_view name = enchantum::to_string(e);
-             if(!name.empty()) {
-                 return std::string(name);
-             }
-            #elif defined(LIBASSERT_USE_MAGIC_ENUM)
-             std::string_view name = magic_enum::enum_name(e);
-             if(!name.empty()) {
-                 return std::string(name);
-             }
-            #endif
-            return stringify_enum(
-                type_name<E>(),
-                stringify(static_cast<std::underlying_type_t<E>>(e))
-            );
-        }
+	[[nodiscard]] LIBASSERT_EXPORT std::string
+	stringify_enum(std::string_view type_name, std::string_view underlying_value);
 
-        //
-        // Compositions of other types
-        //
-        // #ifdef __cpp_lib_expected
-        // template<typename E>
-        // [[nodiscard]] std::string stringify(const std::unexpected<E>& x) {
-        //     return "unexpected " + stringify(x.error());
-        // }
+	template<typename E>
+	[[nodiscard]] std::string stringify_enum(E e) {
+#if defined(LIBASSERT_USE_ENCHANTUM)
+		std::string_view name = enchantum::to_string(e);
+		if (!name.empty()) {
+			return std::string(name);
+		}
+#elif defined(LIBASSERT_USE_MAGIC_ENUM)
+		std::string_view name = magic_enum::enum_name(e);
+		if (!name.empty()) {
+			return std::string(name);
+		}
+#endif
+		return stringify_enum(type_name<E>(), stringify(static_cast<std::underlying_type_t<E>>(e)));
+	}
 
-        // template<typename T, typename E>
-        // [[nodiscard]] std::string stringify(const std::expected<T, E>& x) {
-        //     if(x.has_value()) {
-        //         if constexpr(std::is_void_v<T>) {
-        //             return "expected void";
-        //         } else {
-        //             return "expected " + stringify(*x);
-        //         }
-        //     } else {
-        //         return "unexpected " + stringify(x.error());
-        //     }
-        // }
-        // #endif
+	//
+	// Compositions of other types
+	//
+	// #ifdef __cpp_lib_expected
+	// template<typename E>
+	// [[nodiscard]] std::string stringify(const std::unexpected<E>& x) {
+	//     return "unexpected " + stringify(x.error());
+	// }
 
-        template<typename T>
-        [[nodiscard]]
-        std::string stringify(const std::optional<T>& t) {
-            if(t) {
-                return do_stringify(t.value());
-            } else {
-                return "nullopt";
-            }
-        }
+	// template<typename T, typename E>
+	// [[nodiscard]] std::string stringify(const std::expected<T, E>& x) {
+	//     if(x.has_value()) {
+	//         if constexpr(std::is_void_v<T>) {
+	//             return "expected void";
+	//         } else {
+	//             return "expected " + stringify(*x);
+	//         }
+	//     } else {
+	//         return "unexpected " + stringify(x.error());
+	//     }
+	// }
+	// #endif
 
-        inline constexpr std::size_t max_container_print_items = 1000;
+	template<typename T>
+	[[nodiscard]]
+	std::string stringify(const std::optional<T>& t) {
+		if (t) {
+			return do_stringify(t.value());
+		} else {
+			return "nullopt";
+		}
+	}
 
-        template<typename T>
-        [[nodiscard]]
-        std::string stringify_container(const T& container) {
-            using std::begin, std::end; // ADL
-            std::string str = "[";
-            const auto begin_it = begin(container);
-            std::size_t count = 0;
-            for(auto it = begin_it; it != end(container); it++) {
-                if(it != begin_it) {
-                    str += ", ";
-                }
-                str += do_stringify(*it);
-                if(++count == max_container_print_items) {
-                    str += ", ...";
-                    break;
-                }
-            }
-            str += "]";
-            return str;
-        }
+	inline constexpr std::size_t max_container_print_items = 1000;
 
-        // I'm going to assume at least one index because is_tuple_like requires index 0 to exist
-        template<typename T, size_t... I>
-        [[nodiscard]]
-        std::string stringify_tuple_like_impl(const T& t, std::index_sequence<I...>) {
-            return "[" + (do_stringify(std::get<0>(t)) + ... + (", " + do_stringify(std::get<I + 1>(t)))) + "]";
-        }
+	template<typename T>
+	[[nodiscard]]
+	std::string stringify_container(const T& container) {
+		using std::begin, std::end; // ADL
+		std::string str = "[";
+		const auto begin_it = begin(container);
+		std::size_t count = 0;
+		for (auto it = begin_it; it != end(container); it++) {
+			if (it != begin_it) {
+				str += ", ";
+			}
+			str += do_stringify(*it);
+			if (++count == max_container_print_items) {
+				str += ", ...";
+				break;
+			}
+		}
+		str += "]";
+		return str;
+	}
 
-        template<typename T>
-        [[nodiscard]]
-        std::string stringify_tuple_like(const T& t) {
-            if constexpr(std::tuple_size<T>::value == 0) {
-                return "[]";
-            } else {
-                return stringify_tuple_like_impl(t, std::make_index_sequence<std::tuple_size<T>::value - 1>{});
-            }
-        }
+	// I'm going to assume at least one index because is_tuple_like requires index 0 to exist
+	template<typename T, size_t... I>
+	[[nodiscard]]
+	std::string stringify_tuple_like_impl(const T& t, std::index_sequence<I...>) {
+		return "[" + (do_stringify(std::get<0>(t)) + ... + (", " + do_stringify(std::get<I + 1>(t))))
+			+ "]";
+	}
 
-        template<typename T>
-        [[nodiscard]]
-        std::string stringify_filesystem_path_like(const T& t) {
-            return stringify(t.string());
-        }
-    }
+	template<typename T>
+	[[nodiscard]]
+	std::string stringify_tuple_like(const T& t) {
+		if constexpr (std::tuple_size<T>::value == 0) {
+			return "[]";
+		} else {
+			return stringify_tuple_like_impl(
+				t,
+				std::make_index_sequence<std::tuple_size<T>::value - 1> {}
+			);
+		}
+	}
 
-    template<typename T, typename = void>
-    inline constexpr bool has_value_type = false;
-    template<typename T>
-    inline constexpr bool has_value_type<
-        T,
-        std::void_t<typename T::value_type>
-    > = true;
+	template<typename T>
+	[[nodiscard]]
+	std::string stringify_filesystem_path_like(const T& t) {
+		return stringify(t.string());
+	}
+} // namespace stringification
 
-    template<typename T> inline constexpr bool is_smart_pointer =
-        is_specialization<T, std::unique_ptr>
-        || is_specialization<T, std::shared_ptr>; // TODO: Handle weak_ptr too?
+template<typename T, typename = void>
+inline constexpr bool has_value_type = false;
+template<typename T>
+inline constexpr bool has_value_type<T, std::void_t<typename T::value_type>> = true;
 
-    template<typename T, typename = void>
-    inline constexpr bool can_basic_stringify = false;
-    template<typename T>
-    inline constexpr bool can_basic_stringify<
-        T,
-        std::void_t<decltype(stringification::stringify(std::declval<T>()))>
-    > = true;
+template<typename T>
+inline constexpr bool is_smart_pointer = is_specialization<T, std::unique_ptr>
+	|| is_specialization<T, std::shared_ptr>; // TODO: Handle weak_ptr too?
 
-    template<typename T> constexpr bool stringifiable_container();
+template<typename T, typename = void>
+inline constexpr bool can_basic_stringify = false;
+template<typename T>
+inline constexpr bool
+	can_basic_stringify<T, std::void_t<decltype(stringification::stringify(std::declval<T>()))>> =
+		true;
 
-    template<typename T> inline constexpr bool stringifiable =
-        stringification::has_stringifier<T>
-        || std::is_convertible_v<T, std::string_view>
-        || (std::is_pointer_v<T> || std::is_function_v<T>)
-        || std::is_enum_v<T>
-        || (stringification::is_tuple_like<T> && stringifiable_container<T>())
-        || stringification::is_std_filesystem_path_like<T>
-        || (stringification::adl::is_container<T> && stringifiable_container<T>())
-        || can_basic_stringify<T>
-        || stringification::has_ostream_overload<T>
-        #ifdef LIBASSERT_USE_STD_FORMAT
-        #if LIBASSERT_STD_VER >= 23
-        || std::formattable<T, char> // preferred since this is stricter than the C++20 way of checking
-                                     // and makes sure that the C++ community converges on how `std::formatter`
-                                     // should be used.
-        #elif LIBASSERT_STD_VER == 20
-        || requires { std::formatter<T>(); } // fallback for C++20
-        #endif
-        #endif
-        #ifdef LIBASSERT_USE_FMT
-        || fmt::is_formattable<T>::value
-        #endif
-        || stringifiable_container<T>();
+template<typename T>
+constexpr bool stringifiable_container();
 
-    template<typename T, size_t... I> constexpr bool tuple_has_stringifiable_args_core(std::index_sequence<I...>) {
-        return sizeof...(I) == 0 || (stringifiable<decltype(std::get<I>(std::declval<T>()))> || ...);
-    }
+template<typename T>
+inline constexpr bool stringifiable =
+	stringification::has_stringifier<T> || std::is_convertible_v<T, std::string_view>
+	|| (std::is_pointer_v<T> || std::is_function_v<T>) || std::is_enum_v<T>
+	|| (stringification::is_tuple_like<T> && stringifiable_container<T>())
+	|| stringification::is_std_filesystem_path_like<T>
+	|| (stringification::adl::is_container<T> && stringifiable_container<T>())
+	|| can_basic_stringify<T> || stringification::has_ostream_overload<T>
+#ifdef LIBASSERT_USE_STD_FORMAT
+	#if LIBASSERT_STD_VER >= 23
+	|| std::formattable<T, char> // preferred since this is stricter than the C++20 way of checking
+		// and makes sure that the C++ community converges on how `std::formatter`
+		// should be used.
+	#elif LIBASSERT_STD_VER == 20
+	|| requires { std::formatter<T>(); } // fallback for C++20
+	#endif
+#endif
+#ifdef LIBASSERT_USE_FMT
+	|| fmt::is_formattable<T>::value
+#endif
+	|| stringifiable_container<T>();
 
-    template<typename T> inline constexpr bool tuple_has_stringifiable_args =
-        tuple_has_stringifiable_args_core<T>(std::make_index_sequence<std::tuple_size<T>::value>{});
-
-    template<typename T> constexpr bool stringifiable_container() {
-        // TODO: Guard against std::expected....?
-        if constexpr(has_value_type<T>) {
-            if constexpr(std::is_same_v<typename T::value_type, T>) { // TODO: Reconsider
-                return false;
-            } else {
-                return stringifiable<typename T::value_type>;
-            }
-        } else if constexpr(std::is_array_v<typename std::remove_reference_t<T>>) { // C arrays
-            return stringifiable<decltype(std::declval<T>()[0])>;
-        } else if constexpr(stringification::is_tuple_like<T>) {
-            return tuple_has_stringifiable_args<T>;
-        } else {
-            return false;
-        }
-    }
-
-    // Stringification of some types can result in infinite recursion and subsequent stack-overflow. An example would be
-    // a container/range-like type T whose iterator's value_type is also T (such as std::filesystem::path). This is easy
-    // enough to detect at compile time, however, there are pathological types in the general case which would be much
-    // more difficult to check at compile time.
-    // For example, let T be a container whose iterator's value_type = std::vector<T>. This would cause infinite
-    // recursion via:
-    // do_stringify<T>
-    //   -> stringify_container<T>
-    //     -> do_stringify<std::vector<T>>
-    //       -> stringify_container<std::vector<T>>
-    //         -> do_stringify<T>
-    //           -> ...
-    // Instead of compile-time checks this class and a RAII helper is used at the do_stringify<T> level to detect
-    // stringification recursion at runtime.
-    class recursion_flag {
-        bool the_flag = false;
-    public:
-        recursion_flag() = default;
-        recursion_flag(const recursion_flag&) = delete;
-        recursion_flag(recursion_flag&&) = delete;
-        recursion_flag& operator=(const recursion_flag&) = delete;
-        recursion_flag& operator=(recursion_flag&&) = delete;
-
-        class recursion_canary {
-            bool& flag_ref;
-        public:
-            recursion_canary(bool& flag) : flag_ref(flag) {}
-            ~recursion_canary() {
-                flag_ref = false;
-            }
-        };
-
-        recursion_canary set() {
-            the_flag = true;
-            return recursion_canary(the_flag);
-        }
-
-        bool test() const {
-            return the_flag;
-        }
-    };
-
-    template<typename T>
-    [[nodiscard]]
-    std::string do_stringify(const T& v) {
-        // TODO: This is overkill to do for every instantiation of do_stringify (e.g. primitive types could omit this)
-        thread_local recursion_flag flag;
-        if(flag.test()) { // pathological case detected, fall back to unknown
-            return stringification::stringify_unknown<T>();
-        }
-        auto canary = flag.set();
-        // Ordering notes
-        // - stringifier first
-        // - nullptr before string_view (char*)
-        // - other pointers before basic stringify
-        // - enum before basic stringify
-        // - container before basic stringify (c arrays and decay etc)
-        //   - needs to exclude std::filesystem::path
-        if constexpr(stringification::has_stringifier<T>) {
-            return stringifier<strip<T>>{}.stringify(v);
-        } else if constexpr(std::is_same_v<T, std::nullptr_t>) {
-            return "nullptr";
-        } else if constexpr(std::is_convertible_v<T, std::string_view>) {
-            if constexpr(std::is_pointer_v<T>) {
-                if(v == nullptr) {
-                    return "nullptr";
-                }
-            }
-            #if LIBASSERT_IS_GCC
-                #pragma GCC diagnostic push
-                #pragma GCC diagnostic ignored "-Wnonnull"
-            #endif
-            return stringification::stringify(std::string_view(v));
-            #if LIBASSERT_IS_GCC
-                #pragma GCC diagnostic pop
-            #endif
-        } else if constexpr(std::is_pointer_v<T> || std::is_function_v<T>) {
-            return stringification::stringify_pointer_value(reinterpret_cast<const void*>(v));
-        } else if constexpr(is_smart_pointer<T>) {
-            #ifndef LIBASSERT_NO_STRINGIFY_SMART_POINTER_OBJECTS
-             if(stringifiable<typename T::element_type>) {
-            #else
-             if(false) {
-            #endif
-                return stringification::stringify_smart_ptr(v);
-            } else {
-                return stringification::stringify_pointer_value(v.get());
-            }
-        } else if constexpr(std::is_enum_v<T> && !std::is_same_v<T, std::byte>) {
-            return stringification::stringify_enum(v);
-        } else if constexpr(stringification::is_tuple_like<T>) {
-            if constexpr(stringifiable_container<T>()) {
-                return stringification::stringify_tuple_like(v);
-            } else {
-                return stringification::stringify_unknown<T>();
-            }
-        } else if constexpr(stringification::is_std_filesystem_path_like<T>) {
-            return stringification::stringify_filesystem_path_like(v);
-        } else if constexpr(stringification::adl::is_container<T>) {
-            if constexpr(stringifiable_container<T>()) {
-                return stringification::stringify_container(v);
-            } else {
-                return stringification::stringify_unknown<T>();
-            }
-        } else if constexpr(can_basic_stringify<T>) {
-            return stringification::stringify(v);
-        } else if constexpr(stringification::has_ostream_overload<T>) {
-            return stringification::stringify_by_ostream(v);
-        }
-        #ifdef LIBASSERT_USE_STD_FORMAT
-        #if LIBASSERT_STD_VER >= 23
-        // preferred since this is stricter than the C++20 way of checking and makes sure that the
-        // C++ community converges on how `std::formatter` should be used.
-        else if constexpr (std::formattable<T, char>) {
-            return std::format("{}", v);
-        }
-        #elif LIBASSERT_STD_VER == 20
-        else if constexpr (requires { std::formatter<T>(); }) {
-            return std::format("{}", v);
-        }
-        #endif
-        #endif
-        #ifdef LIBASSERT_USE_FMT
-        else if constexpr(fmt::is_formattable<T>::value) {
-            return fmt::format("{}", v);
-        }
-        #endif
-        else {
-            return stringification::stringify_unknown<T>();
-        }
-    }
-
-    // Top-level stringify utility
-    template<typename T>
-    [[nodiscard]]
-    std::string generate_stringification(const T& v) {
-        if constexpr(
-            stringification::adl::is_container<T>
-            && !is_string_type<T>
-            && !stringification::is_std_filesystem_path_like<T>
-            && stringifiable_container<T>()
-        ) {
-            return prettify_type(std::string(type_name<T>())) + ": " + do_stringify(v);
-        } else if constexpr(stringification::is_tuple_like<T> && stringifiable_container<T>()) {
-            return prettify_type(std::string(type_name<T>())) + ": " + do_stringify(v);
-        } else if constexpr((std::is_pointer_v<T> && !is_string_type<T>) || is_smart_pointer<T>) {
-            return prettify_type(std::string(type_name<T>())) + ": " + do_stringify(v);
-        } else if constexpr(is_specialization<T, std::optional>) {
-            return prettify_type(std::string(type_name<T>())) + ": " + do_stringify(v);
-        } else {
-            return do_stringify(v);
-        }
-    }
+template<typename T, size_t... I>
+constexpr bool tuple_has_stringifiable_args_core(std::index_sequence<I...>) {
+	return sizeof...(I) == 0 || (stringifiable<decltype(std::get<I>(std::declval<T>()))> || ...);
 }
+
+template<typename T>
+inline constexpr bool tuple_has_stringifiable_args =
+	tuple_has_stringifiable_args_core<T>(std::make_index_sequence<std::tuple_size<T>::value> {});
+
+template<typename T>
+constexpr bool stringifiable_container() {
+	// TODO: Guard against std::expected....?
+	if constexpr (has_value_type<T>) {
+		if constexpr (std::is_same_v<typename T::value_type, T>) { // TODO: Reconsider
+			return false;
+		} else {
+			return stringifiable<typename T::value_type>;
+		}
+	} else if constexpr (std::is_array_v<typename std::remove_reference_t<T>>) { // C arrays
+		return stringifiable<decltype(std::declval<T>()[0])>;
+	} else if constexpr (stringification::is_tuple_like<T>) {
+		return tuple_has_stringifiable_args<T>;
+	} else {
+		return false;
+	}
+}
+
+// Stringification of some types can result in infinite recursion and subsequent stack-overflow. An example would be
+// a container/range-like type T whose iterator's value_type is also T (such as std::filesystem::path). This is easy
+// enough to detect at compile time, however, there are pathological types in the general case which would be much
+// more difficult to check at compile time.
+// For example, let T be a container whose iterator's value_type = std::vector<T>. This would cause infinite
+// recursion via:
+// do_stringify<T>
+//   -> stringify_container<T>
+//     -> do_stringify<std::vector<T>>
+//       -> stringify_container<std::vector<T>>
+//         -> do_stringify<T>
+//           -> ...
+// Instead of compile-time checks this class and a RAII helper is used at the do_stringify<T> level to detect
+// stringification recursion at runtime.
+class recursion_flag {
+	bool the_flag = false;
+
+public:
+	recursion_flag() = default;
+	recursion_flag(const recursion_flag&) = delete;
+	recursion_flag(recursion_flag&&) = delete;
+	recursion_flag& operator=(const recursion_flag&) = delete;
+	recursion_flag& operator=(recursion_flag&&) = delete;
+
+	class recursion_canary {
+		bool& flag_ref;
+
+	public:
+		recursion_canary(bool& flag) : flag_ref(flag) {}
+
+		~recursion_canary() {
+			flag_ref = false;
+		}
+	};
+
+	recursion_canary set() {
+		the_flag = true;
+		return recursion_canary(the_flag);
+	}
+
+	bool test() const {
+		return the_flag;
+	}
+};
+
+template<typename T>
+[[nodiscard]]
+std::string do_stringify(const T& v) {
+	// TODO: This is overkill to do for every instantiation of do_stringify (e.g. primitive types could omit this)
+	thread_local recursion_flag flag;
+	if (flag.test()) { // pathological case detected, fall back to unknown
+		return stringification::stringify_unknown<T>();
+	}
+	auto canary = flag.set();
+	// Ordering notes
+	// - stringifier first
+	// - nullptr before string_view (char*)
+	// - other pointers before basic stringify
+	// - enum before basic stringify
+	// - container before basic stringify (c arrays and decay etc)
+	//   - needs to exclude std::filesystem::path
+	if constexpr (stringification::has_stringifier<T>) {
+		return stringifier<strip<T>> {}.stringify(v);
+	} else if constexpr (std::is_same_v<T, std::nullptr_t>) {
+		return "nullptr";
+	} else if constexpr (std::is_convertible_v<T, std::string_view>) {
+		if constexpr (std::is_pointer_v<T>) {
+			if (v == nullptr) {
+				return "nullptr";
+			}
+		}
+#if LIBASSERT_IS_GCC
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wnonnull"
+#endif
+		return stringification::stringify(std::string_view(v));
+#if LIBASSERT_IS_GCC
+	#pragma GCC diagnostic pop
+#endif
+	} else if constexpr (std::is_pointer_v<T> || std::is_function_v<T>) {
+		return stringification::stringify_pointer_value(reinterpret_cast<const void*>(v));
+	} else if constexpr (is_smart_pointer<T>) {
+#ifndef LIBASSERT_NO_STRINGIFY_SMART_POINTER_OBJECTS
+		if (stringifiable<typename T::element_type>) {
+#else
+		if (false) {
+#endif
+			return stringification::stringify_smart_ptr(v);
+		} else {
+			return stringification::stringify_pointer_value(v.get());
+		}
+	} else if constexpr (std::is_enum_v<T> && !std::is_same_v<T, std::byte>) {
+		return stringification::stringify_enum(v);
+	} else if constexpr (stringification::is_tuple_like<T>) {
+		if constexpr (stringifiable_container<T>()) {
+			return stringification::stringify_tuple_like(v);
+		} else {
+			return stringification::stringify_unknown<T>();
+		}
+	} else if constexpr (stringification::is_std_filesystem_path_like<T>) {
+		return stringification::stringify_filesystem_path_like(v);
+	} else if constexpr (stringification::adl::is_container<T>) {
+		if constexpr (stringifiable_container<T>()) {
+			return stringification::stringify_container(v);
+		} else {
+			return stringification::stringify_unknown<T>();
+		}
+	} else if constexpr (can_basic_stringify<T>) {
+		return stringification::stringify(v);
+	} else if constexpr (stringification::has_ostream_overload<T>) {
+		return stringification::stringify_by_ostream(v);
+	}
+#ifdef LIBASSERT_USE_STD_FORMAT
+	#if LIBASSERT_STD_VER >= 23
+	// preferred since this is stricter than the C++20 way of checking and makes sure that the
+	// C++ community converges on how `std::formatter` should be used.
+	else if constexpr (std::formattable<T, char>) {
+		return std::format("{}", v);
+	}
+	#elif LIBASSERT_STD_VER == 20
+	else if constexpr (requires { std::formatter<T>(); }) {
+		return std::format("{}", v);
+	}
+	#endif
+#endif
+#ifdef LIBASSERT_USE_FMT
+	else if constexpr (fmt::is_formattable<T>::value) {
+		return fmt::format("{}", v);
+	}
+#endif
+	else {
+		return stringification::stringify_unknown<T>();
+	}
+}
+
+// Top-level stringify utility
+template<typename T>
+[[nodiscard]]
+std::string generate_stringification(const T& v) {
+	if constexpr (
+		stringification::adl::is_container<T> && !is_string_type<T>
+		&& !stringification::is_std_filesystem_path_like<T> && stringifiable_container<T>()
+	) {
+		return prettify_type(std::string(type_name<T>())) + ": " + do_stringify(v);
+	} else if constexpr (stringification::is_tuple_like<T> && stringifiable_container<T>()) {
+		return prettify_type(std::string(type_name<T>())) + ": " + do_stringify(v);
+	} else if constexpr ((std::is_pointer_v<T> && !is_string_type<T>) || is_smart_pointer<T>) {
+		return prettify_type(std::string(type_name<T>())) + ": " + do_stringify(v);
+	} else if constexpr (is_specialization<T, std::optional>) {
+		return prettify_type(std::string(type_name<T>())) + ": " + do_stringify(v);
+	} else {
+		return do_stringify(v);
+	}
+}
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE
 
 #endif

--- a/include/libassert/utilities.hpp
+++ b/include/libassert/utilities.hpp
@@ -1,9 +1,9 @@
 #ifndef LIBASSERT_UTILITIES_HPP
 #define LIBASSERT_UTILITIES_HPP
 
-#include <type_traits>
 #include <string>
 #include <string_view>
+#include <type_traits>
 
 #include <libassert/platform.hpp>
 
@@ -12,51 +12,57 @@
 // =====================================================================================================================
 
 LIBASSERT_BEGIN_NAMESPACE
-    // Lightweight helper, eventually may use C++20 std::source_location if this library no longer
-    // targets C++17. Note: __builtin_FUNCTION only returns the name, so __PRETTY_FUNCTION__ is
-    // still needed.
-    struct source_location {
-        const char* file;
-        //const char* function; // disabled for now due to static constexpr restrictions
-        int line;
-        constexpr source_location(
-            //const char* _function /*= __builtin_FUNCTION()*/,
-            const char* _file = __builtin_FILE(),
-            int _line         = __builtin_LINE()
-        ) : file(_file), /*function(_function),*/ line(_line) {}
-    };
+
+// Lightweight helper, eventually may use C++20 std::source_location if this library no longer
+// targets C++17. Note: __builtin_FUNCTION only returns the name, so __PRETTY_FUNCTION__ is
+// still needed.
+struct source_location {
+	const char* file;
+	//const char* function; // disabled for now due to static constexpr restrictions
+	int line;
+
+	constexpr source_location(
+		//const char* _function /*= __builtin_FUNCTION()*/,
+		const char* _file = __builtin_FILE(),
+		int _line = __builtin_LINE()
+	) :
+		file(_file),
+		/*function(_function),*/ line(_line) {}
+};
+
 LIBASSERT_END_NAMESPACE
 
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    // bootstrap with primitive implementations
-    LIBASSERT_EXPORT void primitive_assert_impl(
-        bool condition,
-        bool normal_assert,
-        const char* expression,
-        const char* signature,
-        source_location location,
-        const char* message = nullptr
-    );
+// bootstrap with primitive implementations
+LIBASSERT_EXPORT void primitive_assert_impl(
+	bool condition,
+	bool normal_assert,
+	const char* expression,
+	const char* signature,
+	source_location location,
+	const char* message = nullptr
+);
 
-    [[noreturn]] LIBASSERT_EXPORT void primitive_panic_impl (
-        const char* signature,
-        source_location location,
-        const char* message
-    );
+[[noreturn]] LIBASSERT_EXPORT void
+primitive_panic_impl(const char* signature, source_location location, const char* message);
 
-    // always_false is just convenient to use here
-    #define LIBASSERT_PHONY_USE(E) ((void)::libassert::detail::always_false<decltype(E)>)
+// always_false is just convenient to use here
+#define LIBASSERT_PHONY_USE(E) ((void)::libassert::detail::always_false<decltype(E)>)
 
-    #ifndef NDEBUG
-     #define LIBASSERT_PRIMITIVE_DEBUG_ASSERT(c, ...) \
-        libassert::detail::primitive_assert_impl(c, false, #c, LIBASSERT_PFUNC, {} LIBASSERT_VA_ARGS(__VA_ARGS__))
-    #else
-     #define LIBASSERT_PRIMITIVE_DEBUG_ASSERT(c, ...) LIBASSERT_PHONY_USE(c)
-    #endif
+#ifndef NDEBUG
+	#define LIBASSERT_PRIMITIVE_DEBUG_ASSERT(c, ...) \
+		libassert::detail::primitive_assert_impl(c, false, #c, LIBASSERT_PFUNC, { \
+		} LIBASSERT_VA_ARGS(__VA_ARGS__))
+#else
+	#define LIBASSERT_PRIMITIVE_DEBUG_ASSERT(c, ...) LIBASSERT_PHONY_USE(c)
+#endif
 
-    #define LIBASSERT_PRIMITIVE_PANIC(message) ::libassert::detail::primitive_panic_impl(LIBASSERT_PFUNC, {}, message)
-}
+#define LIBASSERT_PRIMITIVE_PANIC(message) \
+	::libassert::detail::primitive_panic_impl(LIBASSERT_PFUNC, {}, message)
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE
 
 // =====================================================================================================================
@@ -64,37 +70,36 @@ LIBASSERT_END_NAMESPACE
 // =====================================================================================================================
 
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    [[nodiscard]]
-    constexpr inline std::string_view substring_bounded_by(
-        std::string_view sig,
-        std::string_view l,
-        std::string_view r
-    ) noexcept {
-        auto i = sig.find(l) + l.length();
-        return sig.substr(i, sig.rfind(r) - i);
-    }
-
-    template<typename T>
-    [[nodiscard]]
-    std::string_view type_name() noexcept {
-        // Cases to handle:
-        // gcc:   constexpr std::string_view ns::type_name() [with T = int; std::string_view = std::basic_string_view<char>]
-        // clang: std::string_view ns::type_name() [T = int]
-        // msvc:  class std::basic_string_view<char,struct std::char_traits<char> > __cdecl ns::type_name<int>(void)
-        #if LIBASSERT_IS_CLANG
-         return substring_bounded_by(LIBASSERT_PFUNC, "[T = ", "]");
-        #elif LIBASSERT_IS_GCC
-         return substring_bounded_by(LIBASSERT_PFUNC, "[with T = ", "; std::string_view = ");
-        #elif LIBASSERT_IS_MSVC
-         return substring_bounded_by(LIBASSERT_PFUNC, "type_name<", ">(void)");
-        #else
-         return LIBASSERT_PFUNC;
-        #endif
-    }
-
-    [[nodiscard]] LIBASSERT_EXPORT std::string prettify_type(std::string type);
+[[nodiscard]]
+constexpr inline std::string_view
+substring_bounded_by(std::string_view sig, std::string_view l, std::string_view r) noexcept {
+	auto i = sig.find(l) + l.length();
+	return sig.substr(i, sig.rfind(r) - i);
 }
+
+template<typename T>
+[[nodiscard]]
+std::string_view type_name() noexcept {
+// Cases to handle:
+// gcc:   constexpr std::string_view ns::type_name() [with T = int; std::string_view = std::basic_string_view<char>]
+// clang: std::string_view ns::type_name() [T = int]
+// msvc:  class std::basic_string_view<char,struct std::char_traits<char> > __cdecl ns::type_name<int>(void)
+#if LIBASSERT_IS_CLANG
+	return substring_bounded_by(LIBASSERT_PFUNC, "[T = ", "]");
+#elif LIBASSERT_IS_GCC
+	return substring_bounded_by(LIBASSERT_PFUNC, "[with T = ", "; std::string_view = ");
+#elif LIBASSERT_IS_MSVC
+	return substring_bounded_by(LIBASSERT_PFUNC, "type_name<", ">(void)");
+#else
+	return LIBASSERT_PFUNC;
+#endif
+}
+
+[[nodiscard]] LIBASSERT_EXPORT std::string prettify_type(std::string type);
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE
 
 // =====================================================================================================================
@@ -102,46 +107,54 @@ LIBASSERT_END_NAMESPACE
 // =====================================================================================================================
 
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    struct nothing {};
+struct nothing {};
 
-    template<typename T> inline constexpr bool is_nothing = std::is_same_v<T, nothing>;
+template<typename T>
+inline constexpr bool is_nothing = std::is_same_v<T, nothing>;
 
-    // Hack to get around static_assert(false); being evaluated before any instantiation, even under
-    // an if-constexpr branch
-    // Also used for PHONY_USE
-    template<typename T> inline constexpr bool always_false = false;
+// Hack to get around static_assert(false); being evaluated before any instantiation, even under
+// an if-constexpr branch
+// Also used for PHONY_USE
+template<typename T>
+inline constexpr bool always_false = false;
 
-    template<typename T> using strip = std::remove_cv_t<std::remove_reference_t<T>>;
+template<typename T>
+using strip = std::remove_cv_t<std::remove_reference_t<T>>;
 
-    // intentionally not stripping B
-    template<typename A, typename B> inline constexpr bool isa = std::is_same_v<strip<A>, B>;
+// intentionally not stripping B
+template<typename A, typename B>
+inline constexpr bool isa = std::is_same_v<strip<A>, B>;
 
-    // Is integral but not boolean
-    template<typename T> inline constexpr bool is_integral_and_not_bool = std::is_integral_v<strip<T>> && !isa<T, bool>;
+// Is integral but not boolean
+template<typename T>
+inline constexpr bool is_integral_and_not_bool = std::is_integral_v<strip<T>> && !isa<T, bool>;
 
-    template<typename T>
-    inline constexpr bool is_arith_not_bool_char = std::is_arithmetic_v<strip<T>> && !isa<T, bool> && !isa<T, char>;
+template<typename T>
+inline constexpr bool is_arith_not_bool_char =
+	std::is_arithmetic_v<strip<T>> && !isa<T, bool> && !isa<T, char>;
 
-    template<typename T>
-    inline constexpr bool is_string_type =
-        std::is_convertible_v<T, std::string_view>
-            && !std::is_same_v<T, std::nullptr_t>;
+template<typename T>
+inline constexpr bool is_string_type =
+	std::is_convertible_v<T, std::string_view> && !std::is_same_v<T, std::nullptr_t>;
 
-    // char(&)[20], const char(&)[20], const char(&)[]
-    template<typename T> inline constexpr bool is_string_literal =
-           std::is_lvalue_reference_v<T>
-            && std::is_array_v<typename std::remove_reference_t<T>>
-            && isa<typename std::remove_extent_t<typename std::remove_reference_t<T>>, char>;
+// char(&)[20], const char(&)[20], const char(&)[]
+template<typename T>
+inline constexpr bool is_string_literal =
+	std::is_lvalue_reference_v<T> && std::is_array_v<typename std::remove_reference_t<T>>
+	&& isa<typename std::remove_extent_t<typename std::remove_reference_t<T>>, char>;
 
-    template<typename T> typename std::add_lvalue_reference_t<T> decllval() noexcept;
+template<typename T>
+typename std::add_lvalue_reference_t<T> decllval() noexcept;
 
-    template<typename T, template<typename...> typename Template>
-    inline constexpr bool is_specialization = false;
+template<typename T, template<typename...> typename Template>
+inline constexpr bool is_specialization = false;
 
-    template<template<typename...> typename Template, typename... Args>
-    inline constexpr bool is_specialization<Template<Args...>, Template> = true;
-}
+template<template<typename...> typename Template, typename... Args>
+inline constexpr bool is_specialization<Template<Args...>, Template> = true;
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE
 
 // =====================================================================================================================
@@ -149,55 +162,57 @@ LIBASSERT_END_NAMESPACE
 // =====================================================================================================================
 
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    // Copied and pasted from https://en.cppreference.com/w/cpp/utility/intcmp
-    // Not using std:: versions because library is targeting C++17
-    template<typename T, typename U>
-    [[nodiscard]] constexpr bool cmp_equal(T t, U u) {
-        using UT = std::make_unsigned_t<T>;
-        using UU = std::make_unsigned_t<U>;
-        if constexpr(std::is_signed_v<T> == std::is_signed_v<U>) {
-            return t == u;
-        } else if constexpr(std::is_signed_v<T>) {
-            return t >= 0 && UT(t) == u;
-        } else {
-            return u >= 0 && t == UU(u);
-        }
-    }
-
-    template<typename T, typename U>
-    [[nodiscard]] constexpr bool cmp_not_equal(T t, U u) {
-        return !cmp_equal(t, u);
-    }
-
-    template<typename T, typename U>
-    [[nodiscard]] constexpr bool cmp_less(T t, U u) {
-        using UT = std::make_unsigned_t<T>;
-        using UU = std::make_unsigned_t<U>;
-        if constexpr(std::is_signed_v<T> == std::is_signed_v<U>) {
-            return t < u;
-        } else if constexpr(std::is_signed_v<T>) {
-            return t < 0  || UT(t) < u;
-        } else {
-            return u >= 0 && t < UU(u);
-        }
-    }
-
-    template<typename T, typename U>
-    [[nodiscard]] constexpr bool cmp_greater(T t, U u) {
-        return cmp_less(u, t);
-    }
-
-    template<typename T, typename U>
-    [[nodiscard]] constexpr bool cmp_less_equal(T t, U u) {
-        return !cmp_less(u, t);
-    }
-
-    template<typename T, typename U>
-    [[nodiscard]] constexpr bool cmp_greater_equal(T t, U u) {
-        return !cmp_less(t, u);
-    }
+// Copied and pasted from https://en.cppreference.com/w/cpp/utility/intcmp
+// Not using std:: versions because library is targeting C++17
+template<typename T, typename U>
+[[nodiscard]] constexpr bool cmp_equal(T t, U u) {
+	using UT = std::make_unsigned_t<T>;
+	using UU = std::make_unsigned_t<U>;
+	if constexpr (std::is_signed_v<T> == std::is_signed_v<U>) {
+		return t == u;
+	} else if constexpr (std::is_signed_v<T>) {
+		return t >= 0 && UT(t) == u;
+	} else {
+		return u >= 0 && t == UU(u);
+	}
 }
+
+template<typename T, typename U>
+[[nodiscard]] constexpr bool cmp_not_equal(T t, U u) {
+	return !cmp_equal(t, u);
+}
+
+template<typename T, typename U>
+[[nodiscard]] constexpr bool cmp_less(T t, U u) {
+	using UT = std::make_unsigned_t<T>;
+	using UU = std::make_unsigned_t<U>;
+	if constexpr (std::is_signed_v<T> == std::is_signed_v<U>) {
+		return t < u;
+	} else if constexpr (std::is_signed_v<T>) {
+		return t < 0 || UT(t) < u;
+	} else {
+		return u >= 0 && t < UU(u);
+	}
+}
+
+template<typename T, typename U>
+[[nodiscard]] constexpr bool cmp_greater(T t, U u) {
+	return cmp_less(u, t);
+}
+
+template<typename T, typename U>
+[[nodiscard]] constexpr bool cmp_less_equal(T t, U u) {
+	return !cmp_less(u, t);
+}
+
+template<typename T, typename U>
+[[nodiscard]] constexpr bool cmp_greater_equal(T t, U u) {
+	return !cmp_less(t, u);
+}
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE
 
 #endif

--- a/src/analysis.cpp
+++ b/src/analysis.cpp
@@ -1,7 +1,9 @@
+#include "analysis.hpp"
+
 #include <algorithm>
-#include <cstdio>
 #include <cctype>
 #include <cmath>
+#include <cstdio>
 #include <initializer_list>
 #include <iterator>
 #include <memory>
@@ -9,8 +11,8 @@
 #include <regex>
 #include <set>
 #include <stdexcept>
-#include <string_view>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -19,475 +21,509 @@
 #include <libassert/assert.hpp>
 
 #include "common.hpp"
-#include "utils.hpp"
 #include "microfmt.hpp"
-#include "analysis.hpp"
 #include "tokenizer.hpp"
+#include "utils.hpp"
 
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    /*
+/*
      * C++ syntax analysis logic
      */
 
-    std::string union_regexes(std::initializer_list<std::string_view> regexes) {
-        std::string composite;
-        for(const std::string_view str : regexes) {
-            if(!composite.empty()) {
-                composite += "|";
-            }
-            composite += "(?:" + std::string(str) + ")";
-        }
-        return composite;
-    }
+std::string union_regexes(std::initializer_list<std::string_view> regexes) {
+	std::string composite;
+	for (const std::string_view str : regexes) {
+		if (!composite.empty()) {
+			composite += "|";
+		}
+		composite += "(?:" + std::string(str) + ")";
+	}
+	return composite;
+}
 
-    std::string prettify_type(std::string type) {
-        // > > -> >> replacement
-        // could put in analysis:: but the replacement is basic and this is more convenient for
-        // using in the stringifier too
-        replace_all_dynamic(type, "> >", ">>");
-        // "," -> ", " and " ," -> ", "
-        static const std::regex comma_re(R"(\s*,\s*)");
-        replace_all(type, comma_re, ", ");
-        // class/struct/enum C -> C for msvc
-        static const std::regex class_re(R"(\b(class|struct|enum)\s+)");
-        replace_all(type, class_re, "");
-        // `anonymous namespace' -> (anonymous namespace) for msvc
-        // this brings it in-line with other compilers and prevents any tokenization/highlighting issues
-        static const std::regex msvc_anonymous_namespace("`anonymous namespace'");
-        replace_all(type, msvc_anonymous_namespace, "(anonymous namespace)");
-        // rules to replace std::basic_string -> std::string and std::basic_string_view -> std::string_view
-        // rule to replace ", std::allocator<whatever>"
-        static const std::pair<std::regex, std::string_view> basic_string = {
-            std::regex(R"(std(::[a-zA-Z0-9_]+)?::basic_string<char)"), "std::string"
-        };
-        replace_all_template(type, basic_string);
-        static const std::pair<std::regex, std::string_view> basic_string_view = {
-            std::regex(R"(std(::[a-zA-Z0-9_]+)?::basic_string_view<char)"), "std::string_view"
-        };
-        replace_all_template(type, basic_string_view);
-        static const std::pair<std::regex, std::string_view> allocator = {
-            std::regex(R"(,\s*std(::[a-zA-Z0-9_]+)?::allocator<)"), ""
-        };
-        replace_all_template(type, allocator);
-        static const std::pair<std::regex, std::string_view> default_delete = {
-            std::regex(R"(,\s*std(::[a-zA-Z0-9_]+)?::default_delete<)"), ""
-        };
-        replace_all_template(type, default_delete);
-        // replace std::__cxx11 -> std:: for gcc dual abi
-        // https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
-        replace_all_dynamic(type, "std::__cxx11::", "std::");
-        return type;
-    }
+std::string prettify_type(std::string type) {
+	// > > -> >> replacement
+	// could put in analysis:: but the replacement is basic and this is more convenient for
+	// using in the stringifier too
+	replace_all_dynamic(type, "> >", ">>");
+	// "," -> ", " and " ," -> ", "
+	static const std::regex comma_re(R"(\s*,\s*)");
+	replace_all(type, comma_re, ", ");
+	// class/struct/enum C -> C for msvc
+	static const std::regex class_re(R"(\b(class|struct|enum)\s+)");
+	replace_all(type, class_re, "");
+	// `anonymous namespace' -> (anonymous namespace) for msvc
+	// this brings it in-line with other compilers and prevents any tokenization/highlighting issues
+	static const std::regex msvc_anonymous_namespace("`anonymous namespace'");
+	replace_all(type, msvc_anonymous_namespace, "(anonymous namespace)");
+	// rules to replace std::basic_string -> std::string and std::basic_string_view -> std::string_view
+	// rule to replace ", std::allocator<whatever>"
+	static const std::pair<std::regex, std::string_view> basic_string = {
+		std::regex(R"(std(::[a-zA-Z0-9_]+)?::basic_string<char)"),
+		"std::string"
+	};
+	replace_all_template(type, basic_string);
+	static const std::pair<std::regex, std::string_view> basic_string_view = {
+		std::regex(R"(std(::[a-zA-Z0-9_]+)?::basic_string_view<char)"),
+		"std::string_view"
+	};
+	replace_all_template(type, basic_string_view);
+	static const std::pair<std::regex, std::string_view> allocator = {
+		std::regex(R"(,\s*std(::[a-zA-Z0-9_]+)?::allocator<)"),
+		""
+	};
+	replace_all_template(type, allocator);
+	static const std::pair<std::regex, std::string_view> default_delete = {
+		std::regex(R"(,\s*std(::[a-zA-Z0-9_]+)?::default_delete<)"),
+		""
+	};
+	replace_all_template(type, default_delete);
+	// replace std::__cxx11 -> std:: for gcc dual abi
+	// https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
+	replace_all_dynamic(type, "std::__cxx11::", "std::");
+	return type;
+}
 
-    class analysis {
-    public:
-        // Analysis singleton, lazy-initialize all the regex nonsense
-        // 8 BSS bytes and <512 bytes heap bytes not a problem
-        static std::unique_ptr<analysis> analysis_singleton;
-        static std::mutex singleton_mutex;
-        static analysis& get() {
-            const std::unique_lock lock(singleton_mutex);
-            if(analysis_singleton == nullptr) {
-                analysis_singleton = std::unique_ptr<analysis>(new analysis);
-            }
-            return *analysis_singleton;
-        }
+class analysis {
+public:
+	// Analysis singleton, lazy-initialize all the regex nonsense
+	// 8 BSS bytes and <512 bytes heap bytes not a problem
+	static std::unique_ptr<analysis> analysis_singleton;
+	static std::mutex singleton_mutex;
 
-        std::regex escapes_re;
-        std::unordered_map<std::string_view, int> precedence;
-        std::unordered_map<std::string_view, std::string_view> braces = {
-            // template angle brackets excluded from this analysis
-            { "(", ")" }, { "{", "}" }, { "[", "]" }, { "<:", ":>" }, { "<%", "%>" }
-        };
-        std::unordered_map<std::string_view, std::string_view> digraph_map = {
-            { "<:", "[" }, { "<%", "{" }, { ":>", "]" }, { "%>", "}" }
-        };
-        // punctuators to highlight
-        std::unordered_set<std::string_view> highlight_ops = {
-            "~", "!", "+", "-", "*", "/", "%", "^", "&", "|", "=", "+=", "-=", "*=", "/=", "%=",
-            "^=", "&=", "|=", "==", "!=", "<", ">", "<=", ">=", "<=>", "&&", "||", "<<", ">>",
-            "<<=", ">>=", "++", "--", "and", "or", "xor", "not", "bitand", "bitor", "compl",
-            "and_eq", "or_eq", "xor_eq", "not_eq"
-        };
-        // all operators
-        std::unordered_set<std::string_view> operators = {
-            ":", "...", "?", "::", ".", ".*", "->", "->*", "~", "!", "+", "-", "*", "/", "%", "^",
-            "&", "|", "=", "+=", "-=", "*=", "/=", "%=", "^=", "&=", "|=", "==", "!=", "<", ">",
-            "<=", ">=", "<=>", "&&", "||", "<<", ">>", "<<=", ">>=", "++", "--", ",", "and", "or",
-            "xor", "not", "bitand", "bitor", "compl", "and_eq", "or_eq", "xor_eq", "not_eq"
-        };
-        std::unordered_map<std::string_view, std::string_view> alternative_operators_map = {
-            {"and", "&&"}, {"or", "||"}, {"xor", "^"}, {"not", "!"}, {"bitand", "&"},
-            {"bitor", "|"}, {"compl", "~"}, {"and_eq", "&="}, {"or_eq", "|="}, {"xor_eq", "^="},
-            {"not_eq", "!="}
-        };
-        std::unordered_set<std::string_view> bitwise_operators = {
-            "^", "&", "|", "^=", "&=", "|=", "xor", "bitand", "bitor", "and_eq", "or_eq", "xor_eq"
-        };
-        std::vector<std::pair<std::regex, literal_format>> literal_formats;
+	static analysis& get() {
+		const std::unique_lock lock(singleton_mutex);
+		if (analysis_singleton == nullptr) {
+			analysis_singleton = std::unique_ptr<analysis>(new analysis);
+		}
+		return *analysis_singleton;
+	}
 
-    private:
-        analysis() {
-            // https://eel.is/c++draft/gram.lex
-            // generate regular expressions
-            std::string keywords[] = { "alignas", "constinit", "public", "alignof", "const_cast",
-                "float", "register", "try", "asm", "continue", "for", "reinterpret_cast", "typedef",
-                "auto", "co_await", "friend", "requires", "typeid", "bool", "co_return", "goto",
-                "return", "typename", "break", "co_yield", "if", "short", "union", "case",
-                "decltype", "inline", "signed", "unsigned", "catch", "default", "int", "sizeof",
-                "using", "char", "delete", "long", "static", "virtual", "char8_t", "do", "mutable",
-                "static_assert", "void", "char16_t", "double", "namespace", "static_cast",
-                "volatile", "char32_t", "dynamic_cast", "new", "struct", "wchar_t", "class", "else",
-                "noexcept", "switch", "while", "concept", "enum", "template", "const", "explicit",
-                "operator", "this", "consteval", "export", "private", "thread_local", "constexpr",
-                "extern", "protected", "throw" };
-            std::string punctuators[] = { "{", "}", "[", "]", "(", ")", "<:", ":>", "<%",
-                "%>", ";", ":", "...", "?", "::", ".", ".*", "->", "->*", "~", "!", "+", "-", "*",
-                "/", "%", "^", "&", "|", "=", "+=", "-=", "*=", "/=", "%=", "^=", "&=", "|=", "==",
-                "!=", "<", ">", "<=", ">=", "<=>", "&&", "||", "<<", ">>", "<<=", ">>=", "++", "--",
-                ",", "and", "or", "xor", "not", "bitand", "bitor", "compl", "and_eq", "or_eq",
-                "xor_eq", "not_eq", "#" }; // # appears in some lambda signatures
-            // Sort longest -> shortest (secondarily A->Z)
-            const auto cmp = [](const std::string_view a, const std::string_view b) {
-                if(a.length() > b.length()) { return true; }
-                else if(a.length() == b.length()) { return a < b; }
-                else { return false; }
-            };
-            std::sort(std::begin(keywords), std::end(keywords), cmp);
-            std::sort(std::begin(punctuators), std::end(punctuators), cmp);
-            // Escape special characters and add wordbreaks
-            const std::regex special_chars { R"([-[\]{}()*+?.,\^$|#\s])" };
-            std::transform(std::begin(punctuators), std::end(punctuators), std::begin(punctuators),
-                [&special_chars](const std::string& str) {
-                    return std::regex_replace(str + (isalpha(str[0]) ? "\\b" : ""), special_chars, "\\$&");
-                });
-            // https://eel.is/c++draft/lex.pptoken#3.2
-            *std::find(std::begin(punctuators), std::end(punctuators), "<:") += "(?!:[^:>])";
-            // regular expressions
-            // numeric literals
-            const std::string optional_integer_suffix = "(?:[Uu](?:LL?|ll?|Z|z)?|(?:LL?|ll?|Z|z)[Uu]?)?";
-            const std::string int_binary  = "0[Bb][01](?:'?[01])*" + optional_integer_suffix;
-            // slightly modified from grammar so 0 is lexed as a decimal literal instead of octal
-            const std::string int_octal   = "0(?:'?[0-7])+" + optional_integer_suffix;
-            const std::string int_decimal = "(?:0|[1-9](?:'?\\d)*)" + optional_integer_suffix;
-            const std::string int_hex        = "0[Xx](?!')(?:'?[\\da-fA-F])+" + optional_integer_suffix;
-            const std::string digit_sequence = "\\d(?:'?\\d)*";
-            const std::string fractional_constant = microfmt::format(
-                "(?:(?:{})?\\.{}|{}\\.)",
-                digit_sequence,
-                digit_sequence,
-                digit_sequence
-            );
-            const std::string exponent_part = "(?:[Ee][\\+-]?" + digit_sequence + ")";
-            const std::string suffix = "[FfLl]";
-            const std::string float_decimal = microfmt::format(
-                "(?:{}{}?|{}{}){}?",
-                fractional_constant,
-                exponent_part,
-                digit_sequence,
-                exponent_part,
-                suffix
-            );
-            const std::string hex_digit_sequence = "[\\da-fA-F](?:'?[\\da-fA-F])*";
-            const std::string hex_frac_const = microfmt::format(
-                "(?:(?:{})?\\.{}|{}\\.)",
-                hex_digit_sequence,
-                hex_digit_sequence,
-                hex_digit_sequence
-            );
-            const std::string binary_exp = "[Pp][\\+-]?" + digit_sequence;
-            const std::string float_hex = microfmt::format(
-                "0[Xx](?:{}|{}){}{}?",
-                hex_frac_const,
-                hex_digit_sequence,
-                binary_exp,
-                suffix
-            );
-            // char and string literals
-            // TODO: This needs to be updated
-            const std::string escapes = R"(\\[0-7]{1,3}|\\x[\da-fA-F]+|\\.)";
-            const std::string char_literal = R"((?:u8|[UuL])?'(?:)" + escapes + R"(|[^\n'])*')";
-            escapes_re = std::regex(escapes);
-            // setup literal format rules
-            literal_formats = {
-                { std::regex(int_binary),    literal_format::integer_binary },
-                { std::regex(int_octal),     literal_format::integer_octal },
-                { std::regex(int_decimal),   literal_format::default_format },
-                { std::regex(int_hex),       literal_format::integer_hex },
-                { std::regex(float_decimal), literal_format::default_format },
-                { std::regex(float_hex),     literal_format::float_hex },
-                { std::regex(char_literal),  literal_format::default_format }
-            };
-            // generate precedence table
-            // bottom few rows of the precedence table:
-            const std::unordered_map<int, std::vector<std::string_view>> precedences = {
-                { -1, { "<<", ">>" } },
-                { -2, { "<=>" } },
-                { -3, { "<", "<=", ">=", ">" } },
-                { -4, { "==", "!=" } },
-                { -5, { "&" } },
-                { -6, { "^" } },
-                { -7, { "|" } },
-                { -8, { "&&" } },
-                { -9, { "||" } },
-                            // Note: associativity logic currently relies on these having precedence -10
-                { -10, { "?", ":", "=", "+=", "-=", "*=", "/=", "%=", "<<=", ">>=", "&=", "^=", "|=" } },
-                { -11, { "," } }
-            };
-            std::unordered_map<std::string_view, int> table;
-            for(const auto& [ p, ops ] : precedences) {
-                for(const auto& op : ops) {
-                    table.insert({op, p});
-                }
-            }
-            precedence = table;
-        }
+	std::regex escapes_re;
+	std::unordered_map<std::string_view, int> precedence;
+	std::unordered_map<std::string_view, std::string_view> braces = {
+		// template angle brackets excluded from this analysis
+		{"(", ")"},
+		{"{", "}"},
+		{"[", "]"},
+		{"<:", ":>"},
+		{"<%", "%>"}
+	};
+	std::unordered_map<std::string_view, std::string_view> digraph_map =
+		{{"<:", "["}, {"<%", "{"}, {":>", "]"}, {"%>", "}"}};
+	// punctuators to highlight
+	std::unordered_set<std::string_view> highlight_ops = {
+		"~",   "!",   "+",      "-",     "*",     "/",      "%",     "^",      "&",
+		"|",   "=",   "+=",     "-=",    "*=",    "/=",     "%=",    "^=",     "&=",
+		"|=",  "==",  "!=",     "<",     ">",     "<=",     ">=",    "<=>",    "&&",
+		"||",  "<<",  ">>",     "<<=",   ">>=",   "++",     "--",    "and",    "or",
+		"xor", "not", "bitand", "bitor", "compl", "and_eq", "or_eq", "xor_eq", "not_eq"
+	};
+	// all operators
+	std::unordered_set<std::string_view> operators = {
+		":",   "...", "?",   "::",     ".",     ".*",    "->",     "->*",   "~",      "!",     "+",
+		"-",   "*",   "/",   "%",      "^",     "&",     "|",      "=",     "+=",     "-=",    "*=",
+		"/=",  "%=",  "^=",  "&=",     "|=",    "==",    "!=",     "<",     ">",      "<=",    ">=",
+		"<=>", "&&",  "||",  "<<",     ">>",    "<<=",   ">>=",    "++",    "--",     ",",     "and",
+		"or",  "xor", "not", "bitand", "bitor", "compl", "and_eq", "or_eq", "xor_eq", "not_eq"
+	};
+	std::unordered_map<std::string_view, std::string_view> alternative_operators_map = {
+		{"and", "&&"},
+		{"or", "||"},
+		{"xor", "^"},
+		{"not", "!"},
+		{"bitand", "&"},
+		{"bitor", "|"},
+		{"compl", "~"},
+		{"and_eq", "&="},
+		{"or_eq", "|="},
+		{"xor_eq", "^="},
+		{"not_eq", "!="}
+	};
+	std::unordered_set<std::string_view> bitwise_operators =
+		{"^", "&", "|", "^=", "&=", "|=", "xor", "bitand", "bitor", "and_eq", "or_eq", "xor_eq"};
+	std::vector<std::pair<std::regex, literal_format>> literal_formats;
 
-    public:
-        std::string_view normalize_op(const std::string_view op) {
-            // Operators need to be normalized to support alternative operators like and and bitand
-            // Normalization instead of just adding to the precedence table because target operators
-            // will always be the normalized operator even when the alternative operator is used.
-            if(auto it = alternative_operators_map.find(op); it != alternative_operators_map.end()) {
-                return it->second;
-            } else {
-                return op;
-            }
-        }
+private:
+	analysis() {
+		// https://eel.is/c++draft/gram.lex
+		// generate regular expressions
+		std::string keywords[] = {"alignas",    "constinit",    "public",        "alignof",
+															"const_cast", "float",        "register",      "try",
+															"asm",        "continue",     "for",           "reinterpret_cast",
+															"typedef",    "auto",         "co_await",      "friend",
+															"requires",   "typeid",       "bool",          "co_return",
+															"goto",       "return",       "typename",      "break",
+															"co_yield",   "if",           "short",         "union",
+															"case",       "decltype",     "inline",        "signed",
+															"unsigned",   "catch",        "default",       "int",
+															"sizeof",     "using",        "char",          "delete",
+															"long",       "static",       "virtual",       "char8_t",
+															"do",         "mutable",      "static_assert", "void",
+															"char16_t",   "double",       "namespace",     "static_cast",
+															"volatile",   "char32_t",     "dynamic_cast",  "new",
+															"struct",     "wchar_t",      "class",         "else",
+															"noexcept",   "switch",       "while",         "concept",
+															"enum",       "template",     "const",         "explicit",
+															"operator",   "this",         "consteval",     "export",
+															"private",    "thread_local", "constexpr",     "extern",
+															"protected",  "throw"};
+		std::string punctuators[] = {
+			"{",     "}",      "[",     "]",      "(",      ")",  "<:",  ":>",  "<%",     "%>",
+			";",     ":",      "...",   "?",      "::",     ".",  ".*",  "->",  "->*",    "~",
+			"!",     "+",      "-",     "*",      "/",      "%",  "^",   "&",   "|",      "=",
+			"+=",    "-=",     "*=",    "/=",     "%=",     "^=", "&=",  "|=",  "==",     "!=",
+			"<",     ">",      "<=",    ">=",     "<=>",    "&&", "||",  "<<",  ">>",     "<<=",
+			">>=",   "++",     "--",    ",",      "and",    "or", "xor", "not", "bitand", "bitor",
+			"compl", "and_eq", "or_eq", "xor_eq", "not_eq", "#"
+		}; // # appears in some lambda signatures
+		// Sort longest -> shortest (secondarily A->Z)
+		const auto cmp = [](const std::string_view a, const std::string_view b) {
+			if (a.length() > b.length()) {
+				return true;
+			} else if (a.length() == b.length()) {
+				return a < b;
+			} else {
+				return false;
+			}
+		};
+		std::sort(std::begin(keywords), std::end(keywords), cmp);
+		std::sort(std::begin(punctuators), std::end(punctuators), cmp);
+		// Escape special characters and add wordbreaks
+		const std::regex special_chars {R"([-[\]{}()*+?.,\^$|#\s])"};
+		std::transform(
+			std::begin(punctuators),
+			std::end(punctuators),
+			std::begin(punctuators),
+			[&special_chars](const std::string& str) {
+				return std::regex_replace(str + (isalpha(str[0]) ? "\\b" : ""), special_chars, "\\$&");
+			}
+		);
+		// https://eel.is/c++draft/lex.pptoken#3.2
+		*std::find(std::begin(punctuators), std::end(punctuators), "<:") += "(?!:[^:>])";
+		// regular expressions
+		// numeric literals
+		const std::string optional_integer_suffix = "(?:[Uu](?:LL?|ll?|Z|z)?|(?:LL?|ll?|Z|z)[Uu]?)?";
+		const std::string int_binary = "0[Bb][01](?:'?[01])*" + optional_integer_suffix;
+		// slightly modified from grammar so 0 is lexed as a decimal literal instead of octal
+		const std::string int_octal = "0(?:'?[0-7])+" + optional_integer_suffix;
+		const std::string int_decimal = "(?:0|[1-9](?:'?\\d)*)" + optional_integer_suffix;
+		const std::string int_hex = "0[Xx](?!')(?:'?[\\da-fA-F])+" + optional_integer_suffix;
+		const std::string digit_sequence = "\\d(?:'?\\d)*";
+		const std::string fractional_constant =
+			microfmt::format("(?:(?:{})?\\.{}|{}\\.)", digit_sequence, digit_sequence, digit_sequence);
+		const std::string exponent_part = "(?:[Ee][\\+-]?" + digit_sequence + ")";
+		const std::string suffix = "[FfLl]";
+		const std::string float_decimal = microfmt::format(
+			"(?:{}{}?|{}{}){}?",
+			fractional_constant,
+			exponent_part,
+			digit_sequence,
+			exponent_part,
+			suffix
+		);
+		const std::string hex_digit_sequence = "[\\da-fA-F](?:'?[\\da-fA-F])*";
+		const std::string hex_frac_const = microfmt::format(
+			"(?:(?:{})?\\.{}|{}\\.)",
+			hex_digit_sequence,
+			hex_digit_sequence,
+			hex_digit_sequence
+		);
+		const std::string binary_exp = "[Pp][\\+-]?" + digit_sequence;
+		const std::string float_hex = microfmt::format(
+			"0[Xx](?:{}|{}){}{}?",
+			hex_frac_const,
+			hex_digit_sequence,
+			binary_exp,
+			suffix
+		);
+		// char and string literals
+		// TODO: This needs to be updated
+		const std::string escapes = R"(\\[0-7]{1,3}|\\x[\da-fA-F]+|\\.)";
+		const std::string char_literal = R"((?:u8|[UuL])?'(?:)" + escapes + R"(|[^\n'])*')";
+		escapes_re = std::regex(escapes);
+		// setup literal format rules
+		literal_formats = {
+			{std::regex(int_binary), literal_format::integer_binary},
+			{std::regex(int_octal), literal_format::integer_octal},
+			{std::regex(int_decimal), literal_format::default_format},
+			{std::regex(int_hex), literal_format::integer_hex},
+			{std::regex(float_decimal), literal_format::default_format},
+			{std::regex(float_hex), literal_format::float_hex},
+			{std::regex(char_literal), literal_format::default_format}
+		};
+		// generate precedence table
+		// bottom few rows of the precedence table:
+		const std::unordered_map<int, std::vector<std::string_view>> precedences = {
+			{-1, {"<<", ">>"}},
+			{-2, {"<=>"}},
+			{-3, {"<", "<=", ">=", ">"}},
+			{-4, {"==", "!="}},
+			{-5, {"&"}},
+			{-6, {"^"}},
+			{-7, {"|"}},
+			{-8, {"&&"}},
+			{-9, {"||"}},
+			// Note: associativity logic currently relies on these having precedence -10
+			{-10, {"?", ":", "=", "+=", "-=", "*=", "/=", "%=", "<<=", ">>=", "&=", "^=", "|="}},
+			{-11, {","}}
+		};
+		std::unordered_map<std::string_view, int> table;
+		for (const auto& [p, ops] : precedences) {
+			for (const auto& op : ops) {
+				table.insert({op, p});
+			}
+		}
+		precedence = table;
+	}
 
-        std::string_view normalize_brace(const std::string_view brace) {
-            // Operators need to be normalized to support alternative operators like and and bitand
-            // Normalization instead of just adding to the precedence table because target operators
-            // will always be the normalized operator even when the alternative operator is used.
-            if(auto it = digraph_map.find(brace); it != digraph_map.end()) {
-                return it->second;
-            } else {
-                return brace;
-            }
-        }
+public:
+	std::string_view normalize_op(const std::string_view op) {
+		// Operators need to be normalized to support alternative operators like and and bitand
+		// Normalization instead of just adding to the precedence table because target operators
+		// will always be the normalized operator even when the alternative operator is used.
+		if (auto it = alternative_operators_map.find(op); it != alternative_operators_map.end()) {
+			return it->second;
+		} else {
+			return op;
+		}
+	}
 
-        std::vector<highlight_block> highlight_string(std::string_view str, const color_scheme& scheme) const {
-            std::vector<highlight_block> output;
-            std::cmatch match;
-            std::size_t i = 0;
-            // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-            while(std::regex_search(str.data() + i, str.data() + str.size(), match, escapes_re)) {
-                // add string part
-                // TODO: I don't know why this assert was added, I might have done it in dev on a whim. Re-evaluate.
-                // LIBASSERT_PRIMITIVE_DEBUG_ASSERT(match.position() > 0);
-                if(match.position() > 0) {
-                    output.push_back({scheme.string, str.substr(i, match.position())});
-                }
-                output.push_back({scheme.escape, str.substr(i + match.position(), match.length())});
-                i += match.position() + match.length();
-            }
-            if(i < str.length()) {
-                output.push_back({scheme.string, str.substr(i)});
-            }
-            return output;
-        }
+	std::string_view normalize_brace(const std::string_view brace) {
+		// Operators need to be normalized to support alternative operators like and and bitand
+		// Normalization instead of just adding to the precedence table because target operators
+		// will always be the normalized operator even when the alternative operator is used.
+		if (auto it = digraph_map.find(brace); it != digraph_map.end()) {
+			return it->second;
+		} else {
+			return brace;
+		}
+	}
 
-        // TODO: Refactor
-        // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-        std::vector<highlight_block> highlight(std::string_view expression, const color_scheme& scheme) try {
-            const auto res = tokenize(expression);
-            if(!res) {
-                return {{"", expression}};
-            }
-            const auto& tokens = *res;
-            std::vector<highlight_block> output;
-            for(size_t i = 0; i < tokens.size(); i++) {
-                const auto& token = tokens[i];
-                // Peek next non-whitespace token, return empty whitespace token if end is reached
-                const auto peek = [i, &tokens](size_t j = 1) {
-                    for(size_t k = 1; j > 0 && i + k < tokens.size(); k++) {
-                        if(tokens[i + k].type != token_e::whitespace) {
-                            if(--j == 0) {
-                                return tokens[i + k];
-                            }
-                        }
-                    }
-                    LIBASSERT_PRIMITIVE_DEBUG_ASSERT(j != 0);
-                    return token_t { token_e::whitespace, "" };
-                };
-                switch(token.type) {
-                    case token_e::keyword:
-                        output.push_back({scheme.keyword, token.str});
-                        break;
-                    case token_e::punctuation:
-                        if(highlight_ops.count(token.str)) {
-                            output.push_back({scheme.operator_token, token.str});
-                        } else {
-                            output.push_back({scheme.punctuation, token.str});
-                        }
-                        break;
-                    case token_e::named_literal:
-                        output.push_back({scheme.named_literal, token.str});
-                        break;
-                    case token_e::number:
-                        output.push_back({scheme.number, token.str});
-                        break;
-                    case token_e::string:
-                        {
-                            auto string_tokens = highlight_string(token.str, scheme);
-                            output.insert(output.end(), string_tokens.begin(), string_tokens.end());
-                        }
-                        break;
-                    case token_e::identifier:
-                        if(peek().str == "(") {
-                            output.push_back({scheme.call_identifier, token.str});
-                        } else if(peek().str == "::") {
-                            output.push_back({scheme.scope_resolution_identifier, token.str});
-                        } else {
-                            output.push_back({scheme.identifier, token.str});
-                        }
-                        break;
-                    case token_e::whitespace:
-                        output.push_back({"", token.str});
-                        break;
-                    case token_e::unknown:
-                        output.push_back({scheme.unknown, token.str});
-                        break;
-                }
-            }
-            return output;
-        } catch(...) {
-            return {{"", std::string(expression)}};
-        }
+	std::vector<highlight_block>
+	highlight_string(std::string_view str, const color_scheme& scheme) const {
+		std::vector<highlight_block> output;
+		std::cmatch match;
+		std::size_t i = 0;
+		// NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+		while (std::regex_search(str.data() + i, str.data() + str.size(), match, escapes_re)) {
+			// add string part
+			// TODO: I don't know why this assert was added, I might have done it in dev on a whim. Re-evaluate.
+			// LIBASSERT_PRIMITIVE_DEBUG_ASSERT(match.position() > 0);
+			if (match.position() > 0) {
+				output.push_back({scheme.string, str.substr(i, match.position())});
+			}
+			output.push_back({scheme.escape, str.substr(i + match.position(), match.length())});
+			i += match.position() + match.length();
+		}
+		if (i < str.length()) {
+			output.push_back({scheme.string, str.substr(i)});
+		}
+		return output;
+	}
 
-        literal_format get_literal_format(std::string_view expression) {
-            for(auto& [ re, type ] : literal_formats) {
-                if(std::regex_match(expression.begin(), expression.end(), re)) {
-                    return type;
-                }
-            }
-            return literal_format::default_format; // not a literal // TODO
-        }
+	// TODO: Refactor
+	// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+	std::vector<highlight_block>
+	highlight(std::string_view expression, const color_scheme& scheme) try {
+		const auto res = tokenize(expression);
+		if (!res) {
+			return {{"", expression}};
+		}
+		const auto& tokens = *res;
+		std::vector<highlight_block> output;
+		for (size_t i = 0; i < tokens.size(); i++) {
+			const auto& token = tokens[i];
+			// Peek next non-whitespace token, return empty whitespace token if end is reached
+			const auto peek = [i, &tokens](size_t j = 1) {
+				for (size_t k = 1; j > 0 && i + k < tokens.size(); k++) {
+					if (tokens[i + k].type != token_e::whitespace) {
+						if (--j == 0) {
+							return tokens[i + k];
+						}
+					}
+				}
+				LIBASSERT_PRIMITIVE_DEBUG_ASSERT(j != 0);
+				return token_t {token_e::whitespace, ""};
+			};
+			switch (token.type) {
+				case token_e::keyword:
+					output.push_back({scheme.keyword, token.str});
+					break;
+				case token_e::punctuation:
+					if (highlight_ops.count(token.str)) {
+						output.push_back({scheme.operator_token, token.str});
+					} else {
+						output.push_back({scheme.punctuation, token.str});
+					}
+					break;
+				case token_e::named_literal:
+					output.push_back({scheme.named_literal, token.str});
+					break;
+				case token_e::number:
+					output.push_back({scheme.number, token.str});
+					break;
+				case token_e::string: {
+					auto string_tokens = highlight_string(token.str, scheme);
+					output.insert(output.end(), string_tokens.begin(), string_tokens.end());
+				} break;
+				case token_e::identifier:
+					if (peek().str == "(") {
+						output.push_back({scheme.call_identifier, token.str});
+					} else if (peek().str == "::") {
+						output.push_back({scheme.scope_resolution_identifier, token.str});
+					} else {
+						output.push_back({scheme.identifier, token.str});
+					}
+					break;
+				case token_e::whitespace:
+					output.push_back({"", token.str});
+					break;
+				case token_e::unknown:
+					output.push_back({scheme.unknown, token.str});
+					break;
+			}
+		}
+		return output;
+	} catch (...) {
+		return {{"", std::string(expression)}};
+	}
 
-        static token_t find_last_non_ws(const std::vector<token_t>& tokens, size_t i) {
-            // returns empty token_e::whitespace on failure
-            while(i--) {
-                if(tokens[i].type != token_e::whitespace) {
-                    return tokens[i];
-                }
-            }
-            return {token_e::whitespace, ""};
-        }
+	literal_format get_literal_format(std::string_view expression) {
+		for (auto& [re, type] : literal_formats) {
+			if (std::regex_match(expression.begin(), expression.end(), re)) {
+				return type;
+			}
+		}
+		return literal_format::default_format; // not a literal // TODO
+	}
 
-        static std::string_view get_real_op(const std::vector<token_t>& tokens, const size_t i) {
-            // re-coalesce >> if necessary
-            const bool is_shr = tokens[i].str == ">" && i < tokens.size() - 1 && tokens[i + 1].str == ">";
-            return is_shr ? std::string_view(">>") : std::string_view(tokens[i].str);
-        }
+	static token_t find_last_non_ws(const std::vector<token_t>& tokens, size_t i) {
+		// returns empty token_e::whitespace on failure
+		while (i--) {
+			if (tokens[i].type != token_e::whitespace) {
+				return tokens[i];
+			}
+		}
+		return {token_e::whitespace, ""};
+	}
 
-        // In this function we are essentially exploring all possible parse trees for an expression
-        // an making an attempt to disambiguate as much as we can. It's potentially O(2^t) (?) with
-        // t being the number of possible templates in the expression, but t is anticipated to
-        // always be small.
-        // Returns true if parse tree traversal was a success, false if depth was exceeded
-        static constexpr int max_depth = 10;
-        // TODO
-        // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-        bool pseudoparse(
-            const std::vector<token_t>& tokens,
-            const std::string_view target_op,
-            size_t i,
-            int current_lowest_precedence,
-            int template_depth,
-            int middle_index, // where the split currently is, current op = tokens[middle_index]
-            int depth,
-            std::set<int>& output
-        ) {
-            #ifdef _0_DEBUG_ASSERT_DISAMBIGUATION
-            (void)fprintf(stderr, "*");
-            #endif
-            if(depth > max_depth) {
-                (void)fprintf(stderr, "Max depth exceeded\n");
-                return false;
-            }
-            // precedence table is binary, unary operators have highest precedence
-            // we can figure out unary / binary easy enough
-            enum {
-                expecting_operator,
-                expecting_term
-            } state = expecting_term;
-            for(; i < tokens.size(); i++) {
-                const token_t& token = tokens[i];
-                // scan forward to matching brace
-                // can assume braces are balanced
-                const auto scan_forward = [this, &i, &tokens](
-                    const std::string_view open,
-                    const std::string_view close)
-                {
-                    bool empty = true;
-                    int count = 0;
-                    while(++i < tokens.size()) {
-                        if(normalize_brace(tokens[i].str) == normalize_brace(open)) {
-                            count++;
-                        } else if(normalize_brace(tokens[i].str) == normalize_brace(close)) {
-                            if(count-- == 0) {
-                                break;
-                            }
-                        } else if(tokens[i].type != token_e::whitespace) {
-                            empty = false;
-                        }
-                    }
-                    if(i == tokens.size() && count != -1) {
-                        LIBASSERT_PRIMITIVE_DEBUG_ASSERT(false, "ill-formed expression input");
-                    }
-                    return empty;
-                };
-                switch(token.type) {
-                    case token_e::punctuation:
-                        if(operators.count(token.str)) {
-                            if(state == expecting_term) {
-                                // must be unary, continue
-                            } else {
-                                // template can only open with a < token, no need to check << or <<=
-                                // also must be preceeded by an identifier
-                                if(token.str == "<" && find_last_non_ws(tokens, i).type == token_e::identifier) {
-                                    // branch 1: this is a template opening
-                                    const bool success = pseudoparse(
-                                        tokens,
-                                        target_op,
-                                        i + 1,
-                                        current_lowest_precedence,
-                                        template_depth + 1,
-                                        middle_index, depth + 1,
-                                        output
-                                    );
-                                    if(!success) { // early exit if we have to discard
-                                        return false;
-                                    }
-                                    // branch 2: this is a binary operator // fallthrough
-                                } else if(token.str == "<" && normalize_brace(find_last_non_ws(tokens, i).str) == "]") {
-                                    // this must be a template parameter list, part of a generic lambda
-                                    const bool empty = scan_forward("<", ">");
-                                    LIBASSERT_PRIMITIVE_DEBUG_ASSERT(!empty);
-                                    state = expecting_operator;
-                                    continue;
-                                }
-                                if(template_depth > 0 && token.str == ">") {
-                                    // No branch here: This must be a close. C++ standard
-                                    // Disambiguates by treating > always as a template parameter
-                                    // list close and >> is broken down.
-                                    // >= and >>= don't need to be broken down and we don't need to
-                                    // worry about re-tokenizing beyond just the simple breakdown.
-                                    // I.e. we don't need to worry about x<2>>>1 which is tokenized
-                                    // as x < 2 >> > 1 but perhaps being intended as x < 2 > >> 1.
-                                    // Standard has saved us from this complexity.
-                                    // Note: >> breakdown moved to initial tokenization so we can
-                                    // take the token vector by reference.
-                                    template_depth--;
-                                    state = expecting_operator;
-                                    continue;
-                                }
-                                // binary
-                                if(template_depth == 0) { // ignore precedence in template parameter list
-                                    // re-coalesce >> if necessary
-                                    const std::string_view op = normalize_op(get_real_op(tokens, i));
-                                    if(
+	static std::string_view get_real_op(const std::vector<token_t>& tokens, const size_t i) {
+		// re-coalesce >> if necessary
+		const bool is_shr = tokens[i].str == ">" && i < tokens.size() - 1 && tokens[i + 1].str == ">";
+		return is_shr ? std::string_view(">>") : std::string_view(tokens[i].str);
+	}
+
+	// In this function we are essentially exploring all possible parse trees for an expression
+	// an making an attempt to disambiguate as much as we can. It's potentially O(2^t) (?) with
+	// t being the number of possible templates in the expression, but t is anticipated to
+	// always be small.
+	// Returns true if parse tree traversal was a success, false if depth was exceeded
+	static constexpr int max_depth = 10;
+
+	// TODO
+	// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+	bool pseudoparse(
+		const std::vector<token_t>& tokens,
+		const std::string_view target_op,
+		size_t i,
+		int current_lowest_precedence,
+		int template_depth,
+		int middle_index, // where the split currently is, current op = tokens[middle_index]
+		int depth,
+		std::set<int>& output
+	) {
+#ifdef _0_DEBUG_ASSERT_DISAMBIGUATION
+		(void)fprintf(stderr, "*");
+#endif
+		if (depth > max_depth) {
+			(void)fprintf(stderr, "Max depth exceeded\n");
+			return false;
+		}
+
+		// precedence table is binary, unary operators have highest precedence
+		// we can figure out unary / binary easy enough
+		enum { expecting_operator, expecting_term } state = expecting_term;
+
+		for (; i < tokens.size(); i++) {
+			const token_t& token = tokens[i];
+			// scan forward to matching brace
+			// can assume braces are balanced
+			const auto scan_forward =
+				[this, &i, &tokens](const std::string_view open, const std::string_view close) {
+					bool empty = true;
+					int count = 0;
+					while (++i < tokens.size()) {
+						if (normalize_brace(tokens[i].str) == normalize_brace(open)) {
+							count++;
+						} else if (normalize_brace(tokens[i].str) == normalize_brace(close)) {
+							if (count-- == 0) {
+								break;
+							}
+						} else if (tokens[i].type != token_e::whitespace) {
+							empty = false;
+						}
+					}
+					if (i == tokens.size() && count != -1) {
+						LIBASSERT_PRIMITIVE_DEBUG_ASSERT(false, "ill-formed expression input");
+					}
+					return empty;
+				};
+			switch (token.type) {
+				case token_e::punctuation:
+					if (operators.count(token.str)) {
+						if (state == expecting_term) {
+							// must be unary, continue
+						} else {
+							// template can only open with a < token, no need to check << or <<=
+							// also must be preceeded by an identifier
+							if (token.str == "<" && find_last_non_ws(tokens, i).type == token_e::identifier) {
+								// branch 1: this is a template opening
+								const bool success = pseudoparse(
+									tokens,
+									target_op,
+									i + 1,
+									current_lowest_precedence,
+									template_depth + 1,
+									middle_index,
+									depth + 1,
+									output
+								);
+								if (!success) { // early exit if we have to discard
+									return false;
+								}
+								// branch 2: this is a binary operator // fallthrough
+							} else if (
+								token.str == "<" && normalize_brace(find_last_non_ws(tokens, i).str) == "]"
+							) {
+								// this must be a template parameter list, part of a generic lambda
+								const bool empty = scan_forward("<", ">");
+								LIBASSERT_PRIMITIVE_DEBUG_ASSERT(!empty);
+								state = expecting_operator;
+								continue;
+							}
+							if (template_depth > 0 && token.str == ">") {
+								// No branch here: This must be a close. C++ standard
+								// Disambiguates by treating > always as a template parameter
+								// list close and >> is broken down.
+								// >= and >>= don't need to be broken down and we don't need to
+								// worry about re-tokenizing beyond just the simple breakdown.
+								// I.e. we don't need to worry about x<2>>>1 which is tokenized
+								// as x < 2 >> > 1 but perhaps being intended as x < 2 > >> 1.
+								// Standard has saved us from this complexity.
+								// Note: >> breakdown moved to initial tokenization so we can
+								// take the token vector by reference.
+								template_depth--;
+								state = expecting_operator;
+								continue;
+							}
+							// binary
+							if (template_depth == 0) { // ignore precedence in template parameter list
+								// re-coalesce >> if necessary
+								const std::string_view op = normalize_op(get_real_op(tokens, i));
+								if(
                                         precedence.count(op)
                                         && (
                                             precedence.at(op) < current_lowest_precedence
@@ -497,313 +533,318 @@ namespace detail {
                                             )
                                         )
                                     ) {
-                                        middle_index = (int)i;
-                                        current_lowest_precedence = precedence.at(op);
-                                    }
-                                    if(op == ">>") {
-                                        i++;
-                                    }
-                                }
-                                state = expecting_term;
-                            }
-                        } else if(braces.count(token.str)) {
-                            // We can assume the given expression is valid.
-                            // Braces must be balanced.
-                            // Scan forward until finding matching brace, don't need to take into
-                            // account other types of braces.
-                            const std::string_view open = token.str;
-                            const std::string_view close = braces.at(token.str);
-                            const bool empty = scan_forward(open, close);
-                            // Handle () and {} when they aren't a call/initializer
-                            // [] may appear in lambdas when state == expecting_term
-                            // [](){ ... }() is parsed fine because state == expecting_operator
-                            // after the captures list. Not concerned with template parameters at
-                            // the moment.
-                            if(state == expecting_term && empty && normalize_brace(open) != "[") {
-                                return true; // this is a failed parse tree
-                            }
-                            state = expecting_operator;
-                        } else {
-                            LIBASSERT_PRIMITIVE_DEBUG_ASSERT(false, "unhandled punctuation?");
-                        }
-                        break;
-                    case token_e::keyword:
-                    case token_e::named_literal:
-                    case token_e::number:
-                    case token_e::string:
-                    case token_e::identifier:
-                    case token_e::unknown:
-                        state = expecting_operator;
-                    case token_e::whitespace:
-                        break;
-                }
-            }
-            if(
-                middle_index != -1
-                && normalize_op(get_real_op(tokens, middle_index)) == target_op
-                && template_depth == 0
-                && state == expecting_operator
-            ) {
-                output.insert(middle_index);
-            } else {
-                // failed parse tree, ignore
-            }
-            return true;
-        }
+									middle_index = (int)i;
+									current_lowest_precedence = precedence.at(op);
+								}
+								if (op == ">>") {
+									i++;
+								}
+							}
+							state = expecting_term;
+						}
+					} else if (braces.count(token.str)) {
+						// We can assume the given expression is valid.
+						// Braces must be balanced.
+						// Scan forward until finding matching brace, don't need to take into
+						// account other types of braces.
+						const std::string_view open = token.str;
+						const std::string_view close = braces.at(token.str);
+						const bool empty = scan_forward(open, close);
+						// Handle () and {} when they aren't a call/initializer
+						// [] may appear in lambdas when state == expecting_term
+						// [](){ ... }() is parsed fine because state == expecting_operator
+						// after the captures list. Not concerned with template parameters at
+						// the moment.
+						if (state == expecting_term && empty && normalize_brace(open) != "[") {
+							return true; // this is a failed parse tree
+						}
+						state = expecting_operator;
+					} else {
+						LIBASSERT_PRIMITIVE_DEBUG_ASSERT(false, "unhandled punctuation?");
+					}
+					break;
+				case token_e::keyword:
+				case token_e::named_literal:
+				case token_e::number:
+				case token_e::string:
+				case token_e::identifier:
+				case token_e::unknown:
+					state = expecting_operator;
+				case token_e::whitespace:
+					break;
+			}
+		}
+		if (
+			middle_index != -1 && normalize_op(get_real_op(tokens, middle_index)) == target_op
+			&& template_depth == 0 && state == expecting_operator
+		) {
+			output.insert(middle_index);
+		} else {
+			// failed parse tree, ignore
+		}
+		return true;
+	}
 
-        std::pair<std::string, std::string> decompose_expression(
-            std::string_view expression,
-            std::string_view target_op
-        ) {
-            // While automatic decomposition allows something like `assert(foo(n) == bar<n> + n);`
-            // treated as `assert_eq(foo(n), bar<n> + n);` we only get the full expression's string
-            // representation.
-            // Here we attempt to parse basic info for the raw string representation. Just enough to
-            // decomposition into left and right parts for diagnostic.
-            // Template parameters make C++ grammar ambiguous without type information. That being
-            // said, many expressions can be disambiguated.
-            // This code will make guesses about the grammar, essentially doing a traversal of all
-            // possibly parse trees and looking for ones that could work. This is O(2^t) with the
-            // where t is the number of potential templates. Usually t is small but this should
-            // perhaps be limited.
-            // Will return {"left", "right"} if unable to decompose unambiguously.
-            // Some cases to consider
-            //   tgt  expr
-            //   ==   a < 1 == 2 > ( 1 + 3 )
-            //   ==   a < 1 == 2 > - 3 == ( 1 + 3 )
-            //   ==   ( 1 + 3 ) == a < 1 == 2 > - 3 // <- ambiguous
-            //   ==   ( 1 + 3 ) == a < 1 == 2 > ()
-            //   <    a<x<x<x<x<x<x<x<x<x<1>>>>>>>>>
-            //   ==   1 == something<a == b>>2 // <- ambiguous
-            //   <    1 == something<a == b>>2 // <- should be an error
-            //   <    1 < something<a < b>>2 // <- ambiguous
-            // If there is only one candidate from the parse trees considered, expression has been
-            // disambiguated. If there are no candidates that's an error. If there is more than one
-            // candidate the expression may be ambiguous, but, not necessarily. For example,
-            // a < 1 == 2 > - 3 == ( 1 + 3 ) is split the same regardless of whether a < 1 == 2 > is
-            // treated as a template or not:
-            //   left:  a < 1 == 2 > - 3
-            //   right: ( 1 + 3 )
-            //   ---
-            //   left:  a < 1 == 2 > - 3
-            //   right: ( 1 + 3 )
-            //   ---
-            // Because we're just splitting an expression in half, instead of storing tokens for
-            // both sides we can just store an index of the split.
-            // Note: We don't need to worry about expressions where there is only a single term.
-            // This will only be called on decomposable expressions.
-            // Note: The >> to > > token breakdown needed in template parameter lists is done in the
-            // initial tokenization so we can pass the token vector by reference and avoid copying
-            // for every recursive path (O(t^2)). This does not create an issue for syntax
-            // highlighting as long as >> and > are highlighted the same.
-            const auto res = tokenize(expression, true);
-            if(!res) {
-                return { "left", "right" };
-            }
-            const auto& tokens = *res;
-            // We're only looking for the split, we can just store a set of split indices. No need
-            // to store a vector<pair<vector<token_t>, vector<token_t>>>
-            std::set<int> candidates;
-            const bool success = pseudoparse(tokens, target_op, 0, 0, 0, -1, 0, candidates);
-            #ifdef _0_DEBUG_ASSERT_DISAMBIGUATION
-             fprintf(stderr, "\n%d %d\n", (int)candidates.size(), success);
-             for(size_t m : candidates) {
-                 std::vector<std::string> left_strings;
-                 std::vector<std::string> right_strings;
-                 for(size_t i = 0; i < m; i++) left_strings.push_back(tokens[i].str);
-                 for(size_t i = m + 1; i < tokens.size(); i++) right_strings.push_back(tokens[i].str);
-                 fprintf(stderr, "left:  %s\n", libassert::detail::highlight(std::string(trim(join(left_strings, "")))).c_str());
-                 fprintf(stderr, "right: %s\n", libassert::detail::highlight(std::string(trim(join(right_strings, "")))).c_str());
-                 fprintf(stderr, "target_op: %s\n", target_op.data()); // should be null terminated
-                 fprintf(stderr, "---\n");
-             }
-            #endif
-            if(success && candidates.size() == 1) {
-                std::vector<std::string> left_strings;
-                std::vector<std::string> right_strings;
-                const size_t m = *candidates.begin();
-                for(size_t i = 0; i < m; i++) {
-                    left_strings.push_back(std::string(tokens[i].str));
-                }
-                // >> is decomposed and requires special handling (m will be the index of the first > token)
-                for(size_t i = m + 1 + (target_op == ">>" ? 1 : 0); i < tokens.size(); i++) {
-                    right_strings.push_back(std::string(tokens[i].str));
-                }
-                return {
-                    std::string(trim(join(left_strings, ""))),
-                    std::string(trim(join(right_strings, "")))
-                };
-            } else {
-                return { "left", "right" };
-            }
-        }
-    };
+	std::pair<std::string, std::string>
+	decompose_expression(std::string_view expression, std::string_view target_op) {
+		// While automatic decomposition allows something like `assert(foo(n) == bar<n> + n);`
+		// treated as `assert_eq(foo(n), bar<n> + n);` we only get the full expression's string
+		// representation.
+		// Here we attempt to parse basic info for the raw string representation. Just enough to
+		// decomposition into left and right parts for diagnostic.
+		// Template parameters make C++ grammar ambiguous without type information. That being
+		// said, many expressions can be disambiguated.
+		// This code will make guesses about the grammar, essentially doing a traversal of all
+		// possibly parse trees and looking for ones that could work. This is O(2^t) with the
+		// where t is the number of potential templates. Usually t is small but this should
+		// perhaps be limited.
+		// Will return {"left", "right"} if unable to decompose unambiguously.
+		// Some cases to consider
+		//   tgt  expr
+		//   ==   a < 1 == 2 > ( 1 + 3 )
+		//   ==   a < 1 == 2 > - 3 == ( 1 + 3 )
+		//   ==   ( 1 + 3 ) == a < 1 == 2 > - 3 // <- ambiguous
+		//   ==   ( 1 + 3 ) == a < 1 == 2 > ()
+		//   <    a<x<x<x<x<x<x<x<x<x<1>>>>>>>>>
+		//   ==   1 == something<a == b>>2 // <- ambiguous
+		//   <    1 == something<a == b>>2 // <- should be an error
+		//   <    1 < something<a < b>>2 // <- ambiguous
+		// If there is only one candidate from the parse trees considered, expression has been
+		// disambiguated. If there are no candidates that's an error. If there is more than one
+		// candidate the expression may be ambiguous, but, not necessarily. For example,
+		// a < 1 == 2 > - 3 == ( 1 + 3 ) is split the same regardless of whether a < 1 == 2 > is
+		// treated as a template or not:
+		//   left:  a < 1 == 2 > - 3
+		//   right: ( 1 + 3 )
+		//   ---
+		//   left:  a < 1 == 2 > - 3
+		//   right: ( 1 + 3 )
+		//   ---
+		// Because we're just splitting an expression in half, instead of storing tokens for
+		// both sides we can just store an index of the split.
+		// Note: We don't need to worry about expressions where there is only a single term.
+		// This will only be called on decomposable expressions.
+		// Note: The >> to > > token breakdown needed in template parameter lists is done in the
+		// initial tokenization so we can pass the token vector by reference and avoid copying
+		// for every recursive path (O(t^2)). This does not create an issue for syntax
+		// highlighting as long as >> and > are highlighted the same.
+		const auto res = tokenize(expression, true);
+		if (!res) {
+			return {"left", "right"};
+		}
+		const auto& tokens = *res;
+		// We're only looking for the split, we can just store a set of split indices. No need
+		// to store a vector<pair<vector<token_t>, vector<token_t>>>
+		std::set<int> candidates;
+		const bool success = pseudoparse(tokens, target_op, 0, 0, 0, -1, 0, candidates);
+#ifdef _0_DEBUG_ASSERT_DISAMBIGUATION
+		fprintf(stderr, "\n%d %d\n", (int)candidates.size(), success);
+		for (size_t m : candidates) {
+			std::vector<std::string> left_strings;
+			std::vector<std::string> right_strings;
+			for (size_t i = 0; i < m; i++)
+				left_strings.push_back(tokens[i].str);
+			for (size_t i = m + 1; i < tokens.size(); i++)
+				right_strings.push_back(tokens[i].str);
+			fprintf(
+				stderr,
+				"left:  %s\n",
+				libassert::detail::highlight(std::string(trim(join(left_strings, "")))).c_str()
+			);
+			fprintf(
+				stderr,
+				"right: %s\n",
+				libassert::detail::highlight(std::string(trim(join(right_strings, "")))).c_str()
+			);
+			fprintf(stderr, "target_op: %s\n", target_op.data()); // should be null terminated
+			fprintf(stderr, "---\n");
+		}
+#endif
+		if (success && candidates.size() == 1) {
+			std::vector<std::string> left_strings;
+			std::vector<std::string> right_strings;
+			const size_t m = *candidates.begin();
+			for (size_t i = 0; i < m; i++) {
+				left_strings.push_back(std::string(tokens[i].str));
+			}
+			// >> is decomposed and requires special handling (m will be the index of the first > token)
+			for (size_t i = m + 1 + (target_op == ">>" ? 1 : 0); i < tokens.size(); i++) {
+				right_strings.push_back(std::string(tokens[i].str));
+			}
+			return {
+				std::string(trim(join(left_strings, ""))),
+				std::string(trim(join(right_strings, "")))
+			};
+		} else {
+			return {"left", "right"};
+		}
+	}
+};
 
-    std::unique_ptr<analysis> analysis::analysis_singleton;
-    std::mutex analysis::singleton_mutex;
+std::unique_ptr<analysis> analysis::analysis_singleton;
+std::mutex analysis::singleton_mutex;
 
-    std::string highlight(std::string_view expression, const color_scheme& scheme) {
-        if(scheme == libassert::color_scheme::blank) {
-            return std::string(expression);
-        } else {
-            auto blocks = analysis::get().highlight(expression, scheme);
-            return combine_blocks(blocks, scheme);
-        }
-    }
-
-    std::string combine_blocks(const std::vector<highlight_block>& blocks, const color_scheme& scheme) {
-        std::string str;
-        for(auto& block : blocks) {
-            str += block.color;
-            str += block.content;
-            if(!block.color.empty()) {
-                str += scheme.reset;
-            }
-        }
-        return str;
-    }
-
-    std::size_t length(const std::vector<highlight_block>& blocks) {
-        std::size_t length = 0;
-        for(auto& block : blocks) {
-            length += block.content.size();
-        }
-        return length;
-    }
-
-    constexpr double diff_max_distance = 0.2;
-    constexpr double diff_min_limit = 5;
-
-    struct formatted_character {
-        std::string_view format;
-        char c;
-    };
-
-    std::vector<formatted_character> to_chars(std::vector<highlight_block> blocks) {
-        std::vector<formatted_character> chars;
-        for(auto& block : blocks) {
-            for(char c : block.content) {
-                chars.push_back({block.color, c});
-            }
-        }
-        return chars;
-    }
-
-    struct operation {
-        enum class type { Keep, Insert, Delete, Replace };
-        type action;
-        formatted_character ch;
-    };
-
-    struct diff_result {
-        std::vector<operation> operations;
-        int distance;
-    };
-
-    // Levenshtein diff
-    diff_result diff(const std::vector<formatted_character>& a, const std::vector<formatted_character>& b) {
-        std::size_t m = a.size();
-        std::size_t n = b.size();
-        std::vector<std::vector<int>> dp(m + 1, std::vector<int>(n + 1, 0));
-        // Levenshtein main-body
-        for(std::size_t i = 0; i <= m; i++) {
-            dp[i][0] = static_cast<int>(i);
-        }
-        for(std::size_t j = 0; j <= n; j++) {
-            dp[0][j] = static_cast<int>(j);
-        }
-        for(std::size_t i = 1; i <= m; i++) {
-            for(std::size_t j = 1; j <= n; j++) {
-                int cost = a[i - 1].c == b[j - 1].c ? 0 : 1;
-                dp[i][j] = std::min({
-                    dp[i - 1][j] + 1,       // delete
-                    dp[i][j - 1] + 1,       // insert
-                    dp[i - 1][j - 1] + cost // replace / keep
-                });
-            }
-        }
-        // Trace edits
-        std::vector<operation> ops;
-        std::size_t i = m;
-        std::size_t j = n;
-        while(i > 0 || j > 0) {
-            if(i > 0 && dp[i][j] == dp[i - 1][j] + 1) {
-                ops.push_back({ operation::type::Delete, a[i - 1] });
-                i--;
-            } else if(j > 0 && dp[i][j] == dp[i][j - 1] + 1) {
-                ops.push_back({ operation::type::Insert, b[j - 1] });
-                j--;
-            } else {
-                operation::type k = a[i - 1].c == b[j - 1].c ? operation::type::Keep : operation::type::Replace;
-                formatted_character c = k == operation::type::Keep ? a[i - 1] : b[j - 1];
-                ops.push_back({ k, c });
-                i--;
-                j--;
-            }
-        }
-        std::reverse(ops.begin(), ops.end());
-        return {ops, dp[m][n]};
-    }
-
-    bool should_show_diff(std::size_t a, std::size_t b, std::size_t distance) {
-        const auto max_len = std::max(a, b);
-        const auto limit = std::max(diff_min_limit, max_len * diff_max_distance);
-        return distance <= std::ceil(limit);
-    }
-
-    std::optional<std::vector<highlight_block>> diff(
-        std::vector<highlight_block> a,
-        std::vector<highlight_block> b,
-        const color_scheme& scheme
-    ) {
-        auto&& [ops, distance] = diff(to_chars(a), to_chars(b));
-        if(!should_show_diff(length(a), length(b), distance)) {
-            return std::nullopt;
-        }
-        std::vector<highlight_block> out;
-        for(const operation& op : ops) {
-            switch(op.action) {
-            case operation::type::Keep:
-                out.push_back({op.ch.format, std::string{op.ch.c}});
-                break;
-            case operation::type::Delete:
-                // pass, don't print deleted chars since they'll be on the other side
-                break;
-            case operation::type::Insert:
-                out.push_back({op.ch.format, scheme.highlight_insert, std::string{op.ch.c}});
-                break;
-            case operation::type::Replace:
-                out.push_back({op.ch.format, scheme.highlight_replace, std::string{op.ch.c}});
-                break;
-            default:
-                LIBASSERT_PRIMITIVE_PANIC("Unhandled diff operation");
-            }
-        }
-        return out;
-    }
-
-    std::vector<highlight_block> highlight_blocks(std::string_view expression, const color_scheme& scheme) {
-        // TODO: Maybe check scheme == libassert::color_scheme::blank here? Have to consult ramifications.
-        return analysis::get().highlight(expression, scheme);
-    }
-
-    literal_format get_literal_format(std::string_view expression) {
-        return analysis::get().get_literal_format(expression);
-    }
-
-    std::string_view trim_suffix(std::string_view expression) {
-        return expression.substr(0, expression.find_last_not_of("FfUuLlZz") + 1);
-    }
-
-    bool is_bitwise(std::string_view op) {
-        return analysis::get().bitwise_operators.count(op);
-    }
-
-    std::pair<std::string, std::string> decompose_expression(
-        std::string_view expression,
-        std::string_view target_op
-    ) {
-        return analysis::get().decompose_expression(expression, target_op);
-    }
+std::string highlight(std::string_view expression, const color_scheme& scheme) {
+	if (scheme == libassert::color_scheme::blank) {
+		return std::string(expression);
+	} else {
+		auto blocks = analysis::get().highlight(expression, scheme);
+		return combine_blocks(blocks, scheme);
+	}
 }
+
+std::string combine_blocks(const std::vector<highlight_block>& blocks, const color_scheme& scheme) {
+	std::string str;
+	for (auto& block : blocks) {
+		str += block.color;
+		str += block.content;
+		if (!block.color.empty()) {
+			str += scheme.reset;
+		}
+	}
+	return str;
+}
+
+std::size_t length(const std::vector<highlight_block>& blocks) {
+	std::size_t length = 0;
+	for (auto& block : blocks) {
+		length += block.content.size();
+	}
+	return length;
+}
+
+constexpr double diff_max_distance = 0.2;
+constexpr double diff_min_limit = 5;
+
+struct formatted_character {
+	std::string_view format;
+	char c;
+};
+
+std::vector<formatted_character> to_chars(std::vector<highlight_block> blocks) {
+	std::vector<formatted_character> chars;
+	for (auto& block : blocks) {
+		for (char c : block.content) {
+			chars.push_back({block.color, c});
+		}
+	}
+	return chars;
+}
+
+struct operation {
+	enum class type { Keep, Insert, Delete, Replace };
+	type action;
+	formatted_character ch;
+};
+
+struct diff_result {
+	std::vector<operation> operations;
+	int distance;
+};
+
+// Levenshtein diff
+diff_result
+diff(const std::vector<formatted_character>& a, const std::vector<formatted_character>& b) {
+	std::size_t m = a.size();
+	std::size_t n = b.size();
+	std::vector<std::vector<int>> dp(m + 1, std::vector<int>(n + 1, 0));
+	// Levenshtein main-body
+	for (std::size_t i = 0; i <= m; i++) {
+		dp[i][0] = static_cast<int>(i);
+	}
+	for (std::size_t j = 0; j <= n; j++) {
+		dp[0][j] = static_cast<int>(j);
+	}
+	for (std::size_t i = 1; i <= m; i++) {
+		for (std::size_t j = 1; j <= n; j++) {
+			int cost = a[i - 1].c == b[j - 1].c ? 0 : 1;
+			dp[i][j] = std::min({
+				dp[i - 1][j] + 1, // delete
+				dp[i][j - 1] + 1, // insert
+				dp[i - 1][j - 1] + cost // replace / keep
+			});
+		}
+	}
+	// Trace edits
+	std::vector<operation> ops;
+	std::size_t i = m;
+	std::size_t j = n;
+	while (i > 0 || j > 0) {
+		if (i > 0 && dp[i][j] == dp[i - 1][j] + 1) {
+			ops.push_back({operation::type::Delete, a[i - 1]});
+			i--;
+		} else if (j > 0 && dp[i][j] == dp[i][j - 1] + 1) {
+			ops.push_back({operation::type::Insert, b[j - 1]});
+			j--;
+		} else {
+			operation::type k =
+				a[i - 1].c == b[j - 1].c ? operation::type::Keep : operation::type::Replace;
+			formatted_character c = k == operation::type::Keep ? a[i - 1] : b[j - 1];
+			ops.push_back({k, c});
+			i--;
+			j--;
+		}
+	}
+	std::reverse(ops.begin(), ops.end());
+	return {ops, dp[m][n]};
+}
+
+bool should_show_diff(std::size_t a, std::size_t b, std::size_t distance) {
+	const auto max_len = std::max(a, b);
+	const auto limit = std::max(diff_min_limit, max_len * diff_max_distance);
+	return distance <= std::ceil(limit);
+}
+
+std::optional<std::vector<highlight_block>>
+diff(std::vector<highlight_block> a, std::vector<highlight_block> b, const color_scheme& scheme) {
+	auto&& [ops, distance] = diff(to_chars(a), to_chars(b));
+	if (!should_show_diff(length(a), length(b), distance)) {
+		return std::nullopt;
+	}
+	std::vector<highlight_block> out;
+	for (const operation& op : ops) {
+		switch (op.action) {
+			case operation::type::Keep:
+				out.push_back({op.ch.format, std::string {op.ch.c}});
+				break;
+			case operation::type::Delete:
+				// pass, don't print deleted chars since they'll be on the other side
+				break;
+			case operation::type::Insert:
+				out.push_back({op.ch.format, scheme.highlight_insert, std::string {op.ch.c}});
+				break;
+			case operation::type::Replace:
+				out.push_back({op.ch.format, scheme.highlight_replace, std::string {op.ch.c}});
+				break;
+			default:
+				LIBASSERT_PRIMITIVE_PANIC("Unhandled diff operation");
+		}
+	}
+	return out;
+}
+
+std::vector<highlight_block>
+highlight_blocks(std::string_view expression, const color_scheme& scheme) {
+	// TODO: Maybe check scheme == libassert::color_scheme::blank here? Have to consult ramifications.
+	return analysis::get().highlight(expression, scheme);
+}
+
+literal_format get_literal_format(std::string_view expression) {
+	return analysis::get().get_literal_format(expression);
+}
+
+std::string_view trim_suffix(std::string_view expression) {
+	return expression.substr(0, expression.find_last_not_of("FfUuLlZz") + 1);
+}
+
+bool is_bitwise(std::string_view op) {
+	return analysis::get().bitwise_operators.count(op);
+}
+
+std::pair<std::string, std::string>
+decompose_expression(std::string_view expression, std::string_view target_op) {
+	return analysis::get().decompose_expression(expression, target_op);
+}
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE

--- a/src/analysis.hpp
+++ b/src/analysis.hpp
@@ -8,40 +8,44 @@
 #include <libassert/assert.hpp>
 
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    struct highlight_block {
-        std::string_view color; // text color
-        std::string_view highlight; // used for the diff highlight
-        std::string content;
-        highlight_block(std::string_view color_, std::string_view content_) : color(color_), content(content_) {}
-        highlight_block(
-            std::string_view color_,
-            std::string_view highlight_,
-            std::string_view content_
-        ) : color(color_), highlight(highlight_), content(content_) {}
-    };
+struct highlight_block {
+	std::string_view color; // text color
+	std::string_view highlight; // used for the diff highlight
+	std::string content;
 
-    LIBASSERT_EXPORT /* FIXME */
-    std::string highlight(std::string_view expression, const color_scheme& scheme);
+	highlight_block(std::string_view color_, std::string_view content_) :
+		color(color_),
+		content(content_) {}
 
-    std::vector<highlight_block> highlight_blocks(std::string_view expression, const color_scheme& scheme);
+	highlight_block(std::string_view color_, std::string_view highlight_, std::string_view content_) :
+		color(color_),
+		highlight(highlight_),
+		content(content_) {}
+};
 
-    std::string combine_blocks(const std::vector<highlight_block>& blocks, const color_scheme& scheme);
+LIBASSERT_EXPORT /* FIXME */
+	std::string
+	highlight(std::string_view expression, const color_scheme& scheme);
 
-    std::size_t length(const std::vector<highlight_block>& blocks);
+std::vector<highlight_block>
+highlight_blocks(std::string_view expression, const color_scheme& scheme);
 
-    std::optional<std::vector<highlight_block>> diff(
-        std::vector<highlight_block> a,
-        std::vector<highlight_block> b,
-        const color_scheme& scheme
-    );
+std::string combine_blocks(const std::vector<highlight_block>& blocks, const color_scheme& scheme);
 
-    literal_format get_literal_format(std::string_view expression);
+std::size_t length(const std::vector<highlight_block>& blocks);
 
-    std::string_view trim_suffix(std::string_view expression);
+std::optional<std::vector<highlight_block>>
+diff(std::vector<highlight_block> a, std::vector<highlight_block> b, const color_scheme& scheme);
 
-    bool is_bitwise(std::string_view op);
-}
+literal_format get_literal_format(std::string_view expression);
+
+std::string_view trim_suffix(std::string_view expression);
+
+bool is_bitwise(std::string_view op);
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE
 
 #endif

--- a/src/assert.cpp
+++ b/src/assert.cpp
@@ -5,9 +5,9 @@
 
 #include <algorithm>
 #include <atomic>
-#include <cstddef>
 #include <cerrno>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -16,8 +16,8 @@
 #include <memory>
 #include <mutex>
 #include <regex>
-#include <string_view>
 #include <string>
+#include <string_view>
 #include <system_error>
 #include <tuple>
 #include <type_traits>
@@ -27,23 +27,23 @@
 #include <vector>
 
 #if defined(__has_include) && __has_include(<cpptrace/basic.hpp>)
- #include <cpptrace/basic.hpp>
- #include <cpptrace/exceptions.hpp>
+	#include <cpptrace/basic.hpp>
+	#include <cpptrace/exceptions.hpp>
 #else
- #include <cpptrace/cpptrace.hpp>
+	#include <cpptrace/cpptrace.hpp>
 #endif
 
-#include "common.hpp"
-#include "utils.hpp"
-#include "microfmt.hpp"
 #include "analysis.hpp"
-#include "platform.hpp"
+#include "common.hpp"
+#include "microfmt.hpp"
 #include "paths.hpp"
+#include "platform.hpp"
 #include "printing.hpp"
+#include "utils.hpp"
 
 #if LIBASSERT_IS_MSVC
- // wchar -> char string warning
- #pragma warning(disable : 4244)
+	// wchar -> char string warning
+	#pragma warning(disable : 4244)
 #endif
 
 using namespace std::string_literals;
@@ -52,686 +52,695 @@ using namespace std::string_view_literals;
 #define STR_(x) #x
 #define STR(x) STR_(x)
 
-
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    /*
+/*
     * stack trace printing
     */
 
-    constexpr std::string_view libassert_detail_prefix = "libassert::" STR(LIBASSERT_ABI_NAMESPACE_TAG) "::detail::";
+constexpr std::string_view libassert_detail_prefix =
+	"libassert::" STR(LIBASSERT_ABI_NAMESPACE_TAG) "::detail::";
 
-    auto get_trace_window(const cpptrace::stacktrace& trace) {
-        // Two boundaries: assert_detail and main
-        // Both are found here, nothing is filtered currently at stack trace generation
-        // (inlining and platform idiosyncrasies interfere)
-        size_t start = 0;
-        size_t end = trace.frames.size() - 1;
-        for(size_t i = 0; i < trace.frames.size(); i++) {
-            if(trace.frames[i].symbol.find(libassert_detail_prefix) != std::string::npos) {
-                start = i + 1;
-            }
-            if(trace.frames[i].symbol == "main" || trace.frames[i].symbol.find("main(") == 0) {
-                end = i;
-            }
-        }
-        return std::pair(start, end);
-    }
-
-    struct stacktrace_result {
-        std::string printed;
-    };
-
-    [[nodiscard]]
-    // TODO
-    // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-    std::string print_stacktrace(
-        const cpptrace::stacktrace& trace,
-        int term_width,
-        const color_scheme& scheme,
-        path_handler* path_handler
-    ) {
-        if(trace.empty()) {
-            return "Empty stacktrace.\n";
-        }
-        // [start, end] is an inclusive range
-        auto [start, end] = get_trace_window(trace);
-        // path preprocessing
-        constexpr size_t hard_max_file_length = 50;
-        size_t max_file_length = 0;
-        for(std::size_t i = start; i <= end; i++) {
-            max_file_length = std::max(
-                path_handler->resolve_path(trace.frames[i].filename).size(),
-                max_file_length
-            );
-        }
-        max_file_length = std::min(max_file_length, hard_max_file_length);
-        // figure out column widths
-        const auto max_line_number =
-            std::max_element(
-                // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-                trace.begin() + start,
-                // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-                trace.begin() + end + 1,
-                [](const cpptrace::stacktrace_frame& a, const cpptrace::stacktrace_frame& b) {
-                    return a.line.value_or(0) < b.line.value_or(0);
-                }
-            )->line;
-        const size_t max_line_number_width = n_digits(max_line_number.value_or(0));
-        const size_t max_frame_width = n_digits(end - start);
-        // do the actual trace printing
-        std::string stacktrace;
-        for(size_t i = start; i <= end; i++) {
-            const auto& [raw_address, obj_address, line, col, source_path, signature_, is_inline] = trace.frames[i];
-            const std::string line_number = line.has_value() ? std::to_string(line.value()) : "?";
-            // look for repeats, i.e. recursion we can fold
-            size_t recursion_folded = 0;
-            if(end - i >= 4) {
-                size_t j = 1;
-                for( ; i + j <= end; j++) {
-                    if(trace.frames[i + j] != trace.frames[i] || trace.frames[i + j].symbol == "??") {
-                        break;
-                    }
-                }
-                if(j >= 4) {
-                    recursion_folded = j - 2;
-                }
-            }
-            const size_t frame_number = i - start + 1;
-            auto signature = prettify_type(signature_);
-            // pretty print with columns for wide terminals
-            // split printing for small terminals
-            if(term_width >= 50) {
-                auto sig = highlight_blocks(signature + "(", scheme); // hack for the highlighter
-                sig.pop_back();
-                const size_t left = 1 + max_frame_width;
-                // todo: is this looking right...?
-                const size_t line_number_width = std::max(line_number.size(), max_line_number_width);
-                const size_t remaining_width = term_width - (left + line_number_width + 2 /* spaces */ + 1 /* : */);
-                const size_t file_width = std::min({max_file_length, remaining_width / 2, max_file_length});
-                LIBASSERT_PRIMITIVE_DEBUG_ASSERT(remaining_width >= 2);
-                const size_t sig_width = remaining_width - file_width;
-                std::vector<highlight_block> location_blocks = concat(
-                    {{"", std::string(path_handler->resolve_path(source_path)) + ":"}},
-                    highlight_blocks(line_number, scheme)
-                );
-                stacktrace += wrapped_print(
-                    {
-                        { left, {{"", "#"}, {scheme.number, std::to_string(frame_number)}}, true },
-                        { file_width + 1 + line_number_width, location_blocks },
-                        { sig_width, sig }
-                    },
-                    scheme
-                );
-            } else {
-                auto sig = detail::highlight(signature + "(", scheme); // hack for the highlighter
-                sig = sig.substr(0, sig.rfind('('));
-                stacktrace += microfmt::format(
-                    "#{}{>2}{} {}\n      at {}:{}{}{}\n",
-                    scheme.number,
-                    frame_number,
-                    scheme.reset,
-                    sig,
-                    path_handler->resolve_path(source_path),
-                    scheme.number,
-                    line_number,
-                    scheme.reset // yes this is excessive; intentionally coloring "?"
-                );
-            }
-            if(recursion_folded) {
-                i += recursion_folded;
-                const std::string s = microfmt::format("| {} layers of recursion were folded |", recursion_folded);
-                stacktrace += microfmt::format("{}|{<{}}|{}\n", scheme.accent, s.size() - 2, "", scheme.reset);
-                stacktrace += microfmt::format("{}{}{}\n", scheme.accent, s, scheme.reset);
-                stacktrace += microfmt::format("{}|{<{}}|{}\n", scheme.accent, s.size() - 2, "", scheme.reset);
-            }
-        }
-        return stacktrace;
-    }
-
-    constexpr int min_term_width = 50;
-    constexpr size_t where_indent = 8;
-    std::string arrow = "=>";
-    std::atomic_bool do_diff_highlighting = false;
-
-    [[nodiscard]]
-    std::string print_binary_diagnostics(
-        const binary_diagnostics_descriptor& diagnostics,
-        size_t term_width,
-        const color_scheme& scheme
-    ) {
-        auto& [
-            left_expression,
-            right_expression,
-            left_stringification,
-            right_stringification,
-            multiple_formats
-        ] = diagnostics;
-        // determine whether we actually gain anything from printing a where clause (e.g. exclude "1 => 1")
-        const struct { bool left, right; } has_useful_where_clause = {
-            multiple_formats
-                || (left_expression != left_stringification && trim_suffix(left_expression) != left_stringification),
-            multiple_formats
-                || (right_expression != right_stringification && trim_suffix(right_expression) != right_stringification)
-        };
-        // print where clause
-        std::string where;
-        if(has_useful_where_clause.left || has_useful_where_clause.right) {
-            size_t lw = std::max(
-                has_useful_where_clause.left  ? left_expression.size() : 0,
-                has_useful_where_clause.right ? right_expression.size() : 0
-            );
-            // Limit lw to about half the screen. TODO: Re-evaluate what we want to do here.
-            if(term_width > 0) {
-                lw = std::min(lw, term_width / 2 - where_indent - (arrow.size() + 2));
-            }
-            where += "    Where:\n";
-            auto print_clause = [term_width, lw, &where, &scheme](
-                std::string_view expr_str,
-                std::string_view stringification,
-                std::optional<std::string_view> diff_against
-            ) {
-                auto highlighted = highlight_blocks(stringification, scheme);
-                if(do_diff_highlighting && diff_against) {
-                    // TODO: Redundant highlight
-                    if(auto res = diff(highlight_blocks(*diff_against, scheme), highlighted, scheme)) {
-                        highlighted = *std::move(res);
-                    }
-                }
-                if(term_width >= min_term_width) {
-                    where += wrapped_print(
-                        {
-                            { where_indent - 1, {{"", ""}} }, // 8 space indent, wrapper will add a space
-                            { lw, highlight_blocks(expr_str, scheme) },
-                            { arrow.size(), {{"", arrow}} },
-                            { term_width - lw - 8 /* indent */ - 4 /* arrow */, highlighted }
-                        },
-                        scheme
-                    );
-                } else {
-                    where += microfmt::format(
-                        "        {}{<{}} {} ",
-                        detail::highlight(expr_str, scheme),
-                        lw - expr_str.size(),
-                        "",
-                        arrow
-                    );
-                    where += microfmt::format(
-                        "{}\n",
-                        indent(detail::combine_blocks(highlighted, scheme), 8 + lw + 4, ' ', true)
-                    );
-                }
-            };
-            auto left =
-                has_useful_where_clause.left ? std::optional<std::string_view>(left_stringification) : std::nullopt;
-            auto right =
-                has_useful_where_clause.right ? std::optional<std::string_view>(right_stringification) : std::nullopt;
-            if(left) {
-                print_clause(left_expression, *left, right);
-            }
-            if(right) {
-                print_clause(right_expression, *right, left);
-            }
-        }
-        return where;
-    }
-
-    [[nodiscard]]
-    std::string print_extra_diagnostics(
-        const std::vector<extra_diagnostic>& extra_diagnostics,
-        size_t term_width,
-        const color_scheme& scheme
-    ) {
-        std::string output = "    Extra diagnostics:\n";
-        size_t lw = 0;
-        for(const auto& entry : extra_diagnostics) {
-            lw = std::max(lw, entry.expression.size());
-        }
-        for(const auto& entry : extra_diagnostics) {
-            if(term_width >= min_term_width) {
-                output += wrapped_print(
-                    {
-                        { 7, {{"", ""}} }, // 8 space indent, wrapper will add a space
-                        { lw, highlight_blocks(entry.expression, scheme) },
-                        { arrow.size(), {{"", arrow}} },
-                        { term_width - lw - 8 /* indent */ - 4 /* arrow */, highlight_blocks(entry.stringification, scheme) }
-                    },
-                    scheme
-                );
-            } else {
-                output += microfmt::format(
-                    "        {}{<{}} {} {}\n",
-                    detail::highlight(entry.expression, scheme),
-                    lw - entry.expression.length(),
-                    "",
-                    arrow,
-                    indent(
-                        detail::highlight(entry.stringification, scheme),
-                        8 + lw + 4,
-                        ' ',
-                        true
-                    )
-                );
-            }
-        }
-        return output;
-    }
+auto get_trace_window(const cpptrace::stacktrace& trace) {
+	// Two boundaries: assert_detail and main
+	// Both are found here, nothing is filtered currently at stack trace generation
+	// (inlining and platform idiosyncrasies interfere)
+	size_t start = 0;
+	size_t end = trace.frames.size() - 1;
+	for (size_t i = 0; i < trace.frames.size(); i++) {
+		if (trace.frames[i].symbol.find(libassert_detail_prefix) != std::string::npos) {
+			start = i + 1;
+		}
+		if (trace.frames[i].symbol == "main" || trace.frames[i].symbol.find("main(") == 0) {
+			end = i;
+		}
+	}
+	return std::pair(start, end);
 }
+
+struct stacktrace_result {
+	std::string printed;
+};
+
+[[nodiscard]]
+// TODO
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+std::string print_stacktrace(
+	const cpptrace::stacktrace& trace,
+	int term_width,
+	const color_scheme& scheme,
+	path_handler* path_handler
+) {
+	if (trace.empty()) {
+		return "Empty stacktrace.\n";
+	}
+	// [start, end] is an inclusive range
+	auto [start, end] = get_trace_window(trace);
+	// path preprocessing
+	constexpr size_t hard_max_file_length = 50;
+	size_t max_file_length = 0;
+	for (std::size_t i = start; i <= end; i++) {
+		max_file_length =
+			std::max(path_handler->resolve_path(trace.frames[i].filename).size(), max_file_length);
+	}
+	max_file_length = std::min(max_file_length, hard_max_file_length);
+	// figure out column widths
+	const auto max_line_number =
+		std::max_element(
+			// NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+			trace.begin() + start,
+			// NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+			trace.begin() + end + 1,
+			[](const cpptrace::stacktrace_frame& a, const cpptrace::stacktrace_frame& b) {
+				return a.line.value_or(0) < b.line.value_or(0);
+			}
+		)->line;
+	const size_t max_line_number_width = n_digits(max_line_number.value_or(0));
+	const size_t max_frame_width = n_digits(end - start);
+	// do the actual trace printing
+	std::string stacktrace;
+	for (size_t i = start; i <= end; i++) {
+		const auto& [raw_address, obj_address, line, col, source_path, signature_, is_inline] =
+			trace.frames[i];
+		const std::string line_number = line.has_value() ? std::to_string(line.value()) : "?";
+		// look for repeats, i.e. recursion we can fold
+		size_t recursion_folded = 0;
+		if (end - i >= 4) {
+			size_t j = 1;
+			for (; i + j <= end; j++) {
+				if (trace.frames[i + j] != trace.frames[i] || trace.frames[i + j].symbol == "??") {
+					break;
+				}
+			}
+			if (j >= 4) {
+				recursion_folded = j - 2;
+			}
+		}
+		const size_t frame_number = i - start + 1;
+		auto signature = prettify_type(signature_);
+		// pretty print with columns for wide terminals
+		// split printing for small terminals
+		if (term_width >= 50) {
+			auto sig = highlight_blocks(signature + "(", scheme); // hack for the highlighter
+			sig.pop_back();
+			const size_t left = 1 + max_frame_width;
+			// todo: is this looking right...?
+			const size_t line_number_width = std::max(line_number.size(), max_line_number_width);
+			const size_t remaining_width =
+				term_width - (left + line_number_width + 2 /* spaces */ + 1 /* : */);
+			const size_t file_width = std::min({max_file_length, remaining_width / 2, max_file_length});
+			LIBASSERT_PRIMITIVE_DEBUG_ASSERT(remaining_width >= 2);
+			const size_t sig_width = remaining_width - file_width;
+			std::vector<highlight_block> location_blocks = concat(
+				{{"", std::string(path_handler->resolve_path(source_path)) + ":"}},
+				highlight_blocks(line_number, scheme)
+			);
+			stacktrace += wrapped_print(
+				{{left, {{"", "#"}, {scheme.number, std::to_string(frame_number)}}, true},
+				 {file_width + 1 + line_number_width, location_blocks},
+				 {sig_width, sig}},
+				scheme
+			);
+		} else {
+			auto sig = detail::highlight(signature + "(", scheme); // hack for the highlighter
+			sig = sig.substr(0, sig.rfind('('));
+			stacktrace += microfmt::format(
+				"#{}{>2}{} {}\n      at {}:{}{}{}\n",
+				scheme.number,
+				frame_number,
+				scheme.reset,
+				sig,
+				path_handler->resolve_path(source_path),
+				scheme.number,
+				line_number,
+				scheme.reset // yes this is excessive; intentionally coloring "?"
+			);
+		}
+		if (recursion_folded) {
+			i += recursion_folded;
+			const std::string s =
+				microfmt::format("| {} layers of recursion were folded |", recursion_folded);
+			stacktrace +=
+				microfmt::format("{}|{<{}}|{}\n", scheme.accent, s.size() - 2, "", scheme.reset);
+			stacktrace += microfmt::format("{}{}{}\n", scheme.accent, s, scheme.reset);
+			stacktrace +=
+				microfmt::format("{}|{<{}}|{}\n", scheme.accent, s.size() - 2, "", scheme.reset);
+		}
+	}
+	return stacktrace;
+}
+
+constexpr int min_term_width = 50;
+constexpr size_t where_indent = 8;
+std::string arrow = "=>";
+std::atomic_bool do_diff_highlighting = false;
+
+[[nodiscard]]
+std::string print_binary_diagnostics(
+	const binary_diagnostics_descriptor& diagnostics,
+	size_t term_width,
+	const color_scheme& scheme
+) {
+	auto& [left_expression, right_expression, left_stringification, right_stringification, multiple_formats] =
+		diagnostics;
+
+	// determine whether we actually gain anything from printing a where clause (e.g. exclude "1 => 1")
+	const struct {
+		bool left, right;
+	} has_useful_where_clause = {
+		multiple_formats
+			|| (left_expression != left_stringification && trim_suffix(left_expression) != left_stringification),
+		multiple_formats
+			|| (right_expression != right_stringification && trim_suffix(right_expression) != right_stringification)
+	};
+
+	// print where clause
+	std::string where;
+	if (has_useful_where_clause.left || has_useful_where_clause.right) {
+		size_t lw = std::max(
+			has_useful_where_clause.left ? left_expression.size() : 0,
+			has_useful_where_clause.right ? right_expression.size() : 0
+		);
+		// Limit lw to about half the screen. TODO: Re-evaluate what we want to do here.
+		if (term_width > 0) {
+			lw = std::min(lw, term_width / 2 - where_indent - (arrow.size() + 2));
+		}
+		where += "    Where:\n";
+		auto print_clause = [term_width, lw, &where, &scheme](
+													std::string_view expr_str,
+													std::string_view stringification,
+													std::optional<std::string_view> diff_against
+												) {
+			auto highlighted = highlight_blocks(stringification, scheme);
+			if (do_diff_highlighting && diff_against) {
+				// TODO: Redundant highlight
+				if (auto res = diff(highlight_blocks(*diff_against, scheme), highlighted, scheme)) {
+					highlighted = *std::move(res);
+				}
+			}
+			if (term_width >= min_term_width) {
+				where += wrapped_print(
+					{{where_indent - 1, {{"", ""}}}, // 8 space indent, wrapper will add a space
+					 {lw, highlight_blocks(expr_str, scheme)},
+					 {arrow.size(), {{"", arrow}}},
+					 {term_width - lw - 8 /* indent */ - 4 /* arrow */, highlighted}},
+					scheme
+				);
+			} else {
+				where += microfmt::format(
+					"        {}{<{}} {} ",
+					detail::highlight(expr_str, scheme),
+					lw - expr_str.size(),
+					"",
+					arrow
+				);
+				where += microfmt::format(
+					"{}\n",
+					indent(detail::combine_blocks(highlighted, scheme), 8 + lw + 4, ' ', true)
+				);
+			}
+		};
+		auto left = has_useful_where_clause.left ? std::optional<std::string_view>(left_stringification)
+																						 : std::nullopt;
+		auto right = has_useful_where_clause.right
+			? std::optional<std::string_view>(right_stringification)
+			: std::nullopt;
+		if (left) {
+			print_clause(left_expression, *left, right);
+		}
+		if (right) {
+			print_clause(right_expression, *right, left);
+		}
+	}
+	return where;
+}
+
+[[nodiscard]]
+std::string print_extra_diagnostics(
+	const std::vector<extra_diagnostic>& extra_diagnostics,
+	size_t term_width,
+	const color_scheme& scheme
+) {
+	std::string output = "    Extra diagnostics:\n";
+	size_t lw = 0;
+	for (const auto& entry : extra_diagnostics) {
+		lw = std::max(lw, entry.expression.size());
+	}
+	for (const auto& entry : extra_diagnostics) {
+		if (term_width >= min_term_width) {
+			output += wrapped_print(
+				{{7, {{"", ""}}}, // 8 space indent, wrapper will add a space
+				 {lw, highlight_blocks(entry.expression, scheme)},
+				 {arrow.size(), {{"", arrow}}},
+				 {term_width - lw - 8 /* indent */ - 4 /* arrow */,
+					highlight_blocks(entry.stringification, scheme)}},
+				scheme
+			);
+		} else {
+			output += microfmt::format(
+				"        {}{<{}} {} {}\n",
+				detail::highlight(entry.expression, scheme),
+				lw - entry.expression.length(),
+				"",
+				arrow,
+				indent(detail::highlight(entry.stringification, scheme), 8 + lw + 4, ' ', true)
+			);
+		}
+	}
+	return output;
+}
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE
 
 LIBASSERT_BEGIN_NAMESPACE
-    LIBASSERT_EXPORT const color_scheme color_scheme::ansi_basic {
-        BASIC_GREEN, /* string */
-        BASIC_BLUE, /* escape */
-        BASIC_PURPL, /* keyword */
-        BASIC_ORANGE, /* named_literal */
-        BASIC_CYAN, /* number */
-        "",
-        BASIC_PURPL, /* operator */
-        BASIC_BLUE, /* call_identifier */
-        BASIC_BLUE, /* scope_resolution_identifier */
-        BASIC_BLUE, /* identifier */
-        BASIC_BLUE, /* accent */
-        BASIC_RED, /* unknown */
-        BASIC_HIGHLIGHT_RED, /* highlight delete */
-        BASIC_HIGHLIGHT_GREEN, /* highlight insert */
-        BASIC_HIGHLIGHT_YELLOW, /* highlight replace */
-        RESET
-    };
+LIBASSERT_EXPORT const color_scheme color_scheme::ansi_basic {
+	BASIC_GREEN, /* string */
+	BASIC_BLUE, /* escape */
+	BASIC_PURPL, /* keyword */
+	BASIC_ORANGE, /* named_literal */
+	BASIC_CYAN, /* number */
+	"",
+	BASIC_PURPL, /* operator */
+	BASIC_BLUE, /* call_identifier */
+	BASIC_BLUE, /* scope_resolution_identifier */
+	BASIC_BLUE, /* identifier */
+	BASIC_BLUE, /* accent */
+	BASIC_RED, /* unknown */
+	BASIC_HIGHLIGHT_RED, /* highlight delete */
+	BASIC_HIGHLIGHT_GREEN, /* highlight insert */
+	BASIC_HIGHLIGHT_YELLOW, /* highlight replace */
+	RESET
+};
 
-    LIBASSERT_EXPORT const color_scheme color_scheme::ansi_rgb {
-        RGB_GREEN, /* string */
-        RGB_BLUE, /* escape */
-        RGB_PURPL, /* keyword */
-        RGB_ORANGE, /* named_literal */
-        RGB_CYAN, /* number */
-        "",
-        RGB_PURPL, /* operator */
-        RGB_BLUE, /* call_identifier */
-        RGB_YELLOW, /* scope_resolution_identifier */
-        RGB_BLUE, /* identifier */
-        RGB_BLUE, /* accent */
-        RGB_RED, /* unknown */
-        BASIC_HIGHLIGHT_RED, /* highlight delete */
-        BASIC_HIGHLIGHT_GREEN, /* highlight insert */
-        BASIC_HIGHLIGHT_YELLOW, /* highlight replace */
-        RESET
-    };
+LIBASSERT_EXPORT const color_scheme color_scheme::ansi_rgb {
+	RGB_GREEN, /* string */
+	RGB_BLUE, /* escape */
+	RGB_PURPL, /* keyword */
+	RGB_ORANGE, /* named_literal */
+	RGB_CYAN, /* number */
+	"",
+	RGB_PURPL, /* operator */
+	RGB_BLUE, /* call_identifier */
+	RGB_YELLOW, /* scope_resolution_identifier */
+	RGB_BLUE, /* identifier */
+	RGB_BLUE, /* accent */
+	RGB_RED, /* unknown */
+	BASIC_HIGHLIGHT_RED, /* highlight delete */
+	BASIC_HIGHLIGHT_GREEN, /* highlight insert */
+	BASIC_HIGHLIGHT_YELLOW, /* highlight replace */
+	RESET
+};
 
-    LIBASSERT_EXPORT const color_scheme color_scheme::blank;
+LIBASSERT_EXPORT const color_scheme color_scheme::blank;
 
-    std::mutex color_scheme_mutex;
-    color_scheme current_color_scheme = color_scheme::ansi_rgb;
+std::mutex color_scheme_mutex;
+color_scheme current_color_scheme = color_scheme::ansi_rgb;
 
-    LIBASSERT_EXPORT void set_color_scheme(const color_scheme& scheme) {
-        std::unique_lock lock(color_scheme_mutex);
-        current_color_scheme = scheme;
-    }
+LIBASSERT_EXPORT void set_color_scheme(const color_scheme& scheme) {
+	std::unique_lock lock(color_scheme_mutex);
+	current_color_scheme = scheme;
+}
 
-    LIBASSERT_EXPORT const color_scheme& get_color_scheme() {
-        std::unique_lock lock(color_scheme_mutex);
-        return current_color_scheme;
-    }
+LIBASSERT_EXPORT const color_scheme& get_color_scheme() {
+	std::unique_lock lock(color_scheme_mutex);
+	return current_color_scheme;
+}
 
-    void set_diff_highlighting(bool dff) {
-        detail::do_diff_highlighting = dff;
-    }
+void set_diff_highlighting(bool dff) {
+	detail::do_diff_highlighting = dff;
+}
 
-    LIBASSERT_EXPORT void set_separator(std::string_view separator) {
-        detail::arrow = separator;
-    }
+LIBASSERT_EXPORT void set_separator(std::string_view separator) {
+	detail::arrow = separator;
+}
 
-    [[nodiscard]] std::string highlight(std::string_view expression, const color_scheme& scheme) {
-        return detail::highlight(expression, scheme);
-    }
+[[nodiscard]] std::string highlight(std::string_view expression, const color_scheme& scheme) {
+	return detail::highlight(expression, scheme);
+}
 
-    std::atomic<path_mode> current_path_mode = path_mode::disambiguated;
+std::atomic<path_mode> current_path_mode = path_mode::disambiguated;
 
-    LIBASSERT_EXPORT void set_path_mode(path_mode mode) {
-        current_path_mode = mode;
-    }
+LIBASSERT_EXPORT void set_path_mode(path_mode mode) {
+	current_path_mode = mode;
+}
 
-    path_mode get_path_mode() {
-        return current_path_mode;
-    }
+path_mode get_path_mode() {
+	return current_path_mode;
+}
 
-    namespace detail {
-        std::unique_ptr<detail::path_handler> new_path_handler(path_mode mode = get_path_mode()) {
-            switch(mode) {
-                case path_mode::disambiguated:
-                    return std::make_unique<disambiguating_path_handler>();
-                case path_mode::basename:
-                    return std::make_unique<basename_path_handler>();
-                case path_mode::full:
-                default:
-                    return std::make_unique<identity_path_handler>();
-            }
-        }
-    }
+namespace detail {
+std::unique_ptr<detail::path_handler> new_path_handler(path_mode mode = get_path_mode()) {
+	switch (mode) {
+		case path_mode::disambiguated:
+			return std::make_unique<disambiguating_path_handler>();
+		case path_mode::basename:
+			return std::make_unique<basename_path_handler>();
+		case path_mode::full:
+		default:
+			return std::make_unique<identity_path_handler>();
+	}
+}
+} // namespace detail
 
-    [[noreturn]] LIBASSERT_EXPORT
-    void default_failure_handler(const assertion_info& info) {
-        enable_virtual_terminal_processing_if_needed(); // for terminal colors on windows
-        std::string message = info.to_string(
-            terminal_width(STDERR_FILENO),
-            isatty(STDERR_FILENO) ? get_color_scheme() : color_scheme::blank
-        );
-        std::cerr << message << std::endl;
-        switch(info.type) {
-            case assert_type::assertion:
-            case assert_type::debug_assertion:
-            case assert_type::assumption:
-            case assert_type::panic:
-            case assert_type::unreachable:
-                (void)fflush(stderr);
-                std::abort();
-                // Breaking here as debug CRT allows aborts to be ignored, if someone wants to make a debug build of
-                // this library
-                break;
-            default:
-                LIBASSERT_PRIMITIVE_PANIC("Unknown assertion type in assertion failure handler");
-        }
-    }
+[[noreturn]] LIBASSERT_EXPORT void default_failure_handler(const assertion_info& info) {
+	enable_virtual_terminal_processing_if_needed(); // for terminal colors on windows
+	std::string message = info.to_string(
+		terminal_width(STDERR_FILENO),
+		isatty(STDERR_FILENO) ? get_color_scheme() : color_scheme::blank
+	);
+	std::cerr << message << std::endl;
+	switch (info.type) {
+		case assert_type::assertion:
+		case assert_type::debug_assertion:
+		case assert_type::assumption:
+		case assert_type::panic:
+		case assert_type::unreachable:
+			(void)fflush(stderr);
+			std::terminate();
+			// Breaking here as debug CRT allows aborts to be ignored, if someone wants to make a debug build of
+			// this library
+			break;
+		default:
+			LIBASSERT_PRIMITIVE_PANIC("Unknown assertion type in assertion failure handler");
+	}
+}
 
-    namespace detail {
-        auto& get_failure_handler() {
-            static std::atomic handler = default_failure_handler;
-            return handler;
-        }
-    }
+namespace detail {
+auto& get_failure_handler() {
+	static std::atomic handler = default_failure_handler;
+	return handler;
+}
+} // namespace detail
 
-    LIBASSERT_EXPORT
-    handler_ptr get_failure_handler() {
-        return detail::get_failure_handler();
-    }
+LIBASSERT_EXPORT
+handler_ptr get_failure_handler() {
+	return detail::get_failure_handler();
+}
 
-    LIBASSERT_EXPORT
-    void set_failure_handler(handler_ptr handler) {
-        detail::get_failure_handler() = handler;
-    }
+LIBASSERT_EXPORT
+void set_failure_handler(handler_ptr handler) {
+	detail::get_failure_handler() = handler;
+}
 
-    namespace detail {
-        LIBASSERT_EXPORT void fail(const assertion_info& info) {
-            detail::get_failure_handler().load()(info);
-        }
-    }
+namespace detail {
+LIBASSERT_EXPORT void fail(const assertion_info& info) {
+	detail::get_failure_handler().load()(info);
+}
+} // namespace detail
 
-    binary_diagnostics_descriptor::binary_diagnostics_descriptor() = default;
-    binary_diagnostics_descriptor::binary_diagnostics_descriptor(
-        std::string_view _left_expression,
-        std::string_view _right_expression,
-        std::string&& _left_stringification,
-        std::string&& _right_stringification,
-        bool _multiple_formats
-    ):
-        left_expression(_left_expression),
-        right_expression(_right_expression),
-        left_stringification(std::move(_left_stringification)),
-        right_stringification(std::move(_right_stringification)),
-        multiple_formats(_multiple_formats) {}
-    binary_diagnostics_descriptor::~binary_diagnostics_descriptor() = default;
-    binary_diagnostics_descriptor::binary_diagnostics_descriptor(const binary_diagnostics_descriptor&) = default;
-    binary_diagnostics_descriptor::binary_diagnostics_descriptor(binary_diagnostics_descriptor&&) noexcept = default;
-    binary_diagnostics_descriptor& binary_diagnostics_descriptor::operator=(const binary_diagnostics_descriptor&) = default;
-    binary_diagnostics_descriptor&
-    binary_diagnostics_descriptor::operator=(binary_diagnostics_descriptor&&) noexcept(LIBASSERT_GCC_ISNT_STUPID) = default;
+binary_diagnostics_descriptor::binary_diagnostics_descriptor() = default;
+
+binary_diagnostics_descriptor::binary_diagnostics_descriptor(
+	std::string_view _left_expression,
+	std::string_view _right_expression,
+	std::string&& _left_stringification,
+	std::string&& _right_stringification,
+	bool _multiple_formats
+) :
+	left_expression(_left_expression),
+	right_expression(_right_expression),
+	left_stringification(std::move(_left_stringification)),
+	right_stringification(std::move(_right_stringification)),
+	multiple_formats(_multiple_formats) {}
+
+binary_diagnostics_descriptor::~binary_diagnostics_descriptor() = default;
+binary_diagnostics_descriptor::binary_diagnostics_descriptor(const binary_diagnostics_descriptor&) =
+	default;
+binary_diagnostics_descriptor::binary_diagnostics_descriptor(
+	binary_diagnostics_descriptor&&
+) noexcept = default;
+binary_diagnostics_descriptor&
+binary_diagnostics_descriptor::operator=(const binary_diagnostics_descriptor&) = default;
+binary_diagnostics_descriptor& binary_diagnostics_descriptor::operator=(
+	binary_diagnostics_descriptor&&
+) noexcept(LIBASSERT_GCC_ISNT_STUPID) = default;
 LIBASSERT_END_NAMESPACE
 
 LIBASSERT_BEGIN_NAMESPACE
-    namespace detail {
-        struct trace_holder {
-            std::variant<cpptrace::raw_trace, cpptrace::stacktrace> trace; // lazy, resolved when needed
 
-            trace_holder(cpptrace::raw_trace raw_trace) : trace(raw_trace) {};
+namespace detail {
+struct trace_holder {
+	std::variant<cpptrace::raw_trace, cpptrace::stacktrace> trace; // lazy, resolved when needed
 
-            const cpptrace::raw_trace& get_raw_trace() const {
-                try {
-                    return std::get<cpptrace::raw_trace>(trace);
-                } catch(std::bad_variant_access&) {
-                    throw cpptrace::runtime_error("get_raw_trace may only be called before get_stacktrace is called because that resoles the trace internally");
-                }
-            }
+	trace_holder(cpptrace::raw_trace raw_trace) : trace(raw_trace) {};
 
-            const cpptrace::stacktrace& get_stacktrace() {
-                if(std::holds_alternative<cpptrace::raw_trace>(trace)) {
-                    // do resolution
-                    auto raw_trace = std::move(std::get<cpptrace::raw_trace>(trace));
-                    trace = raw_trace.resolve();
-                }
-                return std::get<cpptrace::stacktrace>(trace);
-            }
-        };
+	const cpptrace::raw_trace& get_raw_trace() const {
+		try {
+			return std::get<cpptrace::raw_trace>(trace);
+		} catch (std::bad_variant_access&) {
+			throw cpptrace::runtime_error(
+				"get_raw_trace may only be called before get_stacktrace is called because that resoles the trace internally"
+			);
+		}
+	}
 
-        void trace_holder_deleter::operator()(trace_holder* ptr) {
-            delete ptr;
-        }
+	const cpptrace::stacktrace& get_stacktrace() {
+		if (std::holds_alternative<cpptrace::raw_trace>(trace)) {
+			// do resolution
+			auto raw_trace = std::move(std::get<cpptrace::raw_trace>(trace));
+			trace = raw_trace.resolve();
+		}
+		return std::get<cpptrace::stacktrace>(trace);
+	}
+};
 
-        LIBASSERT_ATTR_NOINLINE std::unique_ptr<trace_holder, trace_holder_deleter> generate_trace() {
-            return std::unique_ptr<trace_holder, trace_holder_deleter>(
-                new trace_holder(cpptrace::generate_raw_trace(1)),
-                trace_holder_deleter{}
-            );
-        }
+void trace_holder_deleter::operator()(trace_holder* ptr) {
+	delete ptr;
+}
 
-        void set_message(assertion_info& info, const char* value) {
-            if(value == nullptr) {
-                info.message = "(nullptr)";
-                return;
-            }
-            info.message = value;
-        }
+LIBASSERT_ATTR_NOINLINE std::unique_ptr<trace_holder, trace_holder_deleter> generate_trace() {
+	return std::unique_ptr<trace_holder, trace_holder_deleter>(
+		new trace_holder(cpptrace::generate_raw_trace(1)),
+		trace_holder_deleter {}
+	);
+}
 
-        void set_message(assertion_info& info, std::string_view value) {
-            info.message = value;
-        }
+void set_message(assertion_info& info, const char* value) {
+	if (value == nullptr) {
+		info.message = "(nullptr)";
+		return;
+	}
+	info.message = value;
+}
 
-        constexpr std::string_view errno_expansion = STR(errno);
-        static_assert(std::is_same_v<decltype(errno), int&>);
+void set_message(assertion_info& info, std::string_view value) {
+	info.message = value;
+}
 
-        extra_diagnostic make_extra_diagnostic(std::string_view expression, int value) {
-            if(expression == errno_expansion) {
-                return { "errno", microfmt::format("{>2:} \"{}\"", value, strerror_wrapper(value)) };
-            } else {
-                return { expression, generate_stringification(value) };
-            }
-        }
-    }
+constexpr std::string_view errno_expansion = STR(errno);
+static_assert(std::is_same_v<decltype(errno), int&>);
 
-    using namespace detail;
+extra_diagnostic make_extra_diagnostic(std::string_view expression, int value) {
+	if (expression == errno_expansion) {
+		return {"errno", microfmt::format("{>2:} \"{}\"", value, strerror_wrapper(value))};
+	} else {
+		return {expression, generate_stringification(value)};
+	}
+}
+} // namespace detail
 
-    LIBASSERT_ATTR_NOINLINE assertion_info::assertion_info(
-        const assert_static_parameters* static_params,
-        std::unique_ptr<detail::trace_holder, detail::trace_holder_deleter> _trace,
-        size_t _n_args
-    ) :
-        macro_name(static_params->macro_name),
-        type(static_params->type),
-        expression_string(static_params->expr_str),
-        file_name(static_params->location.file),
-        line(static_params->location.line),
-        function("<error>"),
-        n_args(_n_args),
-        trace(_trace.release()) {}
+using namespace detail;
 
-    assertion_info::~assertion_info() = default;
-    assertion_info::assertion_info(const assertion_info& other) :
-        macro_name(other.macro_name),
-        type(other.type),
-        expression_string(other.expression_string),
-        file_name(other.file_name),
-        line(other.line),
-        function(other.function),
-        message(other.message),
-        binary_diagnostics(other.binary_diagnostics),
-        extra_diagnostics(other.extra_diagnostics),
-        n_args(other.n_args),
-        trace(other.trace ? std::make_unique<trace_holder>(*other.trace) : nullptr),
-        path_handler(other.path_handler ? other.path_handler->clone() : nullptr)
-        {}
-    assertion_info::assertion_info(assertion_info&&) = default;
-    assertion_info& assertion_info::operator=(const assertion_info& other) {
-        macro_name = other.macro_name;
-        type = other.type;
-        expression_string = other.expression_string;
-        file_name = other.file_name;
-        line = other.line;
-        function = other.function;
-        message = other.message;
-        binary_diagnostics = other.binary_diagnostics;
-        extra_diagnostics = other.extra_diagnostics;
-        n_args = other.n_args;
-        trace = other.trace ? std::make_unique<trace_holder>(*other.trace) : nullptr;
-        path_handler = other.path_handler ? other.path_handler->clone() : nullptr;
-        return *this;
-    }
-    assertion_info& assertion_info::operator=(assertion_info&&) = default;
+LIBASSERT_ATTR_NOINLINE assertion_info::assertion_info(
+	const assert_static_parameters* static_params,
+	std::unique_ptr<detail::trace_holder, detail::trace_holder_deleter> _trace,
+	size_t _n_args
+) :
+	macro_name(static_params->macro_name),
+	type(static_params->type),
+	expression_string(static_params->expr_str),
+	file_name(static_params->location.file),
+	line(static_params->location.line),
+	function("<error>"),
+	n_args(_n_args),
+	trace(_trace.release()) {}
 
-    path_handler* assertion_info::get_path_handler() const {
-        if(!path_handler) {
-            path_handler = new_path_handler();
-            // if this is a disambiguating handler or similar it needs to be fed all paths
-            if(path_handler->has_add_path()) {
-                path_handler->add_path(file_name);
-                const auto& stacktrace = get_stacktrace();
-                for(const auto& frame : stacktrace.frames) {
-                    path_handler->add_path(frame.filename);
-                }
-                path_handler->finalize();
-            }
-        }
-        return path_handler.get();
-    }
+assertion_info::~assertion_info() = default;
 
-    std::string_view assertion_info::action() const {
-        switch(type) {
-            case assert_type::debug_assertion: return "Debug Assertion failed";
-            case assert_type::assertion:       return "Assertion failed";
-            case assert_type::assumption:      return "Assumption failed";
-            case assert_type::panic:           return "Panic";
-            case assert_type::unreachable:     return "Unreachable reached";
-            default:
-                return "Unknown assertion";
-        }
-    }
+assertion_info::assertion_info(const assertion_info& other) :
+	macro_name(other.macro_name),
+	type(other.type),
+	expression_string(other.expression_string),
+	file_name(other.file_name),
+	line(other.line),
+	function(other.function),
+	message(other.message),
+	binary_diagnostics(other.binary_diagnostics),
+	extra_diagnostics(other.extra_diagnostics),
+	n_args(other.n_args),
+	trace(other.trace ? std::make_unique<trace_holder>(*other.trace) : nullptr),
+	path_handler(other.path_handler ? other.path_handler->clone() : nullptr) {}
 
-    const cpptrace::raw_trace& assertion_info::get_raw_trace() const {
-        LIBASSERT_PRIMITIVE_ASSERT(trace != nullptr);
-        return trace->get_raw_trace();
-    }
+assertion_info::assertion_info(assertion_info&&) = default;
 
-    const cpptrace::stacktrace& assertion_info::get_stacktrace() const {
-        LIBASSERT_PRIMITIVE_ASSERT(trace != nullptr);
-        return trace->get_stacktrace();
-    }
+assertion_info& assertion_info::operator=(const assertion_info& other) {
+	macro_name = other.macro_name;
+	type = other.type;
+	expression_string = other.expression_string;
+	file_name = other.file_name;
+	line = other.line;
+	function = other.function;
+	message = other.message;
+	binary_diagnostics = other.binary_diagnostics;
+	extra_diagnostics = other.extra_diagnostics;
+	n_args = other.n_args;
+	trace = other.trace ? std::make_unique<trace_holder>(*other.trace) : nullptr;
+	path_handler = other.path_handler ? other.path_handler->clone() : nullptr;
+	return *this;
+}
 
-    std::string assertion_info::header(int width, const color_scheme& scheme) const {
-        return tagline(scheme)
-            + statement(scheme)
-            + print_binary_diagnostics(width, scheme)
-            + print_extra_diagnostics(width, scheme);
-    }
+assertion_info& assertion_info::operator=(assertion_info&&) = default;
 
-    std::string assertion_info::tagline(const color_scheme& scheme) const {
-        const auto prettified_function = prettify_type(std::string(function));
-        if(message && !message->empty()) {
-            return microfmt::format(
-                "{} at {}:{}: {}: {}\n",
-                action(),
-                get_path_handler()->resolve_path(file_name),
-                line,
-                detail::highlight(prettified_function, scheme),
-                *message
-            );
-        } else {
-            return microfmt::format(
-                "{} at {}:{}: {}:\n",
-                action(),
-                get_path_handler()->resolve_path(file_name),
-                line,
-                detail::highlight(prettified_function, scheme)
-            );
-        }
-    }
+path_handler* assertion_info::get_path_handler() const {
+	if (!path_handler) {
+		path_handler = new_path_handler();
+		// if this is a disambiguating handler or similar it needs to be fed all paths
+		if (path_handler->has_add_path()) {
+			path_handler->add_path(file_name);
+			const auto& stacktrace = get_stacktrace();
+			for (const auto& frame : stacktrace.frames) {
+				path_handler->add_path(frame.filename);
+			}
+			path_handler->finalize();
+		}
+	}
+	return path_handler.get();
+}
 
-    std::string assertion_info::location() const {
-        return microfmt::format("{}:{}", get_path_handler()->resolve_path(file_name), line);
-    }
+std::string_view assertion_info::action() const {
+	switch (type) {
+		case assert_type::debug_assertion:
+			return "Debug Assertion failed";
+		case assert_type::assertion:
+			return "Assertion failed";
+		case assert_type::assumption:
+			return "Assumption failed";
+		case assert_type::panic:
+			return "Panic";
+		case assert_type::unreachable:
+			return "Unreachable reached";
+		default:
+			return "Unknown assertion";
+	}
+}
 
-    std::string assertion_info::statement(const color_scheme& scheme) const {
-        return microfmt::format(
-            "    {}\n",
-            detail::highlight(
-                microfmt::format(
-                    "{}({}{});",
-                    macro_name,
-                    expression_string,
-                    n_args > 0 ? (expression_string.empty() ? "..." : ", ...") : ""
-                ),
-                scheme
-            )
-        );
-    }
+const cpptrace::raw_trace& assertion_info::get_raw_trace() const {
+	LIBASSERT_PRIMITIVE_ASSERT(trace != nullptr);
+	return trace->get_raw_trace();
+}
 
-    std::string assertion_info::print_binary_diagnostics(int width, const color_scheme& scheme) const {
-        if(binary_diagnostics) {
-            return libassert::detail::print_binary_diagnostics(*binary_diagnostics, width, scheme);
-        } else {
-            return "";
-        }
-    }
+const cpptrace::stacktrace& assertion_info::get_stacktrace() const {
+	LIBASSERT_PRIMITIVE_ASSERT(trace != nullptr);
+	return trace->get_stacktrace();
+}
 
-    std::string assertion_info::print_extra_diagnostics(int width, const color_scheme& scheme) const {
-        if(!extra_diagnostics.empty()) {
-            return libassert::detail::print_extra_diagnostics(extra_diagnostics, width, scheme);
-        } else {
-            return "";
-        }
-    }
+std::string assertion_info::header(int width, const color_scheme& scheme) const {
+	return tagline(scheme) + statement(scheme) + print_binary_diagnostics(width, scheme)
+		+ print_extra_diagnostics(width, scheme);
+}
 
-    std::string assertion_info::print_stacktrace(int width, const color_scheme& scheme) const {
-        std::string output = "Stack trace:\n";
-        return libassert::detail::print_stacktrace(get_stacktrace(), width, scheme, get_path_handler());
-    }
+std::string assertion_info::tagline(const color_scheme& scheme) const {
+	const auto prettified_function = prettify_type(std::string(function));
+	if (message && !message->empty()) {
+		return microfmt::format(
+			"{} at {}:{}: {}: {}\n",
+			action(),
+			get_path_handler()->resolve_path(file_name),
+			line,
+			detail::highlight(prettified_function, scheme),
+			*message
+		);
+	} else {
+		return microfmt::format(
+			"{} at {}:{}: {}:\n",
+			action(),
+			get_path_handler()->resolve_path(file_name),
+			line,
+			detail::highlight(prettified_function, scheme)
+		);
+	}
+}
 
-    std::string assertion_info::to_string(int width, const color_scheme& scheme) const {
-        // auto& stacktrace = get_stacktrace(); // TODO
-        // now do output
-        std::string output;
-        // generate statement
-        output += tagline(scheme);
-        output += statement(scheme);
-        output += print_binary_diagnostics(width, scheme);
-        output += print_extra_diagnostics(width, scheme);
-        // generate stack trace
-        output += "\nStack trace:\n";
-        output += print_stacktrace(width, scheme);
-        return output;
-    }
+std::string assertion_info::location() const {
+	return microfmt::format("{}:{}", get_path_handler()->resolve_path(file_name), line);
+}
+
+std::string assertion_info::statement(const color_scheme& scheme) const {
+	return microfmt::format(
+		"    {}\n",
+		detail::highlight(
+			microfmt::format(
+				"{}({}{});",
+				macro_name,
+				expression_string,
+				n_args > 0 ? (expression_string.empty() ? "..." : ", ...") : ""
+			),
+			scheme
+		)
+	);
+}
+
+std::string assertion_info::print_binary_diagnostics(int width, const color_scheme& scheme) const {
+	if (binary_diagnostics) {
+		return libassert::detail::print_binary_diagnostics(*binary_diagnostics, width, scheme);
+	} else {
+		return "";
+	}
+}
+
+std::string assertion_info::print_extra_diagnostics(int width, const color_scheme& scheme) const {
+	if (!extra_diagnostics.empty()) {
+		return libassert::detail::print_extra_diagnostics(extra_diagnostics, width, scheme);
+	} else {
+		return "";
+	}
+}
+
+std::string assertion_info::print_stacktrace(int width, const color_scheme& scheme) const {
+	std::string output = "Stack trace:\n";
+	return libassert::detail::print_stacktrace(get_stacktrace(), width, scheme, get_path_handler());
+}
+
+std::string assertion_info::to_string(int width, const color_scheme& scheme) const {
+	// auto& stacktrace = get_stacktrace(); // TODO
+	// now do output
+	std::string output;
+	// generate statement
+	output += tagline(scheme);
+	output += statement(scheme);
+	output += print_binary_diagnostics(width, scheme);
+	output += print_extra_diagnostics(width, scheme);
+	return output;
+}
+
 LIBASSERT_END_NAMESPACE
 
 LIBASSERT_BEGIN_NAMESPACE
-    [[nodiscard]] LIBASSERT_ATTR_NOINLINE
-    std::string stacktrace(int width, const color_scheme& scheme, std::size_t skip) {
-        auto trace = cpptrace::generate_trace(skip + 1);
-        detail::identity_path_handler handler;
-        return print_stacktrace(trace, width, scheme, &handler);
-    }
+[[nodiscard]] LIBASSERT_ATTR_NOINLINE std::string
+stacktrace(int width, const color_scheme& scheme, std::size_t skip) {
+	auto trace = cpptrace::generate_trace(skip + 1);
+	detail::identity_path_handler handler;
+	return print_stacktrace(trace, width, scheme, &handler);
+}
 
-    [[nodiscard]]
-    std::string print_stacktrace(
-        const cpptrace::stacktrace& trace,
-        int width,
-        const color_scheme& scheme,
-        path_mode mode
-    ) {
-        auto path_handler = new_path_handler(mode);
-        // if this is a disambiguating handler or similar it needs to be fed all paths
-        if(path_handler->has_add_path()) {
-            for(const auto& frame : trace.frames) {
-                path_handler->add_path(frame.filename);
-            }
-            path_handler->finalize();
-        }
-        return print_stacktrace(trace, width, scheme, path_handler.get());
-    }
+[[nodiscard]]
+std::string print_stacktrace(
+	const cpptrace::stacktrace& trace,
+	int width,
+	const color_scheme& scheme,
+	path_mode mode
+) {
+	auto path_handler = new_path_handler(mode);
+	// if this is a disambiguating handler or similar it needs to be fed all paths
+	if (path_handler->has_add_path()) {
+		for (const auto& frame : trace.frames) {
+			path_handler->add_path(frame.filename);
+		}
+		path_handler->finalize();
+	}
+	return print_stacktrace(trace, width, scheme, path_handler.get());
+}
+
 LIBASSERT_END_NAMESPACE

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -7,38 +7,38 @@
 // Slightly modified one dark pro colors
 // Original: https://coolors.co/e06b74-d19a66-e5c07a-98c379-62aeef-55b6c2-c678dd
 // Modified: https://coolors.co/e06b74-d19a66-e5c07a-90cc66-62aeef-56c2c0-c678dd
-#define RGB_RED    ANSIRGB(224, 107, 116)
+#define RGB_RED ANSIRGB(224, 107, 116)
 #define RGB_ORANGE ANSIRGB(209, 154, 102)
 #define RGB_YELLOW ANSIRGB(229, 192, 122)
-#define RGB_GREEN  ANSIRGB(150, 205, 112) // modified
-#define RGB_BLUE   ANSIRGB(98,  174, 239)
-#define RGB_CYAN   ANSIRGB(86,  194, 192) // modified
-#define RGB_PURPL  ANSIRGB(198, 120, 221)
+#define RGB_GREEN ANSIRGB(150, 205, 112) // modified
+#define RGB_BLUE ANSIRGB(98, 174, 239)
+#define RGB_CYAN ANSIRGB(86, 194, 192) // modified
+#define RGB_PURPL ANSIRGB(198, 120, 221)
 
-#define BASIC_RED    ESC "31m"
+#define BASIC_RED ESC "31m"
 #define BASIC_ORANGE ESC "33m" // using yellow as orange
 #define BASIC_YELLOW ESC "33m"
-#define BASIC_GREEN  ESC "32m"
-#define BASIC_BLUE   ESC "34m"
-#define BASIC_CYAN   ESC "36m"
-#define BASIC_PURPL  ESC "35m"
+#define BASIC_GREEN ESC "32m"
+#define BASIC_BLUE ESC "34m"
+#define BASIC_CYAN ESC "36m"
+#define BASIC_PURPL ESC "35m"
 
-#define BASIC_HIGHLIGHT_RED    ESC "101m"
-#define BASIC_HIGHLIGHT_GREEN  ESC "102m"
+#define BASIC_HIGHLIGHT_RED ESC "101m"
+#define BASIC_HIGHLIGHT_GREEN ESC "102m"
 #define BASIC_HIGHLIGHT_YELLOW ESC "103m"
 
 #if !defined(LIBASSERT_BUILD_TESTING) || defined(LIBASSERT_STATIC_DEFINE)
- #define LIBASSERT_EXPORT_TESTING
+	#define LIBASSERT_EXPORT_TESTING
 #else
- #ifndef LIBASSERT_EXPORT_TESTING
-  #ifdef libassert_lib_EXPORTS
-   /* We are building this library */
-   #define LIBASSERT_EXPORT_TESTING LIBASSERT_EXPORT_ATTR
-  #else
-   /* We are using this library */
-   #define LIBASSERT_EXPORT_TESTING LIBASSERT_IMPORT_ATTR
-  #endif
- #endif
+	#ifndef LIBASSERT_EXPORT_TESTING
+		#ifdef libassert_lib_EXPORTS
+			/* We are building this library */
+			#define LIBASSERT_EXPORT_TESTING LIBASSERT_EXPORT_ATTR
+		#else
+			/* We are using this library */
+			#define LIBASSERT_EXPORT_TESTING LIBASSERT_IMPORT_ATTR
+		#endif
+	#endif
 #endif
 
 #define IS_WINDOWS 0
@@ -46,16 +46,17 @@
 #define IS_APPLE 0
 
 #if defined(_WIN32)
- #undef IS_WINDOWS
- #define IS_WINDOWS 1
+	#undef IS_WINDOWS
+	#define IS_WINDOWS 1
 #elif defined(__linux)
- #undef IS_LINUX
- #define IS_LINUX 1
+	#undef IS_LINUX
+	#define IS_LINUX 1
 #elif defined(__APPLE__)
- #undef IS_APPLE
- #define IS_APPLE 1
+	#undef IS_APPLE
+	#define IS_APPLE 1
 #else
- #error "Libassert doesn't recognize this system, please open an issue at https://github.com/jeremy-rifkin/libassert"
+	#error \
+		"Libassert doesn't recognize this system, please open an issue at https://github.com/jeremy-rifkin/libassert"
 #endif
 
 #endif

--- a/src/libassert.cppm
+++ b/src/libassert.cppm
@@ -4,66 +4,73 @@ module;
 export module libassert;
 
 LIBASSERT_BEGIN_NAMESPACE
-    // assert.hpp
-    export using libassert::terminal_width;
-    export using libassert::enable_virtual_terminal_processing_if_needed;
-    export using libassert::stdin_fileno;
-    export using libassert::stdout_fileno;
-    export using libassert::stderr_fileno;
-    export using libassert::isatty;
-    export using libassert::is_debugger_present;
-    export using libassert::debugger_check_mode;
-    export using libassert::set_debugger_check_mode;
-    export using libassert::type_name;
-    export using libassert::pretty_type_name;
-    export using libassert::stringify;
-    export using libassert::color_scheme;
-    export using libassert::set_color_scheme;
-    export using libassert::get_color_scheme;
-    export using libassert::set_diff_highlighting;
-    export using libassert::set_separator;
-    export using libassert::highlight;
-    export using libassert::highlight_stringify;
-    export using libassert::stacktrace;
-    export using libassert::print_stacktrace;
-    export using libassert::literal_format;
-    export using libassert::operator|;
-    export using libassert::literal_format_mode;
-    export using libassert::set_literal_format_mode;
-    export using libassert::set_fixed_literal_format;
-    export using libassert::path_mode;
-    export using libassert::set_path_mode;
-    export using libassert::get_path_mode;
-    export using libassert::assert_type;
-    export using libassert::default_failure_handler;
-    export using libassert::handler_ptr;
-    export using libassert::get_failure_handler;
-    export using libassert::set_failure_handler;
-    export using libassert::binary_diagnostics_descriptor;
-    export using libassert::extra_diagnostic;
-    export using libassert::assertion_info;
-    namespace detail {
-        export using libassert::detail::set_literal_format;
-        export using libassert::detail::assert_static_parameters;
-        export using libassert::detail::pretty_function_name_wrapper;
-        export using libassert::detail::process_assert_fail;
-        export using libassert::detail::process_panic;
-        export using libassert::detail::get_expression_return_value;
-    }
-    // expression-decomposition.hpp
-    namespace detail {
-        export using libassert::detail::expression_decomposer;
-    }
-    // stringification.hpp
-    export using libassert::stringifier;
-    namespace detail {
-        export using libassert::detail::generate_stringification;
-        export using libassert::detail::stringifiable;
-        export using libassert::detail::stringifiable_container;
-    }
-    // utilities.hpp
-    export using libassert::source_location;
-    namespace detail {
-        export using libassert::detail::prettify_type;
-    }
+// assert.hpp
+export using libassert::terminal_width;
+export using libassert::enable_virtual_terminal_processing_if_needed;
+export using libassert::stdin_fileno;
+export using libassert::stdout_fileno;
+export using libassert::stderr_fileno;
+export using libassert::isatty;
+export using libassert::is_debugger_present;
+export using libassert::debugger_check_mode;
+export using libassert::set_debugger_check_mode;
+export using libassert::type_name;
+export using libassert::pretty_type_name;
+export using libassert::stringify;
+export using libassert::color_scheme;
+export using libassert::set_color_scheme;
+export using libassert::get_color_scheme;
+export using libassert::set_diff_highlighting;
+export using libassert::set_separator;
+export using libassert::highlight;
+export using libassert::highlight_stringify;
+export using libassert::stacktrace;
+export using libassert::print_stacktrace;
+export using libassert::literal_format;
+export using libassert::operator|;
+export using libassert::literal_format_mode;
+export using libassert::set_literal_format_mode;
+export using libassert::set_fixed_literal_format;
+export using libassert::path_mode;
+export using libassert::set_path_mode;
+export using libassert::get_path_mode;
+export using libassert::assert_type;
+export using libassert::default_failure_handler;
+export using libassert::handler_ptr;
+export using libassert::get_failure_handler;
+export using libassert::set_failure_handler;
+export using libassert::binary_diagnostics_descriptor;
+export using libassert::extra_diagnostic;
+export using libassert::assertion_info;
+
+namespace detail {
+export using libassert::detail::set_literal_format;
+export using libassert::detail::assert_static_parameters;
+export using libassert::detail::pretty_function_name_wrapper;
+export using libassert::detail::process_assert_fail;
+export using libassert::detail::process_panic;
+export using libassert::detail::get_expression_return_value;
+} // namespace detail
+
+// expression-decomposition.hpp
+namespace detail {
+export using libassert::detail::expression_decomposer;
+}
+
+// stringification.hpp
+export using libassert::stringifier;
+
+namespace detail {
+export using libassert::detail::generate_stringification;
+export using libassert::detail::stringifiable;
+export using libassert::detail::stringifiable_container;
+} // namespace detail
+
+// utilities.hpp
+export using libassert::source_location;
+
+namespace detail {
+export using libassert::detail::prettify_type;
+}
+
 LIBASSERT_END_NAMESPACE

--- a/src/microfmt.hpp
+++ b/src/microfmt.hpp
@@ -9,10 +9,10 @@
 #include <iterator>
 #include <string>
 #if (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L
- #include <string_view>
+	#include <string_view>
 #endif
 #ifdef _MSC_VER
- #include <intrin.h>
+	#include <intrin.h>
 #endif
 
 #include <libassert/platform.hpp>
@@ -22,288 +22,326 @@
 // Format: {[align][width][:[fill][base]]}  # width: number or {}
 
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace microfmt {
-    namespace detail {
-        inline std::uint64_t clz(std::uint64_t value) {
-            #ifdef _MSC_VER
-             unsigned long out = 0;
-             #ifdef _WIN64
-              _BitScanReverse64(&out, value);
-             #else
-              if(_BitScanReverse(&out, std::uint32_t(value >> 32))) {
-                  return 63 - int(out + 32);
-              }
-              _BitScanReverse(&out, std::uint32_t(value));
-             #endif
-             return 63 - out;
-            #else
-             return __builtin_clzll(value);
-            #endif
-        }
+namespace detail {
+	inline std::uint64_t clz(std::uint64_t value) {
+#ifdef _MSC_VER
+		unsigned long out = 0;
+	#ifdef _WIN64
+		_BitScanReverse64(&out, value);
+	#else
+		if (_BitScanReverse(&out, std::uint32_t(value >> 32))) {
+			return 63 - int(out + 32);
+		}
+		_BitScanReverse(&out, std::uint32_t(value));
+	#endif
+		return 63 - out;
+#else
+		return __builtin_clzll(value);
+#endif
+	}
 
-        template<typename U, typename V> U to(V v) {
-            return static_cast<U>(v); // A way to cast to U without "warning: useless cast to type"
-        }
+	template<typename U, typename V>
+	U to(V v) {
+		return static_cast<U>(v); // A way to cast to U without "warning: useless cast to type"
+	}
 
-        enum class alignment { left, right };
+	enum class alignment { left, right };
 
-        struct format_options {
-            alignment align = alignment::left;
-            char fill = ' ';
-            size_t width = 0;
-            char base = 'd';
-        };
+	struct format_options {
+		alignment align = alignment::left;
+		char fill = ' ';
+		size_t width = 0;
+		char base = 'd';
+	};
 
-        template<typename OutputIt, typename InputIt>
-        void do_write(OutputIt out, InputIt begin, InputIt end, const format_options& options) {
-            auto size = end - begin;
-            if(static_cast<std::size_t>(size) >= options.width) {
-                std::copy(begin, end, out);
-            } else {
-                if(options.align == alignment::left) {
-                    std::copy(begin, end, out);
-                    std::fill_n(out, options.width - size, options.fill);
-                } else {
-                    std::fill_n(out, options.width - size, options.fill);
-                    std::copy(begin, end, out);
-                }
-            }
-        }
+	template<typename OutputIt, typename InputIt>
+	void do_write(OutputIt out, InputIt begin, InputIt end, const format_options& options) {
+		auto size = end - begin;
+		if (static_cast<std::size_t>(size) >= options.width) {
+			std::copy(begin, end, out);
+		} else {
+			if (options.align == alignment::left) {
+				std::copy(begin, end, out);
+				std::fill_n(out, options.width - size, options.fill);
+			} else {
+				std::fill_n(out, options.width - size, options.fill);
+				std::copy(begin, end, out);
+			}
+		}
+	}
 
-        template<int shift, int mask>
-        std::string to_string(std::uint64_t value, const char* digits = "0123456789abcdef") {
-            if(value == 0) {
-                return "0";
-            } else {
-                // digits = floor(1 + log_base(x))
-                // log_base(x) = log_2(x) / log_2(base)
-                // log_2(x) == 63 - clz(x)
-                // 1 + (63 - clz(value)) / (63 - clz(1 << shift))
-                // 63 - clz(1 << shift) is the same as shift
-                auto n_digits = to<std::size_t>(1 + (63 - clz(value)) / shift);
-                std::string number;
-                number.resize(n_digits);
-                std::size_t i = n_digits - 1;
-                while(value > 0) {
-                    number[i--] = digits[value & mask];
-                    value >>= shift;
-                }
-                return number;
-            }
-        }
+	template<int shift, int mask>
+	std::string to_string(std::uint64_t value, const char* digits = "0123456789abcdef") {
+		if (value == 0) {
+			return "0";
+		} else {
+			// digits = floor(1 + log_base(x))
+			// log_base(x) = log_2(x) / log_2(base)
+			// log_2(x) == 63 - clz(x)
+			// 1 + (63 - clz(value)) / (63 - clz(1 << shift))
+			// 63 - clz(1 << shift) is the same as shift
+			auto n_digits = to<std::size_t>(1 + (63 - clz(value)) / shift);
+			std::string number;
+			number.resize(n_digits);
+			std::size_t i = n_digits - 1;
+			while (value > 0) {
+				number[i--] = digits[value & mask];
+				value >>= shift;
+			}
+			return number;
+		}
+	}
 
-        inline std::string to_string(std::uint64_t value, const format_options& options) {
-            switch(options.base) {
-                case 'H': return to_string<4, 0xf>(value, "0123456789ABCDEF");
-                case 'h': return to_string<4, 0xf>(value);
-                case 'o': return to_string<3, 0x7>(value);
-                case 'b': return to_string<1, 0x1>(value);
-                default: return std::to_string(value); // failure: decimal
-            }
-        }
+	inline std::string to_string(std::uint64_t value, const format_options& options) {
+		switch (options.base) {
+			case 'H':
+				return to_string<4, 0xf>(value, "0123456789ABCDEF");
+			case 'h':
+				return to_string<4, 0xf>(value);
+			case 'o':
+				return to_string<3, 0x7>(value);
+			case 'b':
+				return to_string<1, 0x1>(value);
+			default:
+				return std::to_string(value); // failure: decimal
+		}
+	}
 
-        struct string_view {
-            const char* data;
-            std::size_t size;
-        };
+	struct string_view {
+		const char* data;
+		std::size_t size;
+	};
 
-        class format_value {
-            enum class value_type {
-                char_value,
-                int64_value,
-                uint64_value,
-                string_value,
-                string_view_value,
-                c_string_value,
-            };
-            union {
-                char char_value;
-                std::int64_t int64_value;
-                std::uint64_t uint64_value;
-                const std::string* string_value;
-                string_view string_view_value;
-                const char* c_string_value;
-            };
-            value_type value;
+	class format_value {
+		enum class value_type {
+			char_value,
+			int64_value,
+			uint64_value,
+			string_value,
+			string_view_value,
+			c_string_value,
+		};
 
-        public:
-            format_value(char c) : char_value(c), value(value_type::char_value) {}
-            format_value(short int_val) : int64_value(int_val), value(value_type::int64_value) {}
-            format_value(int int_val) : int64_value(int_val), value(value_type::int64_value) {}
-            format_value(long int_val) : int64_value(int_val), value(value_type::int64_value) {}
-            format_value(long long int_val) : int64_value(int_val), value(value_type::int64_value) {}
-            format_value(unsigned char int_val) : uint64_value(int_val), value(value_type::uint64_value) {}
-            format_value(unsigned short int_val) : uint64_value(int_val), value(value_type::uint64_value) {}
-            format_value(unsigned int int_val) : uint64_value(int_val), value(value_type::uint64_value) {}
-            format_value(unsigned long int_val) : uint64_value(int_val), value(value_type::uint64_value) {}
-            format_value(unsigned long long int_val) : uint64_value(int_val), value(value_type::uint64_value) {}
-            format_value(const std::string& string) : string_value(&string), value(value_type::string_value) {}
-            #if (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L
-            format_value(std::string_view sv)
-                : string_view_value{sv.data(), sv.size()}, value(value_type::string_view_value) {}
-            #endif
-            format_value(const char* c_string) : c_string_value(c_string), value(value_type::c_string_value) {}
+		union {
+			char char_value;
+			std::int64_t int64_value;
+			std::uint64_t uint64_value;
+			const std::string* string_value;
+			string_view string_view_value;
+			const char* c_string_value;
+		};
 
-            int unwrap_int() const {
-                switch(value) {
-                    case value_type::int64_value:  return static_cast<int>(int64_value);
-                    case value_type::uint64_value: return static_cast<int>(uint64_value);
-                    default: return 0; // failure: just 0
-                }
-            }
+		value_type value;
 
-        public:
-            template<typename OutputIt>
-            void write(OutputIt out, const format_options& options) const {
-                switch(value) {
-                    case value_type::char_value:
-                        do_write(out, &char_value, &char_value + 1, options);
-                        break;
-                    case value_type::int64_value:
-                        {
-                            std::string str;
-                            std::int64_t val = int64_value;
-                            if(val < 0) {
-                                str += '-';
-                                val *= -1;
-                            }
-                            str += to_string(static_cast<std::uint64_t>(val), options);
-                            do_write(out, str.begin(), str.end(), options);
-                        }
-                        break;
-                    case value_type::uint64_value:
-                        {
-                            std::string str = to_string(uint64_value, options);
-                            do_write(out, str.begin(), str.end(), options);
-                        }
-                        break;
-                    case value_type::string_value:
-                        do_write(out, string_value->begin(), string_value->end(), options);
-                        break;
-                    case value_type::string_view_value:
-                        do_write(out, string_view_value.data, string_view_value.data + string_view_value.size, options);
-                        break;
-                    case value_type::c_string_value:
-                        do_write(out, c_string_value, c_string_value + std::strlen(c_string_value), options);
-                        break;
-                } // failure: nop
-            }
-        };
+	public:
+		format_value(char c) : char_value(c), value(value_type::char_value) {}
 
-        // note: previously used std::array and there was a bug with std::array<T, 0> affecting old msvc
-        // https://godbolt.org/z/88T8hrzzq mre: https://godbolt.org/z/drd8echbP
-        template<typename OutputIt, typename InputIt>
-        void format(OutputIt out, InputIt fmt_begin, InputIt fmt_end, const std::initializer_list<format_value>& args) {
-            std::size_t arg_i = 0;
-            auto it = fmt_begin;
-            auto peek = [&] (std::size_t dist) -> char { // 0 on failure
-                return fmt_end - it > signed(dist) ? *(it + dist) : 0;
-            };
-            auto read_number = [&] () -> int { // -1 on failure
-                auto scan = it;
-                int num = 0;
-                while(scan != fmt_end && isdigit(*scan)) {
-                    num *= 10;
-                    num += *scan - '0';
-                    scan++;
-                }
-                if(scan != it) {
-                    it = scan;
-                    return num;
-                } else {
-                    return -1;
-                }
-            };
-            for(; it != fmt_end; it++) {
-                if((*it == '{' || *it == '}') && peek(1) == *it) { // parse {{ and }} escapes
-                    it++;
-                } else if(*it == '{' && it + 1 != fmt_end) {
-                    auto saved_it = it;
-                    auto handle_formatter = [&] () {
-                        it++;
-                        format_options options;
-                        // try to parse alignment
-                        if(*it == '<' || *it == '>') {
-                            options.align = *it++ == '<' ? alignment::left : alignment::right;
-                        }
-                        // try to parse width
-                        auto width = read_number(); // handles fmt_end check
-                        if(width != -1) {
-                            options.width = width;
-                        } else if(it != fmt_end && *it == '{') { // try to parse variable width
-                            if(peek(1) != '}') {
-                                return false;
-                            }
-                            it += 2;
-                            options.width = arg_i < args.size() ? args.begin()[arg_i++].unwrap_int() : 0;
-                        }
-                        // try to parse fill/base
-                        if(it != fmt_end && *it == ':') {
-                            it++;
-                            if(fmt_end - it > 1 && *it != '}' && peek(1) != '}') { // two chars before the }, fill+base
-                                options.fill = *it++;
-                                options.base = *it++;
-                            } else if(it != fmt_end && *it != '}') { // one char before the }, just base
-                                if(*it == 'd' || *it == 'h' || *it == 'H' || *it == 'o' || *it == 'b') {
-                                    options.base = *it++;
-                                } else {
-                                    options.fill = *it++;
-                                }
-                            }
-                        }
-                        if(it == fmt_end || *it != '}') {
-                            return false;
-                        }
-                        if(arg_i < args.size()) {
-                            args.begin()[arg_i++].write(out, options);
-                        }
-                        return true;
-                    };
-                    if(handle_formatter()) {
-                        continue; // If reached here, successfully parsed and wrote a formatter. Don't write *it.
-                    }
-                    it = saved_it; // go back
-                }
-                *out++ = *it;
-            }
-        }
+		format_value(short int_val) : int64_value(int_val), value(value_type::int64_value) {}
 
-        #if (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L
-        template<typename OutputIt>
-        void format(OutputIt out, std::string_view fmt, const std::initializer_list<format_value>& args) {
-            return format(out, fmt.begin(), fmt.end(), args);
-        }
-        #endif
+		format_value(int int_val) : int64_value(int_val), value(value_type::int64_value) {}
 
-        template<typename OutputIt>
-        void format(OutputIt out, const char* fmt, const std::initializer_list<format_value>& args) {
-            return format(out, fmt, fmt + std::strlen(fmt), args);
-        }
-    }
+		format_value(long int_val) : int64_value(int_val), value(value_type::int64_value) {}
 
-    template<typename S, typename... Args>
-    std::string format(const S& fmt, Args&&... args) {
-        std::string str;
-        detail::format(std::back_inserter(str), fmt, {detail::format_value(args)...});
-        return str;
-    }
+		format_value(long long int_val) : int64_value(int_val), value(value_type::int64_value) {}
 
-    template<typename S, typename... Args>
-    void print(const S& fmt, Args&&... args) {
-        detail::format(std::ostream_iterator<char>(std::cout), fmt, {args...});
-    }
+		format_value(unsigned char int_val) : uint64_value(int_val), value(value_type::uint64_value) {}
 
-    template<typename S, typename... Args>
-    void print(std::ostream& ostream, const S& fmt, Args&&... args) {
-        detail::format(std::ostream_iterator<char>(ostream), fmt, {args...});
-    }
+		format_value(unsigned short int_val) : uint64_value(int_val), value(value_type::uint64_value) {}
 
-    template<typename S, typename... Args>
-    void print(std::FILE* stream, const S& fmt, Args&&... args) {
-        auto str = format(fmt, args...);
-        fwrite(str.data(), 1, str.size(), stream);
-    }
+		format_value(unsigned int int_val) : uint64_value(int_val), value(value_type::uint64_value) {}
+
+		format_value(unsigned long int_val) : uint64_value(int_val), value(value_type::uint64_value) {}
+
+		format_value(unsigned long long int_val) :
+			uint64_value(int_val),
+			value(value_type::uint64_value) {}
+
+		format_value(const std::string& string) :
+			string_value(&string),
+			value(value_type::string_value) {}
+#if (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L
+		format_value(std::string_view sv) :
+			string_view_value {sv.data(), sv.size()},
+			value(value_type::string_view_value) {}
+#endif
+		format_value(const char* c_string) :
+			c_string_value(c_string),
+			value(value_type::c_string_value) {}
+
+		int unwrap_int() const {
+			switch (value) {
+				case value_type::int64_value:
+					return static_cast<int>(int64_value);
+				case value_type::uint64_value:
+					return static_cast<int>(uint64_value);
+				default:
+					return 0; // failure: just 0
+			}
+		}
+
+	public:
+		template<typename OutputIt>
+		void write(OutputIt out, const format_options& options) const {
+			switch (value) {
+				case value_type::char_value:
+					do_write(out, &char_value, &char_value + 1, options);
+					break;
+				case value_type::int64_value: {
+					std::string str;
+					std::int64_t val = int64_value;
+					if (val < 0) {
+						str += '-';
+						val *= -1;
+					}
+					str += to_string(static_cast<std::uint64_t>(val), options);
+					do_write(out, str.begin(), str.end(), options);
+				} break;
+				case value_type::uint64_value: {
+					std::string str = to_string(uint64_value, options);
+					do_write(out, str.begin(), str.end(), options);
+				} break;
+				case value_type::string_value:
+					do_write(out, string_value->begin(), string_value->end(), options);
+					break;
+				case value_type::string_view_value:
+					do_write(
+						out,
+						string_view_value.data,
+						string_view_value.data + string_view_value.size,
+						options
+					);
+					break;
+				case value_type::c_string_value:
+					do_write(out, c_string_value, c_string_value + std::strlen(c_string_value), options);
+					break;
+			} // failure: nop
+		}
+	};
+
+	// note: previously used std::array and there was a bug with std::array<T, 0> affecting old msvc
+	// https://godbolt.org/z/88T8hrzzq mre: https://godbolt.org/z/drd8echbP
+	template<typename OutputIt, typename InputIt>
+	void format(
+		OutputIt out,
+		InputIt fmt_begin,
+		InputIt fmt_end,
+		const std::initializer_list<format_value>& args
+	) {
+		std::size_t arg_i = 0;
+		auto it = fmt_begin;
+		auto peek = [&](std::size_t dist) -> char { // 0 on failure
+			return fmt_end - it > signed(dist) ? *(it + dist) : 0;
+		};
+		auto read_number = [&]() -> int { // -1 on failure
+			auto scan = it;
+			int num = 0;
+			while (scan != fmt_end && isdigit(*scan)) {
+				num *= 10;
+				num += *scan - '0';
+				scan++;
+			}
+			if (scan != it) {
+				it = scan;
+				return num;
+			} else {
+				return -1;
+			}
+		};
+		for (; it != fmt_end; it++) {
+			if ((*it == '{' || *it == '}') && peek(1) == *it) { // parse {{ and }} escapes
+				it++;
+			} else if (*it == '{' && it + 1 != fmt_end) {
+				auto saved_it = it;
+				auto handle_formatter = [&]() {
+					it++;
+					format_options options;
+					// try to parse alignment
+					if (*it == '<' || *it == '>') {
+						options.align = *it++ == '<' ? alignment::left : alignment::right;
+					}
+					// try to parse width
+					auto width = read_number(); // handles fmt_end check
+					if (width != -1) {
+						options.width = width;
+					} else if (it != fmt_end && *it == '{') { // try to parse variable width
+						if (peek(1) != '}') {
+							return false;
+						}
+						it += 2;
+						options.width = arg_i < args.size() ? args.begin()[arg_i++].unwrap_int() : 0;
+					}
+					// try to parse fill/base
+					if (it != fmt_end && *it == ':') {
+						it++;
+						if (
+							fmt_end - it > 1 && *it != '}' && peek(1) != '}'
+						) { // two chars before the }, fill+base
+							options.fill = *it++;
+							options.base = *it++;
+						} else if (it != fmt_end && *it != '}') { // one char before the }, just base
+							if (*it == 'd' || *it == 'h' || *it == 'H' || *it == 'o' || *it == 'b') {
+								options.base = *it++;
+							} else {
+								options.fill = *it++;
+							}
+						}
+					}
+					if (it == fmt_end || *it != '}') {
+						return false;
+					}
+					if (arg_i < args.size()) {
+						args.begin()[arg_i++].write(out, options);
+					}
+					return true;
+				};
+				if (handle_formatter()) {
+					continue; // If reached here, successfully parsed and wrote a formatter. Don't write *it.
+				}
+				it = saved_it; // go back
+			}
+			*out++ = *it;
+		}
+	}
+
+#if (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L
+	template<typename OutputIt>
+	void format(OutputIt out, std::string_view fmt, const std::initializer_list<format_value>& args) {
+		return format(out, fmt.begin(), fmt.end(), args);
+	}
+#endif
+
+	template<typename OutputIt>
+	void format(OutputIt out, const char* fmt, const std::initializer_list<format_value>& args) {
+		return format(out, fmt, fmt + std::strlen(fmt), args);
+	}
+} // namespace detail
+
+template<typename S, typename... Args>
+std::string format(const S& fmt, Args&&... args) {
+	std::string str;
+	detail::format(std::back_inserter(str), fmt, {detail::format_value(args)...});
+	return str;
 }
+
+template<typename S, typename... Args>
+void print(const S& fmt, Args&&... args) {
+	detail::format(std::ostream_iterator<char>(std::cout), fmt, {args...});
+}
+
+template<typename S, typename... Args>
+void print(std::ostream& ostream, const S& fmt, Args&&... args) {
+	detail::format(std::ostream_iterator<char>(ostream), fmt, {args...});
+}
+
+template<typename S, typename... Args>
+void print(std::FILE* stream, const S& fmt, Args&&... args) {
+	auto str = format(fmt, args...);
+	fwrite(str.data(), 1, str.size(), stream);
+}
+} // namespace microfmt
+
 LIBASSERT_END_NAMESPACE
 
 #endif

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -1,170 +1,172 @@
 #include "paths.hpp"
 
-#include "common.hpp"
-
 #include <algorithm>
 #include <memory>
 
+#include "common.hpp"
+
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    using path_components = std::vector<std::string>;
+using path_components = std::vector<std::string>;
 
-    #if IS_WINDOWS
-     constexpr std::string_view path_delim = "/\\";
-    #else
-     constexpr std::string_view path_delim = "/";
-    #endif
+#if IS_WINDOWS
+constexpr std::string_view path_delim = "/\\";
+#else
+constexpr std::string_view path_delim = "/";
+#endif
 
-    path_components parse_path(const std::string_view path) {
-        // Some cases to consider
-        // projects/libassert/demo.cpp               projects   libassert  demo.cpp
-        // /glibc-2.27/csu/../csu/libc-start.c  /  glibc-2.27 csu      libc-start.c
-        // ./demo.exe                           .  demo.exe
-        // ./../demo.exe                        .. demo.exe
-        // ../x.hpp                             .. x.hpp
-        // /foo/./x                                foo        x
-        // /foo//x                                 f          x
-        path_components parts;
-        for(auto part : split(path, path_delim)) {
-            if(parts.empty()) {
-                // TODO: Maybe it could be ok to use string_view's here, have to be careful about lifetime
-                // first gets added no matter what
-                parts.emplace_back(part);
-            } else {
-                if(part.empty()) {
-                    // nop
-                } else if(part == ".") {
-                    // nop
-                } else if(part == "..") {
-                    // cases where we have unresolvable ..'s, e.g. ./../../demo.exe
-                    if(parts.back() == "." || parts.back() == "..") {
-                        parts.emplace_back(part);
-                    } else {
-                        parts.pop_back();
-                    }
-                } else {
-                    parts.emplace_back(part);
-                }
-            }
-        }
-        LIBASSERT_PRIMITIVE_DEBUG_ASSERT(!parts.empty());
-        LIBASSERT_PRIMITIVE_DEBUG_ASSERT(parts.back() != "." && parts.back() != "..");
-        return parts;
-    }
-
-    void path_trie::insert(const path_components& path) {
-        LIBASSERT_PRIMITIVE_DEBUG_ASSERT(path.back() == root);
-        insert(path, (int)path.size() - 2);
-    }
-
-    path_components path_trie::disambiguate(const path_components& path) {
-        path_components result;
-        path_trie* current = this;
-        LIBASSERT_PRIMITIVE_DEBUG_ASSERT(path.back() == root);
-        result.push_back(current->root);
-        for(size_t i = path.size() - 2; i >= 1; i--) {
-            LIBASSERT_PRIMITIVE_DEBUG_ASSERT(current->downstream_branches >= 1);
-            if(current->downstream_branches == 1) {
-                break;
-            }
-            const std::string& component = path[i];
-            LIBASSERT_PRIMITIVE_DEBUG_ASSERT(current->edges.count(component));
-            current = current->edges.at(component).get();
-            result.push_back(current->root);
-        }
-        std::reverse(result.begin(), result.end());
-        return result;
-    }
-
-    void path_trie::insert(const path_components& path, int i) {
-        if(i < 0) {
-            return;
-        }
-        if(!edges.count(path[i])) {
-            if(!edges.empty()) {
-                downstream_branches++; // this is to deal with making leaves have count 1
-            }
-            edges.insert({path[i], std::make_unique<path_trie>(path[i])});
-        }
-        downstream_branches -= edges.at(path[i])->downstream_branches;
-        edges.at(path[i])->insert(path, i - 1);
-        downstream_branches += edges.at(path[i])->downstream_branches;
-    }
-
-    bool path_handler::has_add_path() const {
-        return false;
-    }
-
-    void path_handler::add_path(std::string_view) {
-        LIBASSERT_PRIMITIVE_DEBUG_ASSERT(false, "Improper path_handler::add_path");
-    }
-
-    void path_handler::finalize() {
-        LIBASSERT_PRIMITIVE_DEBUG_ASSERT(false, "Improper path_handler::finalize");
-    }
-
-    std::unique_ptr<detail::path_handler> identity_path_handler::clone() const {
-        return std::make_unique<identity_path_handler>(*this);
-    }
-
-    std::string_view identity_path_handler::resolve_path(std::string_view path) {
-        return path;
-    }
-
-    std::unique_ptr<detail::path_handler> disambiguating_path_handler::clone() const {
-        return std::make_unique<disambiguating_path_handler>(*this);
-    }
-
-    std::string_view disambiguating_path_handler::resolve_path(std::string_view path) {
-        return path_map.at(std::string(path));
-    }
-
-    bool disambiguating_path_handler::has_add_path() const {
-        return true;
-    }
-
-    void disambiguating_path_handler::add_path(std::string_view path) {
-        paths.emplace_back(path);
-    }
-
-    void disambiguating_path_handler::finalize() {
-        // raw full path -> components
-        std::unordered_map<std::string, path_components> parsed_paths;
-        // base file name -> path trie
-        std::unordered_map<std::string, path_trie> tries;
-        for(const auto& path : paths) {
-            if(!parsed_paths.count(path)) {
-                auto parsed_path = parse_path(path);
-                auto& file_name = parsed_path.back();
-                parsed_paths.insert({path, parsed_path});
-                if(tries.count(file_name) == 0) {
-                    tries.insert({file_name, path_trie(file_name)});
-                }
-                tries.at(file_name).insert(parsed_path);
-            }
-        }
-        // raw full path -> minified path
-        std::unordered_map<std::string, std::string> files;
-        for(auto& [raw, parsed_path] : parsed_paths) {
-            const std::string new_path = join(tries.at(parsed_path.back()).disambiguate(parsed_path), "/");
-            LIBASSERT_PRIMITIVE_ASSERT(files.insert({raw, new_path}).second);
-        }
-        path_map = std::move(files);
-        // return {files, std::min(longest_file_width, size_t(50))};
-    }
-
-    std::unique_ptr<detail::path_handler> basename_path_handler::clone() const {
-        return std::make_unique<basename_path_handler>(*this);
-    }
-
-    std::string_view basename_path_handler::resolve_path(std::string_view path) {
-        auto last = path.find_last_of(path_delim);
-        if(last == path.npos) {
-            last = 0;
-        } else {
-            last++; // go after the delim
-        }
-        return path.substr(last);
-    }
+path_components parse_path(const std::string_view path) {
+	// Some cases to consider
+	// projects/libassert/demo.cpp               projects   libassert  demo.cpp
+	// /glibc-2.27/csu/../csu/libc-start.c  /  glibc-2.27 csu      libc-start.c
+	// ./demo.exe                           .  demo.exe
+	// ./../demo.exe                        .. demo.exe
+	// ../x.hpp                             .. x.hpp
+	// /foo/./x                                foo        x
+	// /foo//x                                 f          x
+	path_components parts;
+	for (auto part : split(path, path_delim)) {
+		if (parts.empty()) {
+			// TODO: Maybe it could be ok to use string_view's here, have to be careful about lifetime
+			// first gets added no matter what
+			parts.emplace_back(part);
+		} else {
+			if (part.empty()) {
+				// nop
+			} else if (part == ".") {
+				// nop
+			} else if (part == "..") {
+				// cases where we have unresolvable ..'s, e.g. ./../../demo.exe
+				if (parts.back() == "." || parts.back() == "..") {
+					parts.emplace_back(part);
+				} else {
+					parts.pop_back();
+				}
+			} else {
+				parts.emplace_back(part);
+			}
+		}
+	}
+	LIBASSERT_PRIMITIVE_DEBUG_ASSERT(!parts.empty());
+	LIBASSERT_PRIMITIVE_DEBUG_ASSERT(parts.back() != "." && parts.back() != "..");
+	return parts;
 }
+
+void path_trie::insert(const path_components& path) {
+	LIBASSERT_PRIMITIVE_DEBUG_ASSERT(path.back() == root);
+	insert(path, (int)path.size() - 2);
+}
+
+path_components path_trie::disambiguate(const path_components& path) {
+	path_components result;
+	path_trie* current = this;
+	LIBASSERT_PRIMITIVE_DEBUG_ASSERT(path.back() == root);
+	result.push_back(current->root);
+	for (size_t i = path.size() - 2; i >= 1; i--) {
+		LIBASSERT_PRIMITIVE_DEBUG_ASSERT(current->downstream_branches >= 1);
+		if (current->downstream_branches == 1) {
+			break;
+		}
+		const std::string& component = path[i];
+		LIBASSERT_PRIMITIVE_DEBUG_ASSERT(current->edges.count(component));
+		current = current->edges.at(component).get();
+		result.push_back(current->root);
+	}
+	std::reverse(result.begin(), result.end());
+	return result;
+}
+
+void path_trie::insert(const path_components& path, int i) {
+	if (i < 0) {
+		return;
+	}
+	if (!edges.count(path[i])) {
+		if (!edges.empty()) {
+			downstream_branches++; // this is to deal with making leaves have count 1
+		}
+		edges.insert({path[i], std::make_unique<path_trie>(path[i])});
+	}
+	downstream_branches -= edges.at(path[i])->downstream_branches;
+	edges.at(path[i])->insert(path, i - 1);
+	downstream_branches += edges.at(path[i])->downstream_branches;
+}
+
+bool path_handler::has_add_path() const {
+	return false;
+}
+
+void path_handler::add_path(std::string_view) {
+	LIBASSERT_PRIMITIVE_DEBUG_ASSERT(false, "Improper path_handler::add_path");
+}
+
+void path_handler::finalize() {
+	LIBASSERT_PRIMITIVE_DEBUG_ASSERT(false, "Improper path_handler::finalize");
+}
+
+std::unique_ptr<detail::path_handler> identity_path_handler::clone() const {
+	return std::make_unique<identity_path_handler>(*this);
+}
+
+std::string_view identity_path_handler::resolve_path(std::string_view path) {
+	return path;
+}
+
+std::unique_ptr<detail::path_handler> disambiguating_path_handler::clone() const {
+	return std::make_unique<disambiguating_path_handler>(*this);
+}
+
+std::string_view disambiguating_path_handler::resolve_path(std::string_view path) {
+	return path_map.at(std::string(path));
+}
+
+bool disambiguating_path_handler::has_add_path() const {
+	return true;
+}
+
+void disambiguating_path_handler::add_path(std::string_view path) {
+	paths.emplace_back(path);
+}
+
+void disambiguating_path_handler::finalize() {
+	// raw full path -> components
+	std::unordered_map<std::string, path_components> parsed_paths;
+	// base file name -> path trie
+	std::unordered_map<std::string, path_trie> tries;
+	for (const auto& path : paths) {
+		if (!parsed_paths.count(path)) {
+			auto parsed_path = parse_path(path);
+			auto& file_name = parsed_path.back();
+			parsed_paths.insert({path, parsed_path});
+			if (tries.count(file_name) == 0) {
+				tries.insert({file_name, path_trie(file_name)});
+			}
+			tries.at(file_name).insert(parsed_path);
+		}
+	}
+	// raw full path -> minified path
+	std::unordered_map<std::string, std::string> files;
+	for (auto& [raw, parsed_path] : parsed_paths) {
+		const std::string new_path = join(tries.at(parsed_path.back()).disambiguate(parsed_path), "/");
+		LIBASSERT_PRIMITIVE_ASSERT(files.insert({raw, new_path}).second);
+	}
+	path_map = std::move(files);
+	// return {files, std::min(longest_file_width, size_t(50))};
+}
+
+std::unique_ptr<detail::path_handler> basename_path_handler::clone() const {
+	return std::make_unique<basename_path_handler>(*this);
+}
+
+std::string_view basename_path_handler::resolve_path(std::string_view path) {
+	auto last = path.find_last_of(path_delim);
+	if (last == path.npos) {
+		last = 0;
+	} else {
+		last++; // go after the delim
+	}
+	return path.substr(last);
+}
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE

--- a/src/paths.hpp
+++ b/src/paths.hpp
@@ -1,65 +1,70 @@
 #ifndef PATHS_HPP
 #define PATHS_HPP
 
-#include <string_view>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
-#include "utils.hpp"
-
 #include <libassert/assert.hpp>
 
+#include "utils.hpp"
+
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    using path_components = std::vector<std::string>;
+using path_components = std::vector<std::string>;
 
-    path_components parse_path(const std::string_view path);
+path_components parse_path(const std::string_view path);
 
-    class path_trie {
-        // Backwards path trie structure
-        // e.g.:
-        // a/b/c/d/e     disambiguate to -> c/d/e
-        // a/b/f/d/e     disambiguate to -> f/d/e
-        //  2   2   1   1   1
-        // e - d - c - b - a
-        //      \   1   1   1
-        //       \ f - b - a
-        // Nodes are marked with the number of downstream branches
-        size_t downstream_branches = 1;
-        std::string root;
-        std::unordered_map<std::string, std::unique_ptr<path_trie>> edges;
-    public:
-        explicit path_trie(std::string _root) : root(std::move(_root)) {};
-        void insert(const path_components& path);
-        path_components disambiguate(const path_components& path);
-    private:
-        void insert(const path_components& path, int i);
-    };
+class path_trie {
+	// Backwards path trie structure
+	// e.g.:
+	// a/b/c/d/e     disambiguate to -> c/d/e
+	// a/b/f/d/e     disambiguate to -> f/d/e
+	//  2   2   1   1   1
+	// e - d - c - b - a
+	//      \   1   1   1
+	//       \ f - b - a
+	// Nodes are marked with the number of downstream branches
+	size_t downstream_branches = 1;
+	std::string root;
+	std::unordered_map<std::string, std::unique_ptr<path_trie>> edges;
 
-    class identity_path_handler : public path_handler {
-    public:
-        std::unique_ptr<detail::path_handler> clone() const override;
-        std::string_view resolve_path(std::string_view) override;
-    };
+public:
+	explicit path_trie(std::string _root) : root(std::move(_root)) {};
+	void insert(const path_components& path);
+	path_components disambiguate(const path_components& path);
 
-    class disambiguating_path_handler : public path_handler {
-        std::vector<std::string> paths;
-        std::unordered_map<std::string, std::string> path_map;
-    public:
-        std::unique_ptr<detail::path_handler> clone() const override;
-        std::string_view resolve_path(std::string_view) override;
-        bool has_add_path() const override;
-        void add_path(std::string_view) override;
-        void finalize() override;
-    };
+private:
+	void insert(const path_components& path, int i);
+};
 
-    class basename_path_handler : public path_handler {
-    public:
-        std::unique_ptr<detail::path_handler> clone() const override;
-        std::string_view resolve_path(std::string_view) override;
-    };
-}
+class identity_path_handler: public path_handler {
+public:
+	std::unique_ptr<detail::path_handler> clone() const override;
+	std::string_view resolve_path(std::string_view) override;
+};
+
+class disambiguating_path_handler: public path_handler {
+	std::vector<std::string> paths;
+	std::unordered_map<std::string, std::string> path_map;
+
+public:
+	std::unique_ptr<detail::path_handler> clone() const override;
+	std::string_view resolve_path(std::string_view) override;
+	bool has_add_path() const override;
+	void add_path(std::string_view) override;
+	void finalize() override;
+};
+
+class basename_path_handler: public path_handler {
+public:
+	std::unique_ptr<detail::path_handler> clone() const override;
+	std::string_view resolve_path(std::string_view) override;
+};
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE
 
 #endif

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -13,20 +13,20 @@
 #include "utils.hpp"
 
 #if IS_WINDOWS
- #include <windows.h>
- #include <io.h>
- #undef min // fucking windows headers, man
- #undef max
+	#include <io.h>
+	#include <windows.h>
+	#undef min // fucking windows headers, man
+	#undef max
 #elif IS_LINUX
- #include <charconv>
- #include <fcntl.h>
- #include <sys/ioctl.h>
- #include <unistd.h>
+	#include <charconv>
+	#include <fcntl.h>
+	#include <sys/ioctl.h>
+	#include <unistd.h>
 #elif IS_APPLE
- #include <sys/ioctl.h>
- #include <sys/sysctl.h>
- #include <sys/types.h>
- #include <unistd.h>
+	#include <sys/ioctl.h>
+	#include <sys/sysctl.h>
+	#include <sys/types.h>
+	#include <unistd.h>
 #endif
 
 #include <libassert/assert.hpp>
@@ -34,171 +34,193 @@
 // All platform-specific/system code lives here
 
 LIBASSERT_BEGIN_NAMESPACE
-    // https://stackoverflow.com/questions/23369503/get-size-of-terminal-window-rows-columns
-    int terminal_width(int fd) {
-        if(fd < 0) {
-            return 0;
-        }
-        #if IS_WINDOWS
-         DWORD windows_handle = detail::needle(fd).lookup(
-             STDIN_FILENO, STD_INPUT_HANDLE,
-             STDOUT_FILENO, STD_OUTPUT_HANDLE,
-             STDERR_FILENO, STD_ERROR_HANDLE
-         );
-         CONSOLE_SCREEN_BUFFER_INFO csbi;
-         HANDLE h = GetStdHandle(windows_handle);
-         if(h == INVALID_HANDLE_VALUE) { return 0; }
-         if(!GetConsoleScreenBufferInfo(h, &csbi)) { return 0; }
-         return csbi.srWindow.Right - csbi.srWindow.Left + 1;
-        #else
-         struct winsize w;
-         // NOLINTNEXTLINE(misc-include-cleaner)
-         if(ioctl(fd, TIOCGWINSZ, &w) == -1) { return 0; }
-         return w.ws_col;
-        #endif
-    }
 
-    #if IS_LINUX
-    class file_closer {
-        int fd;
-    public:
-        file_closer(int fd_) : fd(fd_) {}
-        file_closer(const file_closer&) = delete;
-        file_closer(file_closer&&) = delete;
-        file_closer& operator=(const file_closer&) = delete;
-        file_closer& operator=(file_closer&&) = delete;
-        ~file_closer() {
-            if(close(fd) == -1) {
-                perror("Libassert: Something went wrong when closing a file descriptor.");
-            }
-        }
-    };
-    #endif
+// https://stackoverflow.com/questions/23369503/get-size-of-terminal-window-rows-columns
+int terminal_width(int fd) {
+	if (fd < 0) {
+		return 0;
+	}
+#if IS_WINDOWS
+	DWORD windows_handle = detail::needle(fd).lookup(
+		STDIN_FILENO,
+		STD_INPUT_HANDLE,
+		STDOUT_FILENO,
+		STD_OUTPUT_HANDLE,
+		STDERR_FILENO,
+		STD_ERROR_HANDLE
+	);
+	CONSOLE_SCREEN_BUFFER_INFO csbi;
+	HANDLE h = GetStdHandle(windows_handle);
+	if (h == INVALID_HANDLE_VALUE) {
+		return 0;
+	}
+	if (!GetConsoleScreenBufferInfo(h, &csbi)) {
+		return 0;
+	}
+	return csbi.srWindow.Right - csbi.srWindow.Left + 1;
+#else
+	struct winsize w;
+	// NOLINTNEXTLINE(misc-include-cleaner)
+	if (ioctl(fd, TIOCGWINSZ, &w) == -1) {
+		return 0;
+	}
+	return w.ws_col;
+#endif
+}
 
-	bool is_debugger_present_internal() noexcept {
-        #if IS_WINDOWS
-         return IsDebuggerPresent();
-        #elif IS_LINUX
-         // https://www.man7.org/linux/man-pages/man5/proc.5.html
-         // We're looking at the top of /proc/self/status until we find "TracerPid:"
-         // Sample:
-         //  Name:   cat
-         //  Umask:  0022
-         //  State:  R (running)
-         //  Tgid:   106085
-         //  Ngid:   0
-         //  Pid:    106085
-         //  PPid:   104045
-         //  TracerPid:      0
-         // The name is truncated at 16 characters, so this whole thing should be under 256 chars
-         constexpr std::size_t read_goal = 256;
-         int fd = open("/proc/self/status", O_RDONLY);
-         if(fd == -1) {
-             // something went wrong
-             return false;
-         }
-         file_closer closer(fd);
-         char buffer[read_goal];
-         auto size = read(fd, buffer, read_goal);
-         if(size == -1) {
-             // something went wrong
-             return false;
-         }
-         std::string_view status{buffer, std::size_t(size)};
-         constexpr std::string_view key = "TracerPid:";
-         auto pos = status.find(key);
-         if(pos == std::string_view::npos) {
-             return false;
-         }
-         auto pid_start = status.find_first_not_of(detail::whitespace_chars, pos + key.size());
-         if(pid_start == std::string_view::npos) {
-             return false;
-         }
-         auto pid_end = status.find_first_of(detail::whitespace_chars, pid_start);
-         if(pid_end == std::string_view::npos) {
-             return false;
-         }
-         // since we found a whitespace character after the pid we know the read wasn't somehow weirdly truncated
-         auto tracer_pid = status.substr(pid_start, pid_end - pid_start);
-         int value;
-         if(std::from_chars(tracer_pid.data(), tracer_pid.data() + tracer_pid.size(), value).ec == std::errc{}) {
-             return value != 0;
-         } else {
-             return false;
-         }
-         return false;
-        #else
-         // https://developer.apple.com/library/archive/qa/qa1361/_index.html
-         int mib[4] {CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()};
-         struct kinfo_proc info;
-         info.kp_proc.p_flag = 0;
-         size_t size = sizeof(info);
-         int res = sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, NULL, 0);
-         if(res != 0) {
-             // something went wrong, assume false
-             return false;
-         }
-         return info.kp_proc.p_flag & P_TRACED;
-        #endif
-    }
+#if IS_LINUX
+class file_closer {
+	int fd;
 
-    std::atomic<debugger_check_mode> check_mode = debugger_check_mode::check_once;
-    std::mutex is_debugger_present_mutex;
-    std::optional<bool> cached_is_debugger_present;
+public:
+	file_closer(int fd_) : fd(fd_) {}
 
-    bool is_debugger_present() noexcept {
-        if(check_mode.load() == debugger_check_mode::check_every_time) {
-            return is_debugger_present_internal();
-        } else {
-            std::unique_lock lock(is_debugger_present_mutex);
-            if(cached_is_debugger_present) {
-                return *cached_is_debugger_present;
-            } else {
-                cached_is_debugger_present = is_debugger_present_internal();
-                return *cached_is_debugger_present;
-            }
-        }
-    }
+	file_closer(const file_closer&) = delete;
+	file_closer(file_closer&&) = delete;
+	file_closer& operator=(const file_closer&) = delete;
+	file_closer& operator=(file_closer&&) = delete;
 
-    LIBASSERT_EXPORT
-    void set_debugger_check_mode(debugger_check_mode mode) noexcept {
-        check_mode = mode;
-    }
+	~file_closer() {
+		if (close(fd) == -1) {
+			perror("Libassert: Something went wrong when closing a file descriptor.");
+		}
+	}
+};
+#endif
 
-    LIBASSERT_EXPORT void enable_virtual_terminal_processing_if_needed() {
-        // enable colors / ansi processing if necessary
-        #if IS_WINDOWS
-         // https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#example-of-enabling-virtual-terminal-processing
-         #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
-          constexpr DWORD ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x4;
-         #endif
-         HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
-         DWORD dwMode = 0;
-         if(hOut == INVALID_HANDLE_VALUE) return;
-         if(!GetConsoleMode(hOut, &dwMode)) return;
-         if(dwMode != (dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING))
-         if(!SetConsoleMode(hOut, dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING)) return;
-        #endif
-    }
+bool is_debugger_present_internal() noexcept {
+#if IS_WINDOWS
+	return IsDebuggerPresent();
+#elif IS_LINUX
+	// https://www.man7.org/linux/man-pages/man5/proc.5.html
+	// We're looking at the top of /proc/self/status until we find "TracerPid:"
+	// Sample:
+	//  Name:   cat
+	//  Umask:  0022
+	//  State:  R (running)
+	//  Tgid:   106085
+	//  Ngid:   0
+	//  Pid:    106085
+	//  PPid:   104045
+	//  TracerPid:      0
+	// The name is truncated at 16 characters, so this whole thing should be under 256 chars
+	constexpr std::size_t read_goal = 256;
+	int fd = open("/proc/self/status", O_RDONLY);
+	if (fd == -1) {
+		// something went wrong
+		return false;
+	}
+	file_closer closer(fd);
+	char buffer[read_goal];
+	auto size = read(fd, buffer, read_goal);
+	if (size == -1) {
+		// something went wrong
+		return false;
+	}
+	std::string_view status {buffer, std::size_t(size)};
+	constexpr std::string_view key = "TracerPid:";
+	auto pos = status.find(key);
+	if (pos == std::string_view::npos) {
+		return false;
+	}
+	auto pid_start = status.find_first_not_of(detail::whitespace_chars, pos + key.size());
+	if (pid_start == std::string_view::npos) {
+		return false;
+	}
+	auto pid_end = status.find_first_of(detail::whitespace_chars, pid_start);
+	if (pid_end == std::string_view::npos) {
+		return false;
+	}
+	// since we found a whitespace character after the pid we know the read wasn't somehow weirdly truncated
+	auto tracer_pid = status.substr(pid_start, pid_end - pid_start);
+	int value;
+	if (
+		std::from_chars(tracer_pid.data(), tracer_pid.data() + tracer_pid.size(), value).ec
+		== std::errc {}
+	) {
+		return value != 0;
+	} else {
+		return false;
+	}
+	return false;
+#else
+	// https://developer.apple.com/library/archive/qa/qa1361/_index.html
+	int mib[4] {CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()};
+	struct kinfo_proc info;
+	info.kp_proc.p_flag = 0;
+	size_t size = sizeof(info);
+	int res = sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, NULL, 0);
+	if (res != 0) {
+		// something went wrong, assume false
+		return false;
+	}
+	return info.kp_proc.p_flag & P_TRACED;
+#endif
+}
 
-    bool isatty(int fd) {
-        #if IS_WINDOWS
-         return _isatty(fd);
-        #else
-         return ::isatty(fd);
-        #endif
-    }
+std::atomic<debugger_check_mode> check_mode = debugger_check_mode::check_once;
+std::mutex is_debugger_present_mutex;
+std::optional<bool> cached_is_debugger_present;
+
+bool is_debugger_present() noexcept {
+	if (check_mode.load() == debugger_check_mode::check_every_time) {
+		return is_debugger_present_internal();
+	} else {
+		std::unique_lock lock(is_debugger_present_mutex);
+		if (cached_is_debugger_present) {
+			return *cached_is_debugger_present;
+		} else {
+			cached_is_debugger_present = is_debugger_present_internal();
+			return *cached_is_debugger_present;
+		}
+	}
+}
+
+LIBASSERT_EXPORT
+void set_debugger_check_mode(debugger_check_mode mode) noexcept {
+	check_mode = mode;
+}
+
+LIBASSERT_EXPORT void enable_virtual_terminal_processing_if_needed() {
+// enable colors / ansi processing if necessary
+#if IS_WINDOWS
+	// https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#example-of-enabling-virtual-terminal-processing
+	#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+	constexpr DWORD ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x4;
+	#endif
+	HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+	DWORD dwMode = 0;
+	if (hOut == INVALID_HANDLE_VALUE)
+		return;
+	if (!GetConsoleMode(hOut, &dwMode))
+		return;
+	if (dwMode != (dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING))
+		if (!SetConsoleMode(hOut, dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING))
+			return;
+#endif
+}
+
+bool isatty(int fd) {
+#if IS_WINDOWS
+	return _isatty(fd);
+#else
+	return ::isatty(fd);
+#endif
+}
+
 LIBASSERT_END_NAMESPACE
 
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    std::string strerror_wrapper(int e) {
-        // "strerror is not required to be thread-safe. Implementations may be returning different pointers to static
-        // read-only string literals or may be returning the same pointer over and over, pointing at a static buffer
-        // in which strerror places the string."
-        static std::mutex mutex;
-        std::unique_lock lock(mutex);
-        return strerror(e);
-    }
+std::string strerror_wrapper(int e) {
+	// "strerror is not required to be thread-safe. Implementations may be returning different pointers to static
+	// read-only string literals or may be returning the same pointer over and over, pointing at a static buffer
+	// in which strerror places the string."
+	static std::mutex mutex;
+	std::unique_lock lock(mutex);
+	return strerror(e);
 }
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -4,26 +4,28 @@
 #include "common.hpp"
 
 #ifndef _CRT_SECURE_NO_WARNINGS
-// NOLINTNEXTLINE(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp)
-#define _CRT_SECURE_NO_WARNINGS // done only for strerror
+	// NOLINTNEXTLINE(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp)
+	#define _CRT_SECURE_NO_WARNINGS // done only for strerror
 #endif
 
 #if IS_WINDOWS
- #ifndef STDIN_FILENO
-  #define STDIN_FILENO _fileno(stdin)
-  #define STDOUT_FILENO _fileno(stdout)
-  #define STDERR_FILENO _fileno(stderr)
- #endif
+	#ifndef STDIN_FILENO
+		#define STDIN_FILENO _fileno(stdin)
+		#define STDOUT_FILENO _fileno(stdout)
+		#define STDERR_FILENO _fileno(stderr)
+	#endif
 #else
- #include <unistd.h>
+	#include <unistd.h>
 #endif
 
 #include <libassert/assert.hpp>
 
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    std::string strerror_wrapper(int e);
+std::string strerror_wrapper(int e);
 }
+
 LIBASSERT_END_NAMESPACE
 
 #endif

--- a/src/printing.cpp
+++ b/src/printing.cpp
@@ -3,87 +3,91 @@
 #include "microfmt.hpp"
 
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    // TODO
-    // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-    std::string wrapped_print(const std::vector<column_t>& columns, const color_scheme& scheme) {
-        // 2d array rows/columns
-        struct line_content {
-            size_t length;
-            std::string content;
-        };
-        std::vector<std::vector<line_content>> lines;
-        lines.emplace_back(columns.size());
-        // populate one column at a time
-        for(size_t i = 0; i < columns.size(); i++) {
-            auto [width, blocks, _] = columns[i];
-            size_t current_line = 0;
-            for(auto& block : blocks) {
-                size_t block_i = 0;
-                // digest block
-                while(block_i != block.content.size()) {
-                    if(lines.size() == current_line) {
-                        lines.emplace_back(columns.size());
-                    }
-                    // number of characters we can extract from the block
-                    size_t extract = std::min(width - lines[current_line][i].length, block.content.size() - block_i);
-                    LIBASSERT_PRIMITIVE_DEBUG_ASSERT(block_i + extract <= block.content.size());
-                    auto substr = std::string_view(block.content).substr(block_i, extract);
-                    // handle newlines
-                    if(auto x = substr.find('\n'); x != std::string_view::npos) {
-                        substr = substr.substr(0, x);
-                        extract = x + 1; // extract newline but don't print
-                    }
-                    // append
-                    lines[current_line][i].content += block.highlight;
-                    lines[current_line][i].content += block.color;
-                    lines[current_line][i].content += substr;
-                    lines[current_line][i].content
-                        += block.color.empty() && block.highlight.empty() ? "" : scheme.reset;
-                    // advance
-                    block_i += extract;
-                    lines[current_line][i].length += extract;
-                    // new line if necessary
-                    // substr.size() != extract iff newline
-                    if(lines[current_line][i].length >= width || substr.size() != extract) {
-                        current_line++;
-                    }
-                }
-            }
-        }
-        // print
-        std::string output;
-        for(auto& line : lines) {
-            // don't print empty columns with no content in subsequent columns and more importantly
-            // don't print empty spaces they'll mess up lines after terminal resizing even more
-            size_t last_col = 0;
-            for(size_t i = 0; i < line.size(); i++) {
-                if(!line[i].content.empty()) {
-                    last_col = i;
-                }
-            }
-            for(size_t i = 0; i <= last_col; i++) {
-                auto& content = line[i];
-                if(columns[i].right_align) {
-                    output += microfmt::format(
-                        "{<{}}{}{}",
-                        i == last_col ? 0 : int(columns[i].width - content.length),
-                        "",
-                        content.content,
-                        i == last_col ? "\n" : " "
-                    );
-                } else {
-                    output += microfmt::format(
-                        "{}{<{}}{}",
-                        content.content,
-                        i == last_col ? 0 : int(columns[i].width - content.length),
-                        "",
-                        i == last_col ? "\n" : " "
-                    );
-                }
-            }
-        }
-        return output;
-    }
+// TODO
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+std::string wrapped_print(const std::vector<column_t>& columns, const color_scheme& scheme) {
+	// 2d array rows/columns
+	struct line_content {
+		size_t length;
+		std::string content;
+	};
+
+	std::vector<std::vector<line_content>> lines;
+	lines.emplace_back(columns.size());
+	// populate one column at a time
+	for (size_t i = 0; i < columns.size(); i++) {
+		auto [width, blocks, _] = columns[i];
+		size_t current_line = 0;
+		for (auto& block : blocks) {
+			size_t block_i = 0;
+			// digest block
+			while (block_i != block.content.size()) {
+				if (lines.size() == current_line) {
+					lines.emplace_back(columns.size());
+				}
+				// number of characters we can extract from the block
+				size_t extract =
+					std::min(width - lines[current_line][i].length, block.content.size() - block_i);
+				LIBASSERT_PRIMITIVE_DEBUG_ASSERT(block_i + extract <= block.content.size());
+				auto substr = std::string_view(block.content).substr(block_i, extract);
+				// handle newlines
+				if (auto x = substr.find('\n'); x != std::string_view::npos) {
+					substr = substr.substr(0, x);
+					extract = x + 1; // extract newline but don't print
+				}
+				// append
+				lines[current_line][i].content += block.highlight;
+				lines[current_line][i].content += block.color;
+				lines[current_line][i].content += substr;
+				lines[current_line][i].content +=
+					block.color.empty() && block.highlight.empty() ? "" : scheme.reset;
+				// advance
+				block_i += extract;
+				lines[current_line][i].length += extract;
+				// new line if necessary
+				// substr.size() != extract iff newline
+				if (lines[current_line][i].length >= width || substr.size() != extract) {
+					current_line++;
+				}
+			}
+		}
+	}
+	// print
+	std::string output;
+	for (auto& line : lines) {
+		// don't print empty columns with no content in subsequent columns and more importantly
+		// don't print empty spaces they'll mess up lines after terminal resizing even more
+		size_t last_col = 0;
+		for (size_t i = 0; i < line.size(); i++) {
+			if (!line[i].content.empty()) {
+				last_col = i;
+			}
+		}
+		for (size_t i = 0; i <= last_col; i++) {
+			auto& content = line[i];
+			if (columns[i].right_align) {
+				output += microfmt::format(
+					"{<{}}{}{}",
+					i == last_col ? 0 : int(columns[i].width - content.length),
+					"",
+					content.content,
+					i == last_col ? "\n" : " "
+				);
+			} else {
+				output += microfmt::format(
+					"{}{<{}}{}",
+					content.content,
+					i == last_col ? 0 : int(columns[i].width - content.length),
+					"",
+					i == last_col ? "\n" : " "
+				);
+			}
+		}
+	}
+	return output;
 }
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE

--- a/src/printing.hpp
+++ b/src/printing.hpp
@@ -3,28 +3,34 @@
 
 #include <vector>
 
+#include <libassert/assert.hpp>
+
 #include "analysis.hpp"
 #include "utils.hpp"
 
-#include <libassert/assert.hpp>
-
 LIBASSERT_BEGIN_NAMESPACE
-namespace detail {
-    struct column_t {
-        size_t width;
-        std::vector<highlight_block> blocks;
-        bool right_align = false;
-        column_t(size_t _width, std::vector<highlight_block> _blocks, bool _right_align = false)
-            : width(_width), blocks(std::move(_blocks)), right_align(_right_align) {}
-        column_t(const column_t&) = default;
-        column_t(column_t&&) = default;
-        ~column_t() = default;
-        column_t& operator=(const column_t&) = default;
-        column_t& operator=(column_t&&) = default;
-    };
 
-    std::string wrapped_print(const std::vector<column_t>& columns, const color_scheme& scheme);
-}
+namespace detail {
+struct column_t {
+	size_t width;
+	std::vector<highlight_block> blocks;
+	bool right_align = false;
+
+	column_t(size_t _width, std::vector<highlight_block> _blocks, bool _right_align = false) :
+		width(_width),
+		blocks(std::move(_blocks)),
+		right_align(_right_align) {}
+
+	column_t(const column_t&) = default;
+	column_t(column_t&&) = default;
+	~column_t() = default;
+	column_t& operator=(const column_t&) = default;
+	column_t& operator=(column_t&&) = default;
+};
+
+std::string wrapped_print(const std::vector<column_t>& columns, const color_scheme& scheme);
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE
 
 #endif

--- a/src/stringification.cpp
+++ b/src/stringification.cpp
@@ -5,352 +5,375 @@
 #include <sstream>
 #include <string>
 
+#include <libassert/assert.hpp>
+
 #include "analysis.hpp"
 #include "microfmt.hpp"
 #include "utils.hpp"
 
-#include <libassert/assert.hpp>
-
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    /*
+/*
      * literal format management
      */
 
-    [[nodiscard]] constexpr std::underlying_type<literal_format>::type operator&(literal_format a, literal_format b) {
-        return static_cast<std::underlying_type<literal_format>::type>(a) &
-               static_cast<std::underlying_type<literal_format>::type>(b);
-    }
-
-    std::mutex literal_format_config_mutex;
-    literal_format_mode current_literal_format_mode = literal_format_mode::infer;
-    literal_format current_fixed_literal_format = literal_format::default_format;
-
-    thread_local literal_format thread_current_literal_format = literal_format::default_format;
+[[nodiscard]] constexpr std::underlying_type<literal_format>::type
+operator&(literal_format a, literal_format b) {
+	return static_cast<std::underlying_type<literal_format>::type>(a)
+		& static_cast<std::underlying_type<literal_format>::type>(b);
 }
+
+std::mutex literal_format_config_mutex;
+literal_format_mode current_literal_format_mode = literal_format_mode::infer;
+literal_format current_fixed_literal_format = literal_format::default_format;
+
+thread_local literal_format thread_current_literal_format = literal_format::default_format;
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE
 
 LIBASSERT_BEGIN_NAMESPACE
-    LIBASSERT_EXPORT void set_literal_format_mode(literal_format_mode mode) {
-        std::unique_lock lock(detail::literal_format_config_mutex);
-        detail::current_literal_format_mode = mode;
-    }
+LIBASSERT_EXPORT void set_literal_format_mode(literal_format_mode mode) {
+	std::unique_lock lock(detail::literal_format_config_mutex);
+	detail::current_literal_format_mode = mode;
+}
 
-    LIBASSERT_EXPORT void set_fixed_literal_format(literal_format format) {
-        std::unique_lock lock(detail::literal_format_config_mutex);
-        detail::current_fixed_literal_format = format;
-        detail::thread_current_literal_format = format;
-        detail::current_literal_format_mode = literal_format_mode::fixed_variations;
-    }
+LIBASSERT_EXPORT void set_fixed_literal_format(literal_format format) {
+	std::unique_lock lock(detail::literal_format_config_mutex);
+	detail::current_fixed_literal_format = format;
+	detail::thread_current_literal_format = format;
+	detail::current_literal_format_mode = literal_format_mode::fixed_variations;
+}
+
 LIBASSERT_END_NAMESPACE
 
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    std::pair<literal_format_mode, literal_format> get_literal_format_config() {
-        std::unique_lock lock(literal_format_config_mutex);
-        return {current_literal_format_mode, current_fixed_literal_format};
-    }
+std::pair<literal_format_mode, literal_format> get_literal_format_config() {
+	std::unique_lock lock(literal_format_config_mutex);
+	return {current_literal_format_mode, current_fixed_literal_format};
+}
 
-    // get current literal_format configuration for the thread
-    [[nodiscard]] LIBASSERT_EXPORT literal_format get_thread_current_literal_format() {
-        return thread_current_literal_format;
-    }
+// get current literal_format configuration for the thread
+[[nodiscard]] LIBASSERT_EXPORT literal_format get_thread_current_literal_format() {
+	return thread_current_literal_format;
+}
 
-    // sets the current literal_format configuration for the thread
-    LIBASSERT_EXPORT void set_thread_current_literal_format(literal_format format) {
-        thread_current_literal_format = format;
-    }
+// sets the current literal_format configuration for the thread
+LIBASSERT_EXPORT void set_thread_current_literal_format(literal_format format) {
+	thread_current_literal_format = format;
+}
 
-    LIBASSERT_EXPORT literal_format set_literal_format(
-        std::string_view left_expression,
-        std::string_view right_expression,
-        std::string_view op,
-        bool integer_character
-    ) {
-        auto previous = get_thread_current_literal_format();
-        auto [mode, fixed_format] = get_literal_format_config();
-        if(mode == literal_format_mode::infer) {
-            auto lformat = get_literal_format(left_expression);
-            auto rformat = get_literal_format(right_expression);
-            auto format = lformat | rformat;
-            if(integer_character) { // if one is a character and the other is not
-                format = format | literal_format::integer_character;
-            }
-            if(is_bitwise(op)) {
-                format = format | literal_format::integer_binary;
-            }
-            set_thread_current_literal_format(format);
-        } else if(mode == literal_format_mode::no_variations) {
-            set_thread_current_literal_format(literal_format::default_format);
-        } else if(mode == literal_format_mode::fixed_variations) {
-            set_thread_current_literal_format(fixed_format);
-        } else {
-            LIBASSERT_PRIMITIVE_DEBUG_ASSERT(false);
-        }
-        return previous;
-    }
+LIBASSERT_EXPORT literal_format set_literal_format(
+	std::string_view left_expression,
+	std::string_view right_expression,
+	std::string_view op,
+	bool integer_character
+) {
+	auto previous = get_thread_current_literal_format();
+	auto [mode, fixed_format] = get_literal_format_config();
+	if (mode == literal_format_mode::infer) {
+		auto lformat = get_literal_format(left_expression);
+		auto rformat = get_literal_format(right_expression);
+		auto format = lformat | rformat;
+		if (integer_character) { // if one is a character and the other is not
+			format = format | literal_format::integer_character;
+		}
+		if (is_bitwise(op)) {
+			format = format | literal_format::integer_binary;
+		}
+		set_thread_current_literal_format(format);
+	} else if (mode == literal_format_mode::no_variations) {
+		set_thread_current_literal_format(literal_format::default_format);
+	} else if (mode == literal_format_mode::fixed_variations) {
+		set_thread_current_literal_format(fixed_format);
+	} else {
+		LIBASSERT_PRIMITIVE_DEBUG_ASSERT(false);
+	}
+	return previous;
+}
 
-    LIBASSERT_EXPORT void restore_literal_format(literal_format format) {
-        set_thread_current_literal_format(format);
-    }
+LIBASSERT_EXPORT void restore_literal_format(literal_format format) {
+	set_thread_current_literal_format(format);
+}
 
-    constexpr auto non_default_integer_formats = literal_format::integer_hex
-                                               | literal_format::integer_octal
-                                               | literal_format::integer_binary
-                                            //    | literal_format::integer_character
-                                               ;
+constexpr auto non_default_integer_formats =
+	literal_format::integer_hex | literal_format::integer_octal | literal_format::integer_binary
+	//    | literal_format::integer_character
+	;
 
-    constexpr auto non_default_float_formats = literal_format::float_hex;
+constexpr auto non_default_float_formats = literal_format::float_hex;
 
-    LIBASSERT_EXPORT bool has_multiple_formats() {
-        auto format = get_thread_current_literal_format();
-        return popcount(format & non_default_integer_formats) || popcount(format & non_default_float_formats);
-    }
+LIBASSERT_EXPORT bool has_multiple_formats() {
+	auto format = get_thread_current_literal_format();
+	return popcount(format & non_default_integer_formats)
+		|| popcount(format & non_default_float_formats);
+}
 
-    /*
+/*
      * Stringification
      */
 
-    static std::string escape_string(const std::string_view str, char quote) {
-        std::string escaped;
-        escaped += quote;
-        for(const char c : str) {
-            if(c == '\\') escaped += "\\\\";
-            else if(c == '\t') escaped += "\\t";
-            else if(c == '\r') escaped += "\\r";
-            else if(c == '\n') escaped += "\\n";
-            else if(c == quote) escaped += std::initializer_list<char>{'\\', quote};
-            else if(c >= 32 && c <= 126) escaped += c; // printable
-            else {
-                constexpr const char * const hexdig = "0123456789abcdef";
-                escaped += std::string("\\x") + hexdig[c >> 4] + hexdig[c & 0xF];
-            }
-        }
-        escaped += quote;
-        return escaped;
-    }
-
-    namespace stringification {
-        std::string stringify_unknown(std::string_view type_name) {
-            return microfmt::format("<instance of {}>", prettify_type(std::string(type_name)));
-        }
-
-        std::string stringify(std::string_view value) {
-            return escape_string(value, '"');
-        }
-
-        std::string stringify(std::nullptr_t) {
-            return "nullptr";
-        }
-
-        std::string stringify(char value) {
-            if(get_thread_current_literal_format() & literal_format::integer_character) {
-                return stringify(static_cast<int>(value));
-            } else {
-                return escape_string({&value, 1}, '\'');
-            }
-        }
-
-        std::string stringify(bool value) {
-            return value ? "true" : "false";
-        }
-
-        template<typename T, typename std::enable_if<is_integral_and_not_bool<T>, int>::type = 0>
-        [[nodiscard]]
-        static std::string stringify_integral(T value, literal_format format) {
-            std::ostringstream oss;
-            switch(format) {
-                case literal_format::integer_character:
-                    if(
-                        cmp_greater_equal(value, std::numeric_limits<char>::min()) &&
-                        cmp_less_equal(value, std::numeric_limits<char>::max())
-                    ) {
-                        char c = static_cast<char>(value);
-                        return escape_string({&c, 1}, '\'');
-                    } else {
-                        // TODO: Handle this better
-                        return "<no char>";
-                    }
-                    break;
-                case literal_format::integer_hex:
-                    oss<<std::showbase<<std::hex;
-                    break;
-                case literal_format::integer_octal:
-                    oss<<std::showbase<<std::oct;
-                    break;
-                case literal_format::integer_binary:
-                    oss<<"0b"<<std::bitset<sizeof(value) * 8>(value);
-                    goto r;
-                case literal_format::default_format:
-                    break;
-                default:
-                    LIBASSERT_PRIMITIVE_DEBUG_ASSERT(false, "unexpected literal format requested for printing");
-            }
-            oss<<value;
-            r: return std::move(oss).str();
-        }
-
-        template<typename T, typename std::enable_if<is_integral_and_not_bool<T>, int>::type = 0>
-        [[nodiscard]]
-        static std::string stringify_integral(T value) {
-            auto current_format = get_thread_current_literal_format();
-            std::string result = stringify_integral(value, literal_format::default_format);
-            if(current_format & literal_format::integer_character) {
-                result = stringify_integral(value, literal_format::integer_character) + ' ' + std::move(result);
-            }
-            if(current_format & non_default_integer_formats) {
-                for(auto format : {
-                    literal_format::integer_hex,
-                    literal_format::integer_octal,
-                    literal_format::integer_binary
-                }) {
-                    if(current_format & format) {
-                        result += ' ';
-                        result += stringify_integral(value, format);
-                    }
-                }
-            }
-            return result;
-        }
-
-        std::string stringify(short value) {
-            return stringify_integral(value);
-        }
-
-        std::string stringify(int value) {
-            return stringify_integral(value);
-        }
-
-        std::string stringify(long value) {
-            return stringify_integral(value);
-        }
-
-        std::string stringify(long long value) {
-            return stringify_integral(value);
-        }
-
-        std::string stringify(unsigned short value) {
-            return stringify_integral(value);
-        }
-
-        std::string stringify(unsigned int value) {
-            return stringify_integral(value);
-        }
-
-        std::string stringify(unsigned long value) {
-            return stringify_integral(value);
-        }
-
-        std::string stringify(unsigned long long value) {
-            return stringify_integral(value);
-        }
-
-        template<typename T, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
-        [[nodiscard]]
-        static std::string stringify_floating_point(T value, literal_format format) {
-            std::ostringstream oss;
-            if(format == literal_format::float_hex) {
-                // apparently std::hexfloat automatically prepends "0x" while std::hex does not
-                oss<<std::hexfloat;
-            }
-            oss<<std::setprecision(std::numeric_limits<T>::max_digits10)<<value;
-            std::string s = std::move(oss).str();
-            // std::showpoint adds a bunch of unecessary digits, so manually doing it correctly here
-            if(s.find('.') == std::string::npos) {
-                s += ".0";
-            }
-            return s;
-        }
-
-        template<typename T, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
-        [[nodiscard]]
-        static std::string stringify_floating_point(T value) {
-            auto current_format = get_thread_current_literal_format();
-            std::string result = stringify_floating_point(value, literal_format::default_format);
-            if(current_format & non_default_float_formats) {
-                for(auto format : { literal_format::float_hex }) {
-                    if(current_format & format) {
-                        if(!result.empty()) {
-                            result += ' ';
-                        }
-                        result += stringify_floating_point(value, format);
-                    }
-                }
-            }
-            return result;
-        }
-
-        std::string stringify(float value) {
-            return stringify_floating_point(value);
-        }
-
-        std::string stringify(double value) {
-            return stringify_floating_point(value);
-        }
-
-        std::string stringify(long double value) {
-            return stringify_floating_point(value);
-        }
-
-        std::string stringify(std::byte value) {
-            return stringify_integral(static_cast<unsigned>(value));
-        }
-
-        std::string stringify(std::error_code ec) {
-            return ec.category().name() + (':' + std::to_string(ec.value())) + ' ' + ec.message();
-        }
-
-        std::string stringify(std::error_condition ec) {
-            return ec.category().name() + (':' + std::to_string(ec.value())) + ' ' + ec.message();
-        }
-
-        #if __cplusplus >= 202002L
-        std::string stringify(std::strong_ordering value) {
-                if(value == std::strong_ordering::less)       return "std::strong_ordering::less";
-                if(value == std::strong_ordering::equivalent) return "std::strong_ordering::equivalent";
-                if(value == std::strong_ordering::equal)      return "std::strong_ordering::equal";
-                if(value == std::strong_ordering::greater)    return "std::strong_ordering::greater";
-                return "Unknown std::strong_ordering value";
-        }
-        std::string stringify(std::weak_ordering value) {
-                if(value == std::weak_ordering::less)       return "std::weak_ordering::less";
-                if(value == std::weak_ordering::equivalent) return "std::weak_ordering::equivalent";
-                if(value == std::weak_ordering::greater)    return "std::weak_ordering::greater";
-                return "Unknown std::weak_ordering value";
-        }
-        std::string stringify(std::partial_ordering value) {
-                if(value == std::partial_ordering::less)       return "std::partial_ordering::less";
-                if(value == std::partial_ordering::equivalent) return "std::partial_ordering::equivalent";
-                if(value == std::partial_ordering::greater)    return "std::partial_ordering::greater";
-                if(value == std::partial_ordering::unordered)  return "std::partial_ordering::unordered";
-                return "Unknown std::partial_ordering value";
-        }
-        #endif
-
-        std::string stringify_pointer_value(const void* value) {
-            if(value == nullptr) {
-                return "nullptr";
-            }
-            std::ostringstream oss;
-            // Manually format the pointer - ostream::operator<<(void*) falls back to %p which
-            // is implementation-defined. MSVC prints pointers without the leading "0x" which
-            // messes up the highlighter.
-            oss<<std::showbase<<std::hex<<uintptr_t(value);
-            return std::move(oss).str();
-        }
-
-        std::string stringify_by_ostream(
-            const void* ptr,
-            void(*outputter)(std::ostream&, const void*)
-        ) {
-            std::ostringstream oss;
-            outputter(oss, ptr);
-            return std::move(oss).str();
-        }
-
-        std::string stringify_enum(std::string_view type_name, std::string_view underlying_value) {
-            return microfmt::format("enum {}: {}", prettify_type(std::string(type_name)), underlying_value);
-        }
-    }
+static std::string escape_string(const std::string_view str, char quote) {
+	std::string escaped;
+	escaped += quote;
+	for (const char c : str) {
+		if (c == '\\')
+			escaped += "\\\\";
+		else if (c == '\t')
+			escaped += "\\t";
+		else if (c == '\r')
+			escaped += "\\r";
+		else if (c == '\n')
+			escaped += "\\n";
+		else if (c == quote)
+			escaped += std::initializer_list<char> {'\\', quote};
+		else if (c >= 32 && c <= 126)
+			escaped += c; // printable
+		else {
+			constexpr const char* const hexdig = "0123456789abcdef";
+			escaped += std::string("\\x") + hexdig[c >> 4] + hexdig[c & 0xF];
+		}
+	}
+	escaped += quote;
+	return escaped;
 }
+
+namespace stringification {
+	std::string stringify_unknown(std::string_view type_name) {
+		return microfmt::format("<instance of {}>", prettify_type(std::string(type_name)));
+	}
+
+	std::string stringify(std::string_view value) {
+		return escape_string(value, '"');
+	}
+
+	std::string stringify(std::nullptr_t) {
+		return "nullptr";
+	}
+
+	std::string stringify(char value) {
+		if (get_thread_current_literal_format() & literal_format::integer_character) {
+			return stringify(static_cast<int>(value));
+		} else {
+			return escape_string({&value, 1}, '\'');
+		}
+	}
+
+	std::string stringify(bool value) {
+		return value ? "true" : "false";
+	}
+
+	template<typename T, typename std::enable_if<is_integral_and_not_bool<T>, int>::type = 0>
+	[[nodiscard]]
+	static std::string stringify_integral(T value, literal_format format) {
+		std::ostringstream oss;
+		switch (format) {
+			case literal_format::integer_character:
+				if (
+					cmp_greater_equal(value, std::numeric_limits<char>::min())
+					&& cmp_less_equal(value, std::numeric_limits<char>::max())
+				) {
+					char c = static_cast<char>(value);
+					return escape_string({&c, 1}, '\'');
+				} else {
+					// TODO: Handle this better
+					return "<no char>";
+				}
+				break;
+			case literal_format::integer_hex:
+				oss << std::showbase << std::hex;
+				break;
+			case literal_format::integer_octal:
+				oss << std::showbase << std::oct;
+				break;
+			case literal_format::integer_binary:
+				oss << "0b" << std::bitset<sizeof(value) * 8>(value);
+				goto r;
+			case literal_format::default_format:
+				break;
+			default:
+				LIBASSERT_PRIMITIVE_DEBUG_ASSERT(false, "unexpected literal format requested for printing");
+		}
+		oss << value;
+	r:
+		return std::move(oss).str();
+	}
+
+	template<typename T, typename std::enable_if<is_integral_and_not_bool<T>, int>::type = 0>
+	[[nodiscard]]
+	static std::string stringify_integral(T value) {
+		auto current_format = get_thread_current_literal_format();
+		std::string result = stringify_integral(value, literal_format::default_format);
+		if (current_format & literal_format::integer_character) {
+			result =
+				stringify_integral(value, literal_format::integer_character) + ' ' + std::move(result);
+		}
+		if (current_format & non_default_integer_formats) {
+			for (auto format :
+					 {literal_format::integer_hex,
+						literal_format::integer_octal,
+						literal_format::integer_binary}) {
+				if (current_format & format) {
+					result += ' ';
+					result += stringify_integral(value, format);
+				}
+			}
+		}
+		return result;
+	}
+
+	std::string stringify(short value) {
+		return stringify_integral(value);
+	}
+
+	std::string stringify(int value) {
+		return stringify_integral(value);
+	}
+
+	std::string stringify(long value) {
+		return stringify_integral(value);
+	}
+
+	std::string stringify(long long value) {
+		return stringify_integral(value);
+	}
+
+	std::string stringify(unsigned short value) {
+		return stringify_integral(value);
+	}
+
+	std::string stringify(unsigned int value) {
+		return stringify_integral(value);
+	}
+
+	std::string stringify(unsigned long value) {
+		return stringify_integral(value);
+	}
+
+	std::string stringify(unsigned long long value) {
+		return stringify_integral(value);
+	}
+
+	template<typename T, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+	[[nodiscard]]
+	static std::string stringify_floating_point(T value, literal_format format) {
+		std::ostringstream oss;
+		if (format == literal_format::float_hex) {
+			// apparently std::hexfloat automatically prepends "0x" while std::hex does not
+			oss << std::hexfloat;
+		}
+		oss << std::setprecision(std::numeric_limits<T>::max_digits10) << value;
+		std::string s = std::move(oss).str();
+		// std::showpoint adds a bunch of unecessary digits, so manually doing it correctly here
+		if (s.find('.') == std::string::npos) {
+			s += ".0";
+		}
+		return s;
+	}
+
+	template<typename T, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+	[[nodiscard]]
+	static std::string stringify_floating_point(T value) {
+		auto current_format = get_thread_current_literal_format();
+		std::string result = stringify_floating_point(value, literal_format::default_format);
+		if (current_format & non_default_float_formats) {
+			for (auto format : {literal_format::float_hex}) {
+				if (current_format & format) {
+					if (!result.empty()) {
+						result += ' ';
+					}
+					result += stringify_floating_point(value, format);
+				}
+			}
+		}
+		return result;
+	}
+
+	std::string stringify(float value) {
+		return stringify_floating_point(value);
+	}
+
+	std::string stringify(double value) {
+		return stringify_floating_point(value);
+	}
+
+	std::string stringify(long double value) {
+		return stringify_floating_point(value);
+	}
+
+	std::string stringify(std::byte value) {
+		return stringify_integral(static_cast<unsigned>(value));
+	}
+
+	std::string stringify(std::error_code ec) {
+		return ec.category().name() + (':' + std::to_string(ec.value())) + ' ' + ec.message();
+	}
+
+	std::string stringify(std::error_condition ec) {
+		return ec.category().name() + (':' + std::to_string(ec.value())) + ' ' + ec.message();
+	}
+
+#if __cplusplus >= 202002L
+	std::string stringify(std::strong_ordering value) {
+		if (value == std::strong_ordering::less)
+			return "std::strong_ordering::less";
+		if (value == std::strong_ordering::equivalent)
+			return "std::strong_ordering::equivalent";
+		if (value == std::strong_ordering::equal)
+			return "std::strong_ordering::equal";
+		if (value == std::strong_ordering::greater)
+			return "std::strong_ordering::greater";
+		return "Unknown std::strong_ordering value";
+	}
+
+	std::string stringify(std::weak_ordering value) {
+		if (value == std::weak_ordering::less)
+			return "std::weak_ordering::less";
+		if (value == std::weak_ordering::equivalent)
+			return "std::weak_ordering::equivalent";
+		if (value == std::weak_ordering::greater)
+			return "std::weak_ordering::greater";
+		return "Unknown std::weak_ordering value";
+	}
+
+	std::string stringify(std::partial_ordering value) {
+		if (value == std::partial_ordering::less)
+			return "std::partial_ordering::less";
+		if (value == std::partial_ordering::equivalent)
+			return "std::partial_ordering::equivalent";
+		if (value == std::partial_ordering::greater)
+			return "std::partial_ordering::greater";
+		if (value == std::partial_ordering::unordered)
+			return "std::partial_ordering::unordered";
+		return "Unknown std::partial_ordering value";
+	}
+#endif
+
+	std::string stringify_pointer_value(const void* value) {
+		if (value == nullptr) {
+			return "nullptr";
+		}
+		std::ostringstream oss;
+		// Manually format the pointer - ostream::operator<<(void*) falls back to %p which
+		// is implementation-defined. MSVC prints pointers without the leading "0x" which
+		// messes up the highlighter.
+		oss << std::showbase << std::hex << uintptr_t(value);
+		return std::move(oss).str();
+	}
+
+	std::string stringify_by_ostream(const void* ptr, void (*outputter)(std::ostream&, const void*)) {
+		std::ostringstream oss;
+		outputter(oss, ptr);
+		return std::move(oss).str();
+	}
+
+	std::string stringify_enum(std::string_view type_name, std::string_view underlying_value) {
+		return microfmt::format("enum {}: {}", prettify_type(std::string(type_name)), underlying_value);
+	}
+} // namespace stringification
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -11,565 +11,586 @@
 #include "utils.hpp"
 
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    // http://eel.is/c++draft/lex.name#nt:identifier
-    bool is_identifier_start(char c) {
-        return isalpha(c) || c == '$' || c == '_';
-    }
-    bool is_identifier_continue(char c) {
-        return isdigit(c) || is_identifier_start(c);
-    }
-    bool is_hex_digit(char c) {
-        // codegen is ok https://godbolt.org/z/sEnGPszao
-        return isdigit(c) || needle(c).is_in('a', 'b', 'c', 'd', 'e', 'f', 'A', 'B', 'C', 'D', 'E', 'F');
-    }
-    bool is_octal_digit(char c) {
-        // codegen is ok https://godbolt.org/z/sEnGPszao
-        return needle(c).is_in('0', '1', '2', '3', '4', '5', '6', '7');
-    }
-    bool is_simple_escape_char(char c) {
-        // codegen is ok https://godbolt.org/z/sEnGPszao
-        return needle(c).is_in('\'', '"', '?', '\\', 'a', 'b', 'f', 'n', 'r', 't', 'v');
-    }
+// http://eel.is/c++draft/lex.name#nt:identifier
+bool is_identifier_start(char c) {
+	return isalpha(c) || c == '$' || c == '_';
+}
 
-    // http://eel.is/c++draft/lex.operators#nt:operator-or-punctuator
+bool is_identifier_continue(char c) {
+	return isdigit(c) || is_identifier_start(c);
+}
 
-    constexpr std::array punctuators_and_operators = []() constexpr {
-        std::array arr = to_array<std::string_view>({
-            "{",        "}",        "[",        "]",        "(",        ")",
-            "<:",       ":>",       "<%",       "%>",       ";",        ":",        "...",
-            "?",        "::",       ".",        ".*",       "->",       "->*",      "~",
-            "!",        "+",        "-",        "*",        "/",        "%",        "^",        "&",        "|",
-            "=",        "+=",       "-=",       "*=",       "/=",       "%=",       "^=",       "&=",       "|=",
-            "==",       "!=",       "<",        ">",        "<=",       ">=",       "<=>",      "&&",       "||",
-            "<<",       ">>",       "<<=",      ">>=",      "++",       "--",       ",",
-            // "and",      "or",       "xor",      "not",      "bitand",   "bitor",    "compl",
-            // "and_eq",   "or_eq",    "xor_eq",   "not_eq",
-        });
-        constexpr_sort(arr, [](std::string_view a, std::string_view b) { return a.size() < b.size(); });
-        return arr;
-    } ();
+bool is_hex_digit(char c) {
+	// codegen is ok https://godbolt.org/z/sEnGPszao
+	return isdigit(c) || needle(c).is_in('a', 'b', 'c', 'd', 'e', 'f', 'A', 'B', 'C', 'D', 'E', 'F');
+}
 
-    constexpr std::array alternative_operators = []() constexpr {
-        std::array arr = to_array<std::string_view>({
-            "and",      "or",       "xor",      "not",      "bitand",   "bitor",    "compl",
-            "and_eq",   "or_eq",    "xor_eq",   "not_eq",
-        });
-        constexpr_sort(arr, [](std::string_view a, std::string_view b) { return a.size() < b.size(); });
-        return arr;
-    } ();
+bool is_octal_digit(char c) {
+	// codegen is ok https://godbolt.org/z/sEnGPszao
+	return needle(c).is_in('0', '1', '2', '3', '4', '5', '6', '7');
+}
 
-    struct lexer_error {
-        // lexer_error() { throw std::runtime_error("oops"); }
-    };
+bool is_simple_escape_char(char c) {
+	// codegen is ok https://godbolt.org/z/sEnGPszao
+	return needle(c).is_in('\'', '"', '?', '\\', 'a', 'b', 'f', 'n', 'r', 't', 'v');
+}
 
-    #define TRY(expr) do if(std::optional<lexer_error> res = (expr); res.has_value()) { return res.value(); } while(0)
+// http://eel.is/c++draft/lex.operators#nt:operator-or-punctuator
 
-    // key#nt:keyword
-    // [...temp0.querySelectorAll("span.keyword, span.literal")].map(node => `"${node.innerHTML.replace(`<span class="shy"></span>`, "")}",`).join("\n")
-    std::unordered_set<std::string_view> keywords {
-        "alignas",
-        "constinit",
-        // "false",
-        "public",
-        // "true",
-        "alignof",
-        "const_cast",
-        "float",
-        "register",
-        "try",
-        "asm",
-        "continue",
-        "for",
-        "reinterpret_cast",
-        "typedef",
-        "auto",
-        "co_await",
-        "friend",
-        "requires",
-        "typeid",
-        "bool",
-        "co_return",
-        "goto",
-        "return",
-        "typename",
-        "break",
-        "co_yield",
-        "if",
-        "short",
-        "union",
-        "case",
-        "decltype",
-        "inline",
-        "signed",
-        "unsigned",
-        "catch",
-        "default",
-        "int",
-        "sizeof",
-        "using",
-        "char",
-        "delete",
-        "long",
-        "static",
-        "virtual",
-        "char8_t",
-        "do",
-        "mutable",
-        "static_assert",
-        "void",
-        "char16_t",
-        "double",
-        "namespace",
-        "static_cast",
-        "volatile",
-        "char32_t",
-        "dynamic_cast",
-        "new",
-        "struct",
-        "wchar_t",
-        "class",
-        "else",
-        "noexcept",
-        "switch",
-        "while",
-        "concept",
-        "enum",
-        // "nullptr",
-        "template",
-        "const",
-        "explicit",
-        "operator",
-        "this",
-        "consteval",
-        "export",
-        "private",
-        "thread_local",
-        "constexpr",
-        "extern",
-        "protected",
-        "throw"
-    };
+constexpr std::array punctuators_and_operators = []() constexpr {
+	std::array arr = to_array<std::string_view>({
+		"{",  "}",  "[",   "]",  "(",   ")",  "<:", ":>",  "<%",  "%>", ";",  ":",  "...", "?",
+		"::", ".",  ".*",  "->", "->*", "~",  "!",  "+",   "-",   "*",  "/",  "%",  "^",   "&",
+		"|",  "=",  "+=",  "-=", "*=",  "/=", "%=", "^=",  "&=",  "|=", "==", "!=", "<",   ">",
+		"<=", ">=", "<=>", "&&", "||",  "<<", ">>", "<<=", ">>=", "++", "--", ",",
+		// "and",      "or",       "xor",      "not",      "bitand",   "bitor",    "compl",
+		// "and_eq",   "or_eq",    "xor_eq",   "not_eq",
+	});
+	constexpr_sort(arr, [](std::string_view a, std::string_view b) { return a.size() < b.size(); });
+	return arr;
+}();
 
-    class tokenizer {
-        std::string_view source;
-        std::string_view::iterator it;
-        bool error = false;
-    public:
-        tokenizer(std::string_view source_) : source(source_), it(source.begin()) {}
+constexpr std::array alternative_operators = []() constexpr {
+	std::array arr = to_array<std::string_view>({
+		"and",
+		"or",
+		"xor",
+		"not",
+		"bitand",
+		"bitor",
+		"compl",
+		"and_eq",
+		"or_eq",
+		"xor_eq",
+		"not_eq",
+	});
+	constexpr_sort(arr, [](std::string_view a, std::string_view b) { return a.size() < b.size(); });
+	return arr;
+}();
 
-        std::variant<std::vector<token_t>, lexer_error> tokenize(bool decompose_shr = false) {
-            std::vector<token_t> tokens;
-            while(!end()) {
-                // Blanks, horizontal and vertical tabs, newlines, formfeeds, and comments (collectively, “whitespace”), as
-                // described below, are ignored except as they serve to separate tokens.
-                // http://eel.is/c++draft/lex.token#1.sentence-2
-                if(isspace(peek())) {
-                    tokens.push_back(read_whitespace());
-                } else if(peek("//")) { // comments can't show up here but may as well
-                    TRY(read_comment());
-                } else if(peek("/*")) {
-                    TRY(read_multi_line_comment());
-                }
-                // -----------------------------------------------------------------------------------------------------
-                // There are five kinds of tokens: identifiers, keywords, literals, operators, and other separators
-                // http://eel.is/c++draft/lex.token#1.sentence-1
-                // check in the following order:
-                // 1. literals       must come before identifiers due to R"()" and similar, must come before punctuation
-                //                   due to .1
-                // 2. punctuators    must come before identifiers due to and/or/not/bitand/etc
-                // 3. identifiers and keywords
-                // -----------------------------------------------------------------------------------------------------
-                // 1. literals
-                //      integer-literal          all start with digits
-                //      character-literal        a prefix (u8  u  U  L) followed by ''
-                //      floating-point-literal   all start with digits
-                //      string-literal           a prefix (u8  u  U  L) followed by "", or R"...(...)..."
-                //      boolean-literal          true/false
-                //      pointer-literal          nullptr
-                //      user-defined-literal     integer/float/string/char literal followed by a ud-suffix
-                else if(
-                    auto named_literal = peek_any(to_array<std::string_view>({"false", "true", "nullptr"}));
-                    named_literal && !is_identifier_continue(peek(named_literal->size()))
-                ) {
-                    TRY(advance(named_literal->size()));
-                    tokens.push_back({token_e::named_literal, *named_literal});
-                }
+struct lexer_error {
+	// lexer_error() { throw std::runtime_error("oops"); }
+};
+
+#define TRY(expr) \
+	do \
+		if (std::optional<lexer_error> res = (expr); res.has_value()) { \
+			return res.value(); \
+		} \
+	while (0)
+
+// key#nt:keyword
+// [...temp0.querySelectorAll("span.keyword, span.literal")].map(node => `"${node.innerHTML.replace(`<span class="shy"></span>`, "")}",`).join("\n")
+std::unordered_set<std::string_view> keywords {
+	"alignas",
+	"constinit",
+	// "false",
+	"public",
+	// "true",
+	"alignof",
+	"const_cast",
+	"float",
+	"register",
+	"try",
+	"asm",
+	"continue",
+	"for",
+	"reinterpret_cast",
+	"typedef",
+	"auto",
+	"co_await",
+	"friend",
+	"requires",
+	"typeid",
+	"bool",
+	"co_return",
+	"goto",
+	"return",
+	"typename",
+	"break",
+	"co_yield",
+	"if",
+	"short",
+	"union",
+	"case",
+	"decltype",
+	"inline",
+	"signed",
+	"unsigned",
+	"catch",
+	"default",
+	"int",
+	"sizeof",
+	"using",
+	"char",
+	"delete",
+	"long",
+	"static",
+	"virtual",
+	"char8_t",
+	"do",
+	"mutable",
+	"static_assert",
+	"void",
+	"char16_t",
+	"double",
+	"namespace",
+	"static_cast",
+	"volatile",
+	"char32_t",
+	"dynamic_cast",
+	"new",
+	"struct",
+	"wchar_t",
+	"class",
+	"else",
+	"noexcept",
+	"switch",
+	"while",
+	"concept",
+	"enum",
+	// "nullptr",
+	"template",
+	"const",
+	"explicit",
+	"operator",
+	"this",
+	"consteval",
+	"export",
+	"private",
+	"thread_local",
+	"constexpr",
+	"extern",
+	"protected",
+	"throw"
+};
+
+class tokenizer {
+	std::string_view source;
+	std::string_view::iterator it;
+	bool error = false;
+
+public:
+	tokenizer(std::string_view source_) : source(source_), it(source.begin()) {}
+
+	std::variant<std::vector<token_t>, lexer_error> tokenize(bool decompose_shr = false) {
+		std::vector<token_t> tokens;
+		while (!end()) {
+			// Blanks, horizontal and vertical tabs, newlines, formfeeds, and comments (collectively, “whitespace”), as
+			// described below, are ignored except as they serve to separate tokens.
+			// http://eel.is/c++draft/lex.token#1.sentence-2
+			if (isspace(peek())) {
+				tokens.push_back(read_whitespace());
+			} else if (peek("//")) { // comments can't show up here but may as well
+				TRY(read_comment());
+			} else if (peek("/*")) {
+				TRY(read_multi_line_comment());
+			}
+			// -----------------------------------------------------------------------------------------------------
+			// There are five kinds of tokens: identifiers, keywords, literals, operators, and other separators
+			// http://eel.is/c++draft/lex.token#1.sentence-1
+			// check in the following order:
+			// 1. literals       must come before identifiers due to R"()" and similar, must come before punctuation
+			//                   due to .1
+			// 2. punctuators    must come before identifiers due to and/or/not/bitand/etc
+			// 3. identifiers and keywords
+			// -----------------------------------------------------------------------------------------------------
+			// 1. literals
+			//      integer-literal          all start with digits
+			//      character-literal        a prefix (u8  u  U  L) followed by ''
+			//      floating-point-literal   all start with digits
+			//      string-literal           a prefix (u8  u  U  L) followed by "", or R"...(...)..."
+			//      boolean-literal          true/false
+			//      pointer-literal          nullptr
+			//      user-defined-literal     integer/float/string/char literal followed by a ud-suffix
+			else if (
+				auto named_literal = peek_any(to_array<std::string_view>({"false", "true", "nullptr"}));
+				named_literal && !is_identifier_continue(peek(named_literal->size()))
+			) {
+				TRY(advance(named_literal->size()));
+				tokens.push_back({token_e::named_literal, *named_literal});
+			}
                 else if( // char literals
                     auto prefix = peek_any(to_array<std::string_view>({"u8", "u", "U", "L"}));
                     peek(prefix.value_or("").size()) == '\''
                 ) {
-                    auto begin = pos();
-                    TRY(advance(prefix.value_or("").size()));
-                    TRY(read_char_literal());
-                    auto end = pos();
-                    tokens.push_back({token_e::string, std::string_view(source.data() + begin, end - begin)});
-                }
+				auto begin = pos();
+				TRY(advance(prefix.value_or("").size()));
+				TRY(read_char_literal());
+				auto end = pos();
+				tokens.push_back({token_e::string, std::string_view(source.data() + begin, end - begin)});
+			}
                 else if( // string literals
                     // reusing same prefix from last if
                     peek(prefix.value_or("").size()) == '"'
                         || (peek(prefix.value_or("").size()) == 'R' && peek(prefix.value_or("").size() + 1) == '"')
                 ) {
-                    auto begin = pos();
-                    TRY(advance(prefix.value_or("").size()));
-                    if(peek() == 'R') {
-                        TRY(read_raw_string_literal());
-                    } else {
-                        TRY(read_string_literal());
-                    }
-                    auto end = pos();
-                    tokens.push_back({token_e::string, std::string_view(source.data() + begin, end - begin)});
-                }
-                else if(isdigit(peek()) || (peek() == '.' && isdigit(peek(1)))) { // integer, float
-                    auto begin = pos();
-                    TRY(read_numeric_literal());
-                    auto end = pos();
-                    tokens.push_back({token_e::number, std::string_view(source.data() + begin, end - begin)});
-                }
-                // 2. punctuation
-                //     handle normal punctuation and alternative operators separately
-                else if(auto punctuator = peek_any(punctuators_and_operators)) {
-                    TRY(advance(punctuator->size()));
-                    // handle <:: edge case https://eel.is/c++draft/lex.pptoken#3.2
-                    if(punctuator == "<:" && peek() == ':' && !needle(peek(1)).is_in(':', '>')) {
-                        rollback(1);
-                        tokens.push_back({token_e::punctuation, "<"});
-                    }
-                    // handle >> decomposition for templates
-                    else if(decompose_shr && punctuator == ">>") {
-                        tokens.push_back({token_e::punctuation, ">"});
-                        tokens.push_back({token_e::punctuation, ">"});
-                    } else {
-                        tokens.push_back({token_e::punctuation, *punctuator});
-                    }
-                }
-                else if(
-                    auto alternative_operator = peek_any(alternative_operators);
-                    alternative_operator && !is_identifier_continue(peek(alternative_operator->size()))
-                ) {
-                    TRY(advance(alternative_operator->size()));
-                    tokens.push_back({token_e::punctuation, *alternative_operator});
-                }
-                // 3. identifiers
-                else if(is_identifier_start(peek())) {
-                    auto begin = pos();
-                    TRY(read_identifier_or_keyword());
-                    auto end = pos();
-                    std::string_view contents = std::string_view(source.data() + begin, end - begin);
-                    tokens.push_back({
-                        keywords.find(contents) == keywords.end() ? token_e::identifier : token_e::keyword,
-                        contents
-                    });
-                } else {
-                    // we don't know....
-                    tokens.push_back({token_e::unknown, std::string_view(source.data(), 1)});
-                    TRY(advance());
-                }
-                // // universal character escapes like \U0001F60A get stringified so we have to handle them
-                // // http://eel.is/c++draft/lex#charset-3
-                // // fortunately we don't have to worry about unicode spellings of basic character set characters
-                // // http://eel.is/c++draft/lex#charset-6.sentence-1
-                // else if(peek() == '\\' && needle(peek(1)).is_in('u', 'U', 'N')) {
-                //     // tokens.push_back(read_universal_character_name());
-                // }
-            }
-            if(error) {
-                return lexer_error{};
-            } else {
-                return tokens;
-            }
-        }
-    private:
-        token_t read_whitespace() {
-            auto begin = pos();
-            std::size_t count = 0;
-            while(isspace(peek())) {
-                LIBASSERT_PRIMITIVE_ASSERT(advance() == std::nullopt);
-                count++;
-            }
-            return {token_e::whitespace, std::string_view(source.data() + begin, count)};
-        }
+				auto begin = pos();
+				TRY(advance(prefix.value_or("").size()));
+				if (peek() == 'R') {
+					TRY(read_raw_string_literal());
+				} else {
+					TRY(read_string_literal());
+				}
+				auto end = pos();
+				tokens.push_back({token_e::string, std::string_view(source.data() + begin, end - begin)});
+			} else if (isdigit(peek()) || (peek() == '.' && isdigit(peek(1)))) { // integer, float
+				auto begin = pos();
+				TRY(read_numeric_literal());
+				auto end = pos();
+				tokens.push_back({token_e::number, std::string_view(source.data() + begin, end - begin)});
+			}
+			// 2. punctuation
+			//     handle normal punctuation and alternative operators separately
+			else if (auto punctuator = peek_any(punctuators_and_operators)) {
+				TRY(advance(punctuator->size()));
+				// handle <:: edge case https://eel.is/c++draft/lex.pptoken#3.2
+				if (punctuator == "<:" && peek() == ':' && !needle(peek(1)).is_in(':', '>')) {
+					rollback(1);
+					tokens.push_back({token_e::punctuation, "<"});
+				}
+				// handle >> decomposition for templates
+				else if (decompose_shr && punctuator == ">>") {
+					tokens.push_back({token_e::punctuation, ">"});
+					tokens.push_back({token_e::punctuation, ">"});
+				} else {
+					tokens.push_back({token_e::punctuation, *punctuator});
+				}
+			} else if (
+				auto alternative_operator = peek_any(alternative_operators);
+				alternative_operator && !is_identifier_continue(peek(alternative_operator->size()))
+			) {
+				TRY(advance(alternative_operator->size()));
+				tokens.push_back({token_e::punctuation, *alternative_operator});
+			}
+			// 3. identifiers
+			else if (is_identifier_start(peek())) {
+				auto begin = pos();
+				TRY(read_identifier_or_keyword());
+				auto end = pos();
+				std::string_view contents = std::string_view(source.data() + begin, end - begin);
+				tokens.push_back(
+					{keywords.find(contents) == keywords.end() ? token_e::identifier : token_e::keyword,
+					 contents}
+				);
+			} else {
+				// we don't know....
+				tokens.push_back({token_e::unknown, std::string_view(source.data(), 1)});
+				TRY(advance());
+			}
+			// // universal character escapes like \U0001F60A get stringified so we have to handle them
+			// // http://eel.is/c++draft/lex#charset-3
+			// // fortunately we don't have to worry about unicode spellings of basic character set characters
+			// // http://eel.is/c++draft/lex#charset-6.sentence-1
+			// else if(peek() == '\\' && needle(peek(1)).is_in('u', 'U', 'N')) {
+			//     // tokens.push_back(read_universal_character_name());
+			// }
+		}
+		if (error) {
+			return lexer_error {};
+		} else {
+			return tokens;
+		}
+	}
 
-        [[nodiscard]] std::optional<lexer_error> read_comment() {
-            while(!end() && peek() != '\n') {
-                TRY(advance());
-            }
-            return std::nullopt;
-        }
+private:
+	token_t read_whitespace() {
+		auto begin = pos();
+		std::size_t count = 0;
+		while (isspace(peek())) {
+			LIBASSERT_PRIMITIVE_ASSERT(advance() == std::nullopt);
+			count++;
+		}
+		return {token_e::whitespace, std::string_view(source.data() + begin, count)};
+	}
 
-        [[nodiscard]] std::optional<lexer_error> read_multi_line_comment() {
-            while(!end() && !(peek() == '*' && peek(1) == '/')) {
-                TRY(advance());
-            }
-            TRY(expect('*'));
-            TRY(expect('/'));
-            return std::nullopt;
-        }
+	[[nodiscard]] std::optional<lexer_error> read_comment() {
+		while (!end() && peek() != '\n') {
+			TRY(advance());
+		}
+		return std::nullopt;
+	}
 
-        [[nodiscard]] std::optional<lexer_error> read_identifier_or_keyword() {
-            while(!end() && is_identifier_continue(peek())) {
-                TRY(advance());
-            }
-            return std::nullopt;
-        }
+	[[nodiscard]] std::optional<lexer_error> read_multi_line_comment() {
+		while (!end() && !(peek() == '*' && peek(1) == '/')) {
+			TRY(advance());
+		}
+		TRY(expect('*'));
+		TRY(expect('/'));
+		return std::nullopt;
+	}
 
-        [[nodiscard]] std::optional<lexer_error> read_char_literal() {
-            // http://eel.is/c++draft/lex.ccon
-            TRY(expect('\''));
-            // make sure this isn't an invalid char literal
-            if(peek() == '\'') {
-                return lexer_error{};
-            }
-            // read one character, or an escape sequence
-            if(peek() == '\\') {
-                TRY(read_escape_sequence());
-            } else {
-                TRY(advance());
-            }
-            // expect end of char literal
-            TRY(expect('\''));
-            TRY(read_optional_udl_suffix());
-            return std::nullopt;
-        }
+	[[nodiscard]] std::optional<lexer_error> read_identifier_or_keyword() {
+		while (!end() && is_identifier_continue(peek())) {
+			TRY(advance());
+		}
+		return std::nullopt;
+	}
 
-        [[nodiscard]] std::optional<lexer_error> read_string_literal() {
-            // string#nt:string-literal
-            TRY(expect('"'));
-            while(!end() && peek() != '"') {
-                if(peek() == '\\') {
-                    TRY(read_escape_sequence());
-                } else {
-                    TRY(advance());
-                }
-            }
-            TRY(expect('"'));
-            TRY(read_optional_udl_suffix());
-            return std::nullopt;
-        }
+	[[nodiscard]] std::optional<lexer_error> read_char_literal() {
+		// http://eel.is/c++draft/lex.ccon
+		TRY(expect('\''));
+		// make sure this isn't an invalid char literal
+		if (peek() == '\'') {
+			return lexer_error {};
+		}
+		// read one character, or an escape sequence
+		if (peek() == '\\') {
+			TRY(read_escape_sequence());
+		} else {
+			TRY(advance());
+		}
+		// expect end of char literal
+		TRY(expect('\''));
+		TRY(read_optional_udl_suffix());
+		return std::nullopt;
+	}
 
-        [[nodiscard]] std::optional<lexer_error> read_raw_string_literal() {
-            // string#nt:string-literal
-            TRY(expect('R'));
-            TRY(expect('"'));
-            // read d-char sequence
-            // we'll be much more permissive about what is allowed as a d-char, we'll allow anything that's not a (
-            auto d_begin = pos();
-            while(!end() && peek() != '(') {
-                TRY(advance());
-            }
-            auto d_char_sequence = std::string_view(source.data() + d_begin, pos() - d_begin);
-            // read r-char sequence
-            while(!end()) {
-                if(peek() == ')' && peek(d_char_sequence, 1) && peek(1 + d_char_sequence.size()) == '"') {
-                    // end of string
-                    TRY(advance(1 + d_char_sequence.size()));
-                    break;
-                } else {
-                    TRY(advance());
-                }
-            }
-            TRY(expect('"'));
-            return std::nullopt;
-        }
+	[[nodiscard]] std::optional<lexer_error> read_string_literal() {
+		// string#nt:string-literal
+		TRY(expect('"'));
+		while (!end() && peek() != '"') {
+			if (peek() == '\\') {
+				TRY(read_escape_sequence());
+			} else {
+				TRY(advance());
+			}
+		}
+		TRY(expect('"'));
+		TRY(read_optional_udl_suffix());
+		return std::nullopt;
+	}
 
-        [[nodiscard]] std::optional<lexer_error> read_escape_sequence() {
-            // http://eel.is/c++draft/lex.ccon#nt:escape-sequence
-            // escape-sequence:
-            //   simple-escape-sequence
-            //   numeric-escape-sequence
-            //   conditional-escape-sequence
-            TRY(expect('\\'));
-            // the only escape sequences we really need to parse are those that could contain ' or "
-            if(is_simple_escape_char(peek())) {
-                TRY(advance());
-            } else if(is_octal_digit(peek())) {
-                TRY(advance()); // read the first
-                if(is_octal_digit(peek())) { // read the second
-                    TRY(advance());
-                }
-                if(is_octal_digit(peek())) { // read the third
-                    TRY(advance());
-                }
-            } else if(peek() == 'o') {
-                TRY(read_braced_sequence());
-            } else if(peek() == 'x') {
-                TRY(advance());
-                if(peek() == '{') {
-                    TRY(read_braced_sequence());
-                } else if(is_hex_digit(peek())) {
-                    while(!end() && is_hex_digit(peek())) {
-                        TRY(advance());
-                    }
-                } else {
-                    return lexer_error{};
-                }
-            } else {
-                TRY(read_universal_character_name());
-            }
-            return std::nullopt;
-        }
+	[[nodiscard]] std::optional<lexer_error> read_raw_string_literal() {
+		// string#nt:string-literal
+		TRY(expect('R'));
+		TRY(expect('"'));
+		// read d-char sequence
+		// we'll be much more permissive about what is allowed as a d-char, we'll allow anything that's not a (
+		auto d_begin = pos();
+		while (!end() && peek() != '(') {
+			TRY(advance());
+		}
+		auto d_char_sequence = std::string_view(source.data() + d_begin, pos() - d_begin);
+		// read r-char sequence
+		while (!end()) {
+			if (peek() == ')' && peek(d_char_sequence, 1) && peek(1 + d_char_sequence.size()) == '"') {
+				// end of string
+				TRY(advance(1 + d_char_sequence.size()));
+				break;
+			} else {
+				TRY(advance());
+			}
+		}
+		TRY(expect('"'));
+		return std::nullopt;
+	}
 
-        [[nodiscard]] std::optional<lexer_error> read_universal_character_name() {
-            // http://eel.is/c++draft/lex.charset#nt:universal-character-name
-            // universal-character-name:
-            //   \u hex-quad
-            //   \U hex-quad hex-quad
-            //   \u{ simple-hexadecimal-digit-sequence }
-            //   named-universal-character
-            if(peek() == 'u') {
-                TRY(advance());
-                if(peek() == '{') {
-                    TRY(read_braced_sequence());
-                } else {
-                    TRY(read_hex_quad());
-                }
-            } else if(peek() == 'U') {
-                TRY(advance());
-                TRY(read_hex_quad());
-                TRY(read_hex_quad());
-            } else if(peek() == 'N') {
-                TRY(advance());
-                TRY(read_braced_sequence());
-            } else {
-                return lexer_error{};
-            }
-            return std::nullopt;
-        }
+	[[nodiscard]] std::optional<lexer_error> read_escape_sequence() {
+		// http://eel.is/c++draft/lex.ccon#nt:escape-sequence
+		// escape-sequence:
+		//   simple-escape-sequence
+		//   numeric-escape-sequence
+		//   conditional-escape-sequence
+		TRY(expect('\\'));
+		// the only escape sequences we really need to parse are those that could contain ' or "
+		if (is_simple_escape_char(peek())) {
+			TRY(advance());
+		} else if (is_octal_digit(peek())) {
+			TRY(advance()); // read the first
+			if (is_octal_digit(peek())) { // read the second
+				TRY(advance());
+			}
+			if (is_octal_digit(peek())) { // read the third
+				TRY(advance());
+			}
+		} else if (peek() == 'o') {
+			TRY(read_braced_sequence());
+		} else if (peek() == 'x') {
+			TRY(advance());
+			if (peek() == '{') {
+				TRY(read_braced_sequence());
+			} else if (is_hex_digit(peek())) {
+				while (!end() && is_hex_digit(peek())) {
+					TRY(advance());
+				}
+			} else {
+				return lexer_error {};
+			}
+		} else {
+			TRY(read_universal_character_name());
+		}
+		return std::nullopt;
+	}
 
-        [[nodiscard]] std::optional<lexer_error> read_hex_quad() {
-            // http://eel.is/c++draft/lex.charset#nt:hex-quad
-            // hex-quad:
-            //   hexadecimal-digit hexadecimal-digit hexadecimal-digit hexadecimal-digit
-            for(int i = 0; i < 4; i++) {
-                if(!is_hex_digit(peek())) {
-                    return lexer_error{};
-                } else {
-                    TRY(advance());
-                }
-            }
-            return std::nullopt;
-        }
+	[[nodiscard]] std::optional<lexer_error> read_universal_character_name() {
+		// http://eel.is/c++draft/lex.charset#nt:universal-character-name
+		// universal-character-name:
+		//   \u hex-quad
+		//   \U hex-quad hex-quad
+		//   \u{ simple-hexadecimal-digit-sequence }
+		//   named-universal-character
+		if (peek() == 'u') {
+			TRY(advance());
+			if (peek() == '{') {
+				TRY(read_braced_sequence());
+			} else {
+				TRY(read_hex_quad());
+			}
+		} else if (peek() == 'U') {
+			TRY(advance());
+			TRY(read_hex_quad());
+			TRY(read_hex_quad());
+		} else if (peek() == 'N') {
+			TRY(advance());
+			TRY(read_braced_sequence());
+		} else {
+			return lexer_error {};
+		}
+		return std::nullopt;
+	}
 
-        [[nodiscard]] std::optional<lexer_error> read_numeric_literal() {
-            // since we can assume a valid token, and we'll treat it as a pp-number....
-            // http://eel.is/c++draft/lex.ppnumber
-            // just read [0-9a-zA-Z'\.]+, essentially, with special handling for exponents/sign
-            while(!end() && (isdigit(peek()) || isalpha(peek()) || peek() == '\'' ||  peek() == '.')) {
-                if(needle(peek()).is_in('e', 'E', 'p', 'P') && needle(peek(1)).is_in('-', '+')) {
-                    TRY(advance(2));
-                } else {
-                    TRY(advance());
-                }
-            }
-            // non-underscore udls will already be handled above, catch remaining here
-            TRY(read_optional_udl_suffix());
-            return std::nullopt;
-        }
+	[[nodiscard]] std::optional<lexer_error> read_hex_quad() {
+		// http://eel.is/c++draft/lex.charset#nt:hex-quad
+		// hex-quad:
+		//   hexadecimal-digit hexadecimal-digit hexadecimal-digit hexadecimal-digit
+		for (int i = 0; i < 4; i++) {
+			if (!is_hex_digit(peek())) {
+				return lexer_error {};
+			} else {
+				TRY(advance());
+			}
+		}
+		return std::nullopt;
+	}
 
-        [[nodiscard]] std::optional<lexer_error> read_optional_udl_suffix() {
-            // http://eel.is/c++draft/lex.ext#nt:ud-suffix
-            if(is_identifier_start(peek())) {
-                TRY(read_identifier_or_keyword());
-            }
-            return std::nullopt;
-        }
+	[[nodiscard]] std::optional<lexer_error> read_numeric_literal() {
+		// since we can assume a valid token, and we'll treat it as a pp-number....
+		// http://eel.is/c++draft/lex.ppnumber
+		// just read [0-9a-zA-Z'\.]+, essentially, with special handling for exponents/sign
+		while (!end() && (isdigit(peek()) || isalpha(peek()) || peek() == '\'' || peek() == '.')) {
+			if (needle(peek()).is_in('e', 'E', 'p', 'P') && needle(peek(1)).is_in('-', '+')) {
+				TRY(advance(2));
+			} else {
+				TRY(advance());
+			}
+		}
+		// non-underscore udls will already be handled above, catch remaining here
+		TRY(read_optional_udl_suffix());
+		return std::nullopt;
+	}
 
-        // reads a {...}
-        // TODO: Allow a predicate to decide what is allowed between the braces
-        [[nodiscard]] std::optional<lexer_error> read_braced_sequence() {
-            TRY(expect('{'));
-            while(!end() && peek() != '}') {
-                TRY(advance());
-            }
-            TRY(expect('}'));
-            return std::nullopt;
-        }
-    private:
+	[[nodiscard]] std::optional<lexer_error> read_optional_udl_suffix() {
+		// http://eel.is/c++draft/lex.ext#nt:ud-suffix
+		if (is_identifier_start(peek())) {
+			TRY(read_identifier_or_keyword());
+		}
+		return std::nullopt;
+	}
 
-        [[nodiscard]] std::size_t pos() const {
-            return it - source.begin();
-        }
+	// reads a {...}
+	// TODO: Allow a predicate to decide what is allowed between the braces
+	[[nodiscard]] std::optional<lexer_error> read_braced_sequence() {
+		TRY(expect('{'));
+		while (!end() && peek() != '}') {
+			TRY(advance());
+		}
+		TRY(expect('}'));
+		return std::nullopt;
+	}
 
-        [[nodiscard]] char peek(std::size_t count = 0) const {
-            auto pos = it - source.begin();
-            if(pos + count < source.size()) {
-                return *(it + count);
-            } else {
-                return 0;
-            }
-        }
+private:
+	[[nodiscard]] std::size_t pos() const {
+		return it - source.begin();
+	}
 
-        [[nodiscard]] bool peek(std::string_view pattern, std::size_t offset = 0) const {
-            for(std::size_t i = 0; i < pattern.size(); i++) {
-                if(peek(offset + i) != pattern[i]) {
-                    return false;
-                }
-            }
-            return true;
-        }
+	[[nodiscard]] char peek(std::size_t count = 0) const {
+		auto pos = it - source.begin();
+		if (pos + count < source.size()) {
+			return *(it + count);
+		} else {
+			return 0;
+		}
+	}
 
-        template<std::size_t N>
-        [[nodiscard]]
-        std::optional<std::string_view> peek_any(const std::array<std::string_view, N>& candidates) const {
-            for(auto entry : candidates) {
-                if(peek(entry)) {
-                    return entry;
-                }
-            }
-            return std::nullopt;
-        }
+	[[nodiscard]] bool peek(std::string_view pattern, std::size_t offset = 0) const {
+		for (std::size_t i = 0; i < pattern.size(); i++) {
+			if (peek(offset + i) != pattern[i]) {
+				return false;
+			}
+		}
+		return true;
+	}
 
-        [[nodiscard]] std::optional<lexer_error> advance() {
-            if(it != source.end()) {
-                it++;
-                return std::nullopt;
-            } else {
-                return lexer_error{};
-            }
-        }
+	template<std::size_t N>
+	[[nodiscard]]
+	std::optional<std::string_view>
+	peek_any(const std::array<std::string_view, N>& candidates) const {
+		for (auto entry : candidates) {
+			if (peek(entry)) {
+				return entry;
+			}
+		}
+		return std::nullopt;
+	}
 
-        [[nodiscard]] std::optional<lexer_error> advance(std::size_t count) {
-            while(it != source.end() && count > 0) {
-                it++;
-                count--;
-            }
-            if(count == 0) {
-                return std::nullopt;
-            } else {
-                return lexer_error{};
-            }
-        }
+	[[nodiscard]] std::optional<lexer_error> advance() {
+		if (it != source.end()) {
+			it++;
+			return std::nullopt;
+		} else {
+			return lexer_error {};
+		}
+	}
 
-        void rollback(std::size_t count) {
-            while(count--) {
-                LIBASSERT_PRIMITIVE_ASSERT(it != source.begin(), "Tokenizer rollback() failed, please report this bug");
-                it--;
-            }
-        }
+	[[nodiscard]] std::optional<lexer_error> advance(std::size_t count) {
+		while (it != source.end() && count > 0) {
+			it++;
+			count--;
+		}
+		if (count == 0) {
+			return std::nullopt;
+		} else {
+			return lexer_error {};
+		}
+	}
 
-        [[nodiscard]] std::optional<lexer_error> expect(char c) {
-            if(peek() != c) {
-                error = true;
-                return lexer_error{};
-            }
-            TRY(advance());
-            return std::nullopt;
-        }
+	void rollback(std::size_t count) {
+		while (count--) {
+			LIBASSERT_PRIMITIVE_ASSERT(
+				it != source.begin(),
+				"Tokenizer rollback() failed, please report this bug"
+			);
+			it--;
+		}
+	}
 
-        // returns true if the end of the input has been reached or if tokenization should otherwise stop
-        [[nodiscard]] bool end() const {
-            return it == source.end() || error;
-        }
-    };
+	[[nodiscard]] std::optional<lexer_error> expect(char c) {
+		if (peek() != c) {
+			error = true;
+			return lexer_error {};
+		}
+		TRY(advance());
+		return std::nullopt;
+	}
 
-    std::optional<std::vector<token_t>> tokenize(std::string_view source, bool decompose_shr) {
-        auto res = tokenizer(source).tokenize(decompose_shr);
-        if(res.index() == 0) {
-            return std::move(std::get<std::vector<token_t>>(res));
-        } else {
-            LIBASSERT_PRIMITIVE_ASSERT(res.index() == 1);
-            return std::nullopt;
-        }
-    }
+	// returns true if the end of the input has been reached or if tokenization should otherwise stop
+	[[nodiscard]] bool end() const {
+		return it == source.end() || error;
+	}
+};
+
+std::optional<std::vector<token_t>> tokenize(std::string_view source, bool decompose_shr) {
+	auto res = tokenizer(source).tokenize(decompose_shr);
+	if (res.index() == 0) {
+		return std::move(std::get<std::vector<token_t>>(res));
+	} else {
+		LIBASSERT_PRIMITIVE_ASSERT(res.index() == 1);
+		return std::nullopt;
+	}
 }
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE

--- a/src/tokenizer.hpp
+++ b/src/tokenizer.hpp
@@ -5,37 +5,40 @@
 #include <string_view>
 #include <vector>
 
-#include "utils.hpp"
 #include "common.hpp"
+#include "utils.hpp"
 
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    enum class token_e {
-        keyword,
-        punctuation,
-        number,
-        string,
-        named_literal,
-        identifier,
-        whitespace,
-        unknown
-    };
+enum class token_e {
+	keyword,
+	punctuation,
+	number,
+	string,
+	named_literal,
+	identifier,
+	whitespace,
+	unknown
+};
 
-    struct token_t {
-        token_e type;
-        std::string_view str;
-        token_t(token_e type_, std::string_view str_) : type(type_), str(str_) {}
+struct token_t {
+	token_e type;
+	std::string_view str;
 
-        bool operator==(const token_t& other) const {
-            return type == other.type && str == other.str;
-        }
-    };
+	token_t(token_e type_, std::string_view str_) : type(type_), str(str_) {}
 
-    // lifetime notes: token_t's store string_views to data with at least the same lifetime as the source string_view's
-    // data
-    LIBASSERT_EXPORT_TESTING
-    std::optional<std::vector<token_t>> tokenize(std::string_view source, bool decompose_shr = false);
-}
+	bool operator==(const token_t& other) const {
+		return type == other.type && str == other.str;
+	}
+};
+
+// lifetime notes: token_t's store string_views to data with at least the same lifetime as the source string_view's
+// data
+LIBASSERT_EXPORT_TESTING
+std::optional<std::vector<token_t>> tokenize(std::string_view source, bool decompose_shr = false);
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE
 
 #endif

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2,171 +2,174 @@
 #include <cstdio>
 #include <cstdlib>
 #include <regex>
-#include <string_view>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
 #include <libassert/assert.hpp>
 
 #if defined(__has_include) && __has_include(<cpptrace/basic.hpp>)
- #include <cpptrace/basic.hpp>
- #include <cpptrace/exceptions.hpp>
+	#include <cpptrace/basic.hpp>
+	#include <cpptrace/exceptions.hpp>
 #else
- #include <cpptrace/cpptrace.hpp>
+	#include <cpptrace/cpptrace.hpp>
 #endif
-
-#include "utils.hpp"
-#include "microfmt.hpp"
 
 #include <libassert/assert.hpp>
 
+#include "microfmt.hpp"
+#include "utils.hpp"
+
 LIBASSERT_BEGIN_NAMESPACE
+
 namespace detail {
-    LIBASSERT_EXPORT
-    void primitive_assert_impl(
-        bool condition,
-        bool normal_assert,
-        const char* expression,
-        const char* signature,
-        source_location location,
-        const char* message
-    ) {
-        if(!condition) {
-            const char* action = normal_assert ? "Assert"                     : "Debug assert";
-            const char* name   = normal_assert ? "LIBASSERT_PRIMITIVE_ASSERT" : "LIBASSERT_PRIMITIVE_DEBUG_ASSERT";
-            std::string out_message;
-            if(message == nullptr) {
-                out_message += microfmt::format(
-                    "{} failed at {}:{}: {}\n",
-                    action,
-                    location.file,
-                    location.line,
-                    signature
-                );
-            } else {
-                out_message += microfmt::format(
-                    "{} failed at {}:{}: {}: {}\n",
-                    action,
-                    location.file,
-                    location.line,
-                    signature,
-                    message
-                );
-            }
-            out_message += microfmt::format("    {}({});\n", name, expression);
-            throw cpptrace::runtime_error(std::move(out_message));
-        }
-    }
+LIBASSERT_EXPORT
+void primitive_assert_impl(
+	bool condition,
+	bool normal_assert,
+	const char* expression,
+	const char* signature,
+	source_location location,
+	const char* message
+) {
+	if (!condition) {
+		const char* action = normal_assert ? "Assert" : "Debug assert";
+		const char* name =
+			normal_assert ? "LIBASSERT_PRIMITIVE_ASSERT" : "LIBASSERT_PRIMITIVE_DEBUG_ASSERT";
+		std::string out_message;
+		if (message == nullptr) {
+			out_message += microfmt::format(
+				"{} failed at {}:{}: {}\n",
+				action,
+				location.file,
+				location.line,
+				signature
+			);
+		} else {
+			out_message += microfmt::format(
+				"{} failed at {}:{}: {}: {}\n",
+				action,
+				location.file,
+				location.line,
+				signature,
+				message
+			);
+		}
+		out_message += microfmt::format("    {}({});\n", name, expression);
+		throw cpptrace::runtime_error(std::move(out_message));
+	}
+}
 
-    [[noreturn]] LIBASSERT_EXPORT
-    void primitive_panic_impl(
-        const char* signature,
-        source_location location,
-        const char* message
-    ) {
-        std::string out_message = microfmt::format(
-            "PANIC failed at {}:{}: {}: {}\n",
-            location.file,
-            location.line,
-            signature,
-            message
-        );
-        out_message += "    LIBASSERT_PRIMITIVE_PANIC(...);\n";
-        throw cpptrace::runtime_error(std::move(out_message));
-    }
+[[noreturn]] LIBASSERT_EXPORT void
+primitive_panic_impl(const char* signature, source_location location, const char* message) {
+	std::string out_message = microfmt::format(
+		"PANIC failed at {}:{}: {}: {}\n",
+		location.file,
+		location.line,
+		signature,
+		message
+	);
+	out_message += "    LIBASSERT_PRIMITIVE_PANIC(...);\n";
+	throw cpptrace::runtime_error(std::move(out_message));
+}
 
-    /*
+/*
      * string utilities
      */
 
-    LIBASSERT_EXPORT_TESTING
-    std::vector<std::string_view> split(std::string_view s, std::string_view delims) {
-        std::vector<std::string_view> vec;
-        size_t old_pos = 0;
-        size_t pos = 0;
-        while((pos = s.find_first_of(delims, old_pos)) != std::string::npos) {
-            vec.emplace_back(s.substr(old_pos, pos - old_pos));
-            old_pos = pos + 1;
-        }
-        vec.emplace_back(s.substr(old_pos));
-        return vec;
-    }
-
-    std::string_view trim(const std::string_view s) {
-        const size_t l = s.find_first_not_of(whitespace_chars);
-        if(l == std::string_view::npos) {
-            return "";
-        }
-        const size_t r = s.find_last_not_of(whitespace_chars) + 1;
-        return s.substr(l, r - l);
-    }
-
-    void replace_all_dynamic(std::string& str, std::string_view text, std::string_view replacement) {
-        std::string::size_type pos = 0;
-        while((pos = str.find(text.data(), pos, text.length())) != std::string::npos) {
-            str.replace(pos, text.length(), replacement.data(), replacement.length());
-            // advancing by one rather than replacement.length() in case replacement leads to
-            // another replacement opportunity, e.g. folding > > > to >> > then >>>
-            pos++;
-        }
-    }
-
-    LIBASSERT_EXPORT_TESTING
-    void replace_all(std::string& str, const std::regex& re, std::string_view replacement) {
-        std::smatch match;
-        std::size_t i = 0;
-        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-        while(std::regex_search(str.cbegin() + i, str.cend(), match, re)) {
-            str.replace(i + match.position(), match.length(), replacement);
-            i += match.position() + replacement.length();
-        }
-    }
-
-    LIBASSERT_EXPORT_TESTING
-    void replace_all(std::string& str, std::string_view substr, std::string_view replacement) {
-        std::string::size_type pos = 0;
-        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-        while((pos = str.find(substr.data(), pos, substr.length())) != std::string::npos) {
-            str.replace(pos, substr.length(), replacement.data(), replacement.length());
-            pos += replacement.length();
-        }
-    }
-
-    void replace_all_template(std::string& str, const std::pair<std::regex, std::string_view>& rule) {
-        const auto& [re, replacement] = rule;
-        std::smatch match;
-        std::size_t cursor = 0;
-        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-        while(std::regex_search(str.cbegin() + cursor, str.cend(), match, re)) {
-            // find matching >
-            const std::size_t match_begin = cursor + match.position();
-            std::size_t end = match_begin + match.length();
-            for(int c = 1; end < str.size() && c > 0; end++) {
-                if(str[end] == '<') {
-                    c++;
-                } else if(str[end] == '>') {
-                    c--;
-                }
-            }
-            // make the replacement
-            str.replace(match_begin, end - match_begin, replacement);
-            cursor = match_begin + replacement.length();
-        }
-    }
-
-    std::string indent(const std::string_view str, size_t depth, char c, bool ignore_first) {
-        size_t i = 0;
-        size_t j;
-        std::string output;
-        while((j = str.find('\n', i)) != std::string::npos) {
-            if(i != 0 || !ignore_first) { output.insert(output.end(), depth, c); }
-            output.insert(output.end(), str.begin() + i, str.begin() + j + 1);
-            i = j + 1;
-        }
-        if(i != 0 || !ignore_first) { output.insert(output.end(), depth, c); }
-        output.insert(output.end(), str.begin() + i, str.end());
-        return output;
-    }
+LIBASSERT_EXPORT_TESTING
+std::vector<std::string_view> split(std::string_view s, std::string_view delims) {
+	std::vector<std::string_view> vec;
+	size_t old_pos = 0;
+	size_t pos = 0;
+	while ((pos = s.find_first_of(delims, old_pos)) != std::string::npos) {
+		vec.emplace_back(s.substr(old_pos, pos - old_pos));
+		old_pos = pos + 1;
+	}
+	vec.emplace_back(s.substr(old_pos));
+	return vec;
 }
+
+std::string_view trim(const std::string_view s) {
+	const size_t l = s.find_first_not_of(whitespace_chars);
+	if (l == std::string_view::npos) {
+		return "";
+	}
+	const size_t r = s.find_last_not_of(whitespace_chars) + 1;
+	return s.substr(l, r - l);
+}
+
+void replace_all_dynamic(std::string& str, std::string_view text, std::string_view replacement) {
+	std::string::size_type pos = 0;
+	while ((pos = str.find(text.data(), pos, text.length())) != std::string::npos) {
+		str.replace(pos, text.length(), replacement.data(), replacement.length());
+		// advancing by one rather than replacement.length() in case replacement leads to
+		// another replacement opportunity, e.g. folding > > > to >> > then >>>
+		pos++;
+	}
+}
+
+LIBASSERT_EXPORT_TESTING
+void replace_all(std::string& str, const std::regex& re, std::string_view replacement) {
+	std::smatch match;
+	std::size_t i = 0;
+	// NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+	while (std::regex_search(str.cbegin() + i, str.cend(), match, re)) {
+		str.replace(i + match.position(), match.length(), replacement);
+		i += match.position() + replacement.length();
+	}
+}
+
+LIBASSERT_EXPORT_TESTING
+void replace_all(std::string& str, std::string_view substr, std::string_view replacement) {
+	std::string::size_type pos = 0;
+	// NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+	while ((pos = str.find(substr.data(), pos, substr.length())) != std::string::npos) {
+		str.replace(pos, substr.length(), replacement.data(), replacement.length());
+		pos += replacement.length();
+	}
+}
+
+void replace_all_template(std::string& str, const std::pair<std::regex, std::string_view>& rule) {
+	const auto& [re, replacement] = rule;
+	std::smatch match;
+	std::size_t cursor = 0;
+	// NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+	while (std::regex_search(str.cbegin() + cursor, str.cend(), match, re)) {
+		// find matching >
+		const std::size_t match_begin = cursor + match.position();
+		std::size_t end = match_begin + match.length();
+		for (int c = 1; end < str.size() && c > 0; end++) {
+			if (str[end] == '<') {
+				c++;
+			} else if (str[end] == '>') {
+				c--;
+			}
+		}
+		// make the replacement
+		str.replace(match_begin, end - match_begin, replacement);
+		cursor = match_begin + replacement.length();
+	}
+}
+
+std::string indent(const std::string_view str, size_t depth, char c, bool ignore_first) {
+	size_t i = 0;
+	size_t j;
+	std::string output;
+	while ((j = str.find('\n', i)) != std::string::npos) {
+		if (i != 0 || !ignore_first) {
+			output.insert(output.end(), depth, c);
+		}
+		output.insert(output.end(), str.begin() + i, str.begin() + j + 1);
+		i = j + 1;
+	}
+	if (i != 0 || !ignore_first) {
+		output.insert(output.end(), depth, c);
+	}
+	output.insert(output.end(), str.begin() + i, str.end());
+	return output;
+}
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -7,184 +7,183 @@
 #include <iterator>
 #include <optional>
 #include <regex>
-#include <string_view>
 #include <string>
+#include <string_view>
+#include <type_traits>
 #include <utility>
 #include <vector>
-#include <type_traits>
 
 #include <libassert/assert.hpp>
 
 #include "common.hpp"
 
 LIBASSERT_BEGIN_NAMESPACE
-namespace detail {
-    // Still present in release mode, nonfatal
-    #define LIBASSERT_PRIMITIVE_ASSERT(c, ...) ::libassert::detail::primitive_assert_impl( \
-        c, \
-        true, \
-        #c, \
-        LIBASSERT_PFUNC, \
-        {} LIBASSERT_VA_ARGS(__VA_ARGS__) \
-    )
 
-    /*
+namespace detail {
+// Still present in release mode, nonfatal
+#define LIBASSERT_PRIMITIVE_ASSERT(c, ...) \
+	::libassert::detail::primitive_assert_impl(c, true, #c, LIBASSERT_PFUNC, { \
+	} LIBASSERT_VA_ARGS(__VA_ARGS__))
+
+/*
      * string utilities
      */
 
-    LIBASSERT_EXPORT_TESTING
-    std::vector<std::string_view> split(std::string_view s, std::string_view delims);
+LIBASSERT_EXPORT_TESTING
+std::vector<std::string_view> split(std::string_view s, std::string_view delims);
 
-    template<typename C>
-    std::string join(const C& container, const std::string_view delim) {
-        auto iter = std::begin(container);
-        auto end = std::end(container);
-        std::string str;
-        if(std::distance(iter, end) > 0) {
-            str += *iter;
-            while(++iter != end) {
-                str += delim;
-                str += *iter;
-            }
-        }
-        return str;
-    }
+template<typename C>
+std::string join(const C& container, const std::string_view delim) {
+	auto iter = std::begin(container);
+	auto end = std::end(container);
+	std::string str;
+	if (std::distance(iter, end) > 0) {
+		str += *iter;
+		while (++iter != end) {
+			str += delim;
+			str += *iter;
+		}
+	}
+	return str;
+}
 
-    template<typename T>
-    std::vector<T> concat(std::vector<T> a, std::vector<T> b) {
-        a.insert(
-            a.end(),
-            std::make_move_iterator(b.begin()),
-            std::make_move_iterator(b.end())
-        );
-        return a;
-    }
+template<typename T>
+std::vector<T> concat(std::vector<T> a, std::vector<T> b) {
+	a.insert(a.end(), std::make_move_iterator(b.begin()), std::make_move_iterator(b.end()));
+	return a;
+}
 
-    constexpr const char* const whitespace_chars = " \t\n\r\f\v";
+constexpr const char* const whitespace_chars = " \t\n\r\f\v";
 
-    std::string_view trim(std::string_view s);
+std::string_view trim(std::string_view s);
 
-    void replace_all_dynamic(std::string& str, std::string_view text, std::string_view replacement);
+void replace_all_dynamic(std::string& str, std::string_view text, std::string_view replacement);
 
-    LIBASSERT_EXPORT_TESTING
-    void replace_all(std::string& str, const std::regex& re, std::string_view replacement);
+LIBASSERT_EXPORT_TESTING
+void replace_all(std::string& str, const std::regex& re, std::string_view replacement);
 
-    LIBASSERT_EXPORT_TESTING
-    void replace_all(std::string& str, std::string_view substr, std::string_view replacement);
+LIBASSERT_EXPORT_TESTING
+void replace_all(std::string& str, std::string_view substr, std::string_view replacement);
 
-    void replace_all_template(std::string& str, const std::pair<std::regex, std::string_view>& rule);
+void replace_all_template(std::string& str, const std::pair<std::regex, std::string_view>& rule);
 
-    std::string indent(std::string_view str, size_t depth, char c = ' ', bool ignore_first = false);
+std::string indent(std::string_view str, size_t depth, char c = ' ', bool ignore_first = false);
 
-    /*
+/*
      * Other
      */
 
-    // Container utility
-    template<typename N> class needle {
-        // TODO: Re-evaluate
-        const N& needle_value;
-    public:
-        explicit needle(const N& n) : needle_value(n) {}
-        template<typename K, typename V, typename... Rest>
-        constexpr V lookup(const K& option, const V& result, const Rest&... rest) {
-            if(needle_value == option) { return result; }
-            if constexpr(sizeof...(Rest) > 0) { return lookup(rest...); }
-            else { LIBASSERT_PRIMITIVE_DEBUG_ASSERT(false); LIBASSERT_UNREACHABLE_CALL(); }
-        }
-        template<typename... Args>
-        constexpr bool is_in(const Args&... option) {
-            return ((needle_value == option) || ... || false);
-        }
-    };
+// Container utility
+template<typename N>
+class needle {
+	// TODO: Re-evaluate
+	const N& needle_value;
 
-    #if LIBASSERT_IS_GCC && LIBASSERT_GCC_VERSION < 900
-    // note: the use of U here is to workaround a gcc 8 issue https://godbolt.org/z/bdsWhdGj3
-    template<typename T, typename U, std::size_t N, std::size_t... I>
-    constexpr std::array<std::remove_cv_t<T>, N> to_array_impl(U(&&a)[N], std::index_sequence<I...>) {
-        return {{std::move(a[I])...}};
-    }
-    template<typename T, typename U, std::size_t N>
-    constexpr std::array<std::remove_cv_t<T>, N> to_array(U(&&a)[N]) {
-        return to_array_impl<T>(std::move(a), std::make_index_sequence<N>{});
-    }
-    #else
-    // unfortunately the above workaround ICEs MSVC https://godbolt.org/z/bjMEcY9fM
-    template<typename T, std::size_t N, std::size_t... I>
-    constexpr std::array<std::remove_cv_t<T>, N> to_array_impl(T(&&a)[N], std::index_sequence<I...>) {
-        return {{std::move(a[I])...}};
-    }
-    template<typename T, std::size_t N>
-    constexpr std::array<std::remove_cv_t<T>, N> to_array(T(&&a)[N]) {
-        return to_array_impl<T>(std::move(a), std::make_index_sequence<N>{});
-    }
-    #endif
+public:
+	explicit needle(const N& n) : needle_value(n) {}
 
-    template<typename A, typename B>
-    constexpr void constexpr_swap(A& a, B& b) {
-        B tmp = std::move(b);
-        b = std::move(a);
-        a = std::move(tmp);
-    }
+	template<typename K, typename V, typename... Rest>
+	constexpr V lookup(const K& option, const V& result, const Rest&... rest) {
+		if (needle_value == option) {
+			return result;
+		}
+		if constexpr (sizeof...(Rest) > 0) {
+			return lookup(rest...);
+		} else {
+			LIBASSERT_PRIMITIVE_DEBUG_ASSERT(false);
+			LIBASSERT_UNREACHABLE_CALL();
+		}
+	}
 
-    // cmp(a, b) should return whether a comes before b
-    template<typename T, std::size_t N, typename C>
-    constexpr void constexpr_sort(std::array<T, N>& arr, const C& cmp) {
-        // insertion sort is fine for small arrays
-        static_assert(N <= 65);
-        for(std::size_t i = 1; i < arr.size(); i++) {
-            for(std::size_t j = 0; j < i; j++) {
-                if(cmp(arr[j], arr[i])) {
-                    constexpr_swap(arr[i], arr[j]);
-                }
-            }
-        }
-    }
+	template<typename... Args>
+	constexpr bool is_in(const Args&... option) {
+		return ((needle_value == option) || ... || false);
+	}
+};
 
-    template<typename T, typename std::enable_if<std::is_unsigned<T>::value, int>::type = 0>
-    constexpr T popcount(T value) {
-        T pop = 0;
-        while(value) {
-            value &= value - 1;
-            pop++;
-        }
-        return pop;
-    }
-
-    static_assert(popcount(0U) == 0);
-    static_assert(popcount(1U) == 1);
-    static_assert(popcount(2U) == 1);
-    static_assert(popcount(3U) == 2);
-    static_assert(popcount(0xf0U) == 4);
-
-    template<typename T>
-    static constexpr T n_digits(T value) {
-        return value < 10 ? 1 : 1 + n_digits(value / 10);
-    }
-
-    static_assert(n_digits(0) == 1);
-    static_assert(n_digits(1) == 1);
-    static_assert(n_digits(9) == 1);
-    static_assert(n_digits(10) == 2);
-    static_assert(n_digits(11) == 2);
-    static_assert(n_digits(1024) == 4);
-
-    inline bool operator==(const color_scheme& a, const color_scheme& b) {
-        return a.string == b.string
-            && a.escape == b.escape
-            && a.keyword == b.keyword
-            && a.named_literal == b.named_literal
-            && a.number == b.number
-            && a.punctuation == b.punctuation
-            && a.operator_token == b.operator_token
-            && a.call_identifier == b.call_identifier
-            && a.scope_resolution_identifier == b.scope_resolution_identifier
-            && a.identifier == b.identifier
-            && a.accent == b.accent
-            && a.unknown == b.unknown
-            && a.reset == b.reset;
-    }
+#if LIBASSERT_IS_GCC && LIBASSERT_GCC_VERSION < 900
+// note: the use of U here is to workaround a gcc 8 issue https://godbolt.org/z/bdsWhdGj3
+template<typename T, typename U, std::size_t N, std::size_t... I>
+constexpr std::array<std::remove_cv_t<T>, N> to_array_impl(U (&&a)[N], std::index_sequence<I...>) {
+	return {{std::move(a[I])...}};
 }
+
+template<typename T, typename U, std::size_t N>
+constexpr std::array<std::remove_cv_t<T>, N> to_array(U (&&a)[N]) {
+	return to_array_impl<T>(std::move(a), std::make_index_sequence<N> {});
+}
+#else
+// unfortunately the above workaround ICEs MSVC https://godbolt.org/z/bjMEcY9fM
+template<typename T, std::size_t N, std::size_t... I>
+constexpr std::array<std::remove_cv_t<T>, N> to_array_impl(T (&&a)[N], std::index_sequence<I...>) {
+	return {{std::move(a[I])...}};
+}
+
+template<typename T, std::size_t N>
+constexpr std::array<std::remove_cv_t<T>, N> to_array(T (&&a)[N]) {
+	return to_array_impl<T>(std::move(a), std::make_index_sequence<N> {});
+}
+#endif
+
+template<typename A, typename B>
+constexpr void constexpr_swap(A& a, B& b) {
+	B tmp = std::move(b);
+	b = std::move(a);
+	a = std::move(tmp);
+}
+
+// cmp(a, b) should return whether a comes before b
+template<typename T, std::size_t N, typename C>
+constexpr void constexpr_sort(std::array<T, N>& arr, const C& cmp) {
+	// insertion sort is fine for small arrays
+	static_assert(N <= 65);
+	for (std::size_t i = 1; i < arr.size(); i++) {
+		for (std::size_t j = 0; j < i; j++) {
+			if (cmp(arr[j], arr[i])) {
+				constexpr_swap(arr[i], arr[j]);
+			}
+		}
+	}
+}
+
+template<typename T, typename std::enable_if<std::is_unsigned<T>::value, int>::type = 0>
+constexpr T popcount(T value) {
+	T pop = 0;
+	while (value) {
+		value &= value - 1;
+		pop++;
+	}
+	return pop;
+}
+
+static_assert(popcount(0U) == 0);
+static_assert(popcount(1U) == 1);
+static_assert(popcount(2U) == 1);
+static_assert(popcount(3U) == 2);
+static_assert(popcount(0xf0U) == 4);
+
+template<typename T>
+static constexpr T n_digits(T value) {
+	return value < 10 ? 1 : 1 + n_digits(value / 10);
+}
+
+static_assert(n_digits(0) == 1);
+static_assert(n_digits(1) == 1);
+static_assert(n_digits(9) == 1);
+static_assert(n_digits(10) == 2);
+static_assert(n_digits(11) == 2);
+static_assert(n_digits(1024) == 4);
+
+inline bool operator==(const color_scheme& a, const color_scheme& b) {
+	return a.string == b.string && a.escape == b.escape && a.keyword == b.keyword
+		&& a.named_literal == b.named_literal && a.number == b.number && a.punctuation == b.punctuation
+		&& a.operator_token == b.operator_token && a.call_identifier == b.call_identifier
+		&& a.scope_resolution_identifier == b.scope_resolution_identifier
+		&& a.identifier == b.identifier && a.accent == b.accent && a.unknown == b.unknown
+		&& a.reset == b.reset;
+}
+} // namespace detail
+
 LIBASSERT_END_NAMESPACE
 
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -186,6 +186,11 @@ if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
       LIBS GTest::gtest_main fmt::fmt
     )
     add_unittest(
+      SOURCE tests/unit/temporaries-test.cpp
+      OPTIONS $<$<CXX_COMPILER_ID:MSVC>:/Zc:preprocessor>
+      LIBS GTest::gtest_main
+    )
+    add_unittest(
       SOURCE tests/unit/std_format20.cpp
       OPTIONS $<$<CXX_COMPILER_ID:MSVC>:/Zc:preprocessor>
       FEATURES cxx_std_20

--- a/tests/add_subdirectory-integration/main.cpp
+++ b/tests/add_subdirectory-integration/main.cpp
@@ -1,7 +1,7 @@
 #include <libassert/assert.hpp>
 
 int main() {
-    ASSERT(true);
-    ASSUME(true);
-    DEBUG_ASSERT(true);
+	ASSERT(true);
+	ASSUME(true);
+	DEBUG_ASSERT(true);
 }

--- a/tests/binaries/basic_demo.cpp
+++ b/tests/binaries/basic_demo.cpp
@@ -1,5 +1,5 @@
 #include <libassert/assert.hpp>
 
 int main() {
-    ASSERT(1 + 1 == 3);
+	ASSERT(1 + 1 == 3);
 }

--- a/tests/binaries/basic_test.cpp
+++ b/tests/binaries/basic_test.cpp
@@ -7,11 +7,11 @@
 #include <libassert/assert.hpp>
 
 std::optional<float> foo() {
-    return 2.5f;
+	return 2.5f;
 }
 
 int main() {
-    auto f = *DEBUG_ASSERT_VAL(foo());
-    static_assert(std::is_same<decltype(f), float>::value);
-    assert(f == 2.5f);
+	auto f = *DEBUG_ASSERT_VAL(foo());
+	static_assert(std::is_same<decltype(f), float>::value);
+	assert(f == 2.5f);
 }

--- a/tests/binaries/catch2-demo.cpp
+++ b/tests/binaries/catch2-demo.cpp
@@ -1,18 +1,19 @@
-#include "catch2/catch_test_macros.hpp"
 #include <libassert/assert-catch2.hpp>
 
+#include "catch2/catch_test_macros.hpp"
+
 TEST_CASE("1 + 1 is 2") {
-    ASSERT(1 + 1 == 3);
+	ASSERT(1 + 1 == 3);
 }
 
 void foo(int x) {
-    LIBASSERT_ASSERT(x >= 20, "foobar");
+	LIBASSERT_ASSERT(x >= 20, "foobar");
 }
 
 TEST_CASE("REQUIRE_ASSERT FAIL") {
-    REQUIRE_ASSERT(foo(20));
+	REQUIRE_ASSERT(foo(20));
 }
 
 TEST_CASE("REQUIRE_ASSERT PASS") {
-    REQUIRE_ASSERT(foo(5));
+	REQUIRE_ASSERT(foo(5));
 }

--- a/tests/binaries/gtest-demo.cpp
+++ b/tests/binaries/gtest-demo.cpp
@@ -1,5 +1,5 @@
 #include <libassert/assert-gtest.hpp>
 
 TEST(Addition, Arithmetic) {
-    ASSERT(1 + 1 == 3);
+	ASSERT(1 + 1 == 3);
 }

--- a/tests/binaries/tokens_and_highlighting.cpp
+++ b/tests/binaries/tokens_and_highlighting.cpp
@@ -8,8 +8,10 @@
 #include "analysis.hpp"
 
 int main() {
-    std::ifstream file("tests/test_program.cpp"); // just a test program that doesn't have preprocessor directives, which we don't tokenize
-    std::ostringstream buf;
-    buf<<file.rdbuf();
-    std::cout<<libassert::detail::highlight(buf.str(), libassert::color_scheme::ansi_rgb);
+	std::ifstream file(
+		"tests/test_program.cpp"
+	); // just a test program that doesn't have preprocessor directives, which we don't tokenize
+	std::ostringstream buf;
+	buf << file.rdbuf();
+	std::cout << libassert::detail::highlight(buf.str(), libassert::color_scheme::ansi_rgb);
 }

--- a/tests/demo/baz/demo.cpp
+++ b/tests/demo/baz/demo.cpp
@@ -1,6 +1,7 @@
 #include <libassert/assert.hpp>
+
 // This file is used for testing path disambiguation
 
 void wubble() {
-    debug_assert(false);
+	debug_assert(false);
 }

--- a/tests/demo/demo.cpp
+++ b/tests/demo/demo.cpp
@@ -10,8 +10,8 @@
 #include <optional>
 #include <set>
 #include <sstream>
-#include <string_view>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -37,274 +37,307 @@ void qux();
 void wubble();
 
 void custom_fail(const libassert::assertion_info& assertion) {
-    std::cerr<<assertion.to_string(libassert::terminal_width(STDERR_FILENO), libassert::color_scheme::ansi_rgb)<<std::endl<<std::endl;
+	std::cerr << assertion.to_string(
+		libassert::terminal_width(STDERR_FILENO),
+		libassert::color_scheme::ansi_rgb
+	) << std::endl
+						<< std::endl;
 }
 
-static std::string indent(const std::string_view str, size_t depth, char c = ' ', bool ignore_first = false) {
-    size_t i = 0, j;
-    std::string output;
-    while((j = str.find('\n', i)) != std::string::npos) {
-        if(i != 0 || !ignore_first) {
-            output.insert(output.end(), depth, c);
-        }
-        output.insert(output.end(), str.begin() + i, str.begin() + j + 1);
-        i = j + 1;
-    }
-    if(i != 0 || !ignore_first) {
-        output.insert(output.end(), depth, c);
-    }
-    output.insert(output.end(), str.begin() + i, str.end());
-    return output;
+static std::string
+indent(const std::string_view str, size_t depth, char c = ' ', bool ignore_first = false) {
+	size_t i = 0, j;
+	std::string output;
+	while ((j = str.find('\n', i)) != std::string::npos) {
+		if (i != 0 || !ignore_first) {
+			output.insert(output.end(), depth, c);
+		}
+		output.insert(output.end(), str.begin() + i, str.begin() + j + 1);
+		i = j + 1;
+	}
+	if (i != 0 || !ignore_first) {
+		output.insert(output.end(), depth, c);
+	}
+	output.insert(output.end(), str.begin() + i, str.end());
+	return output;
 }
 
-template<class T> struct S {
-    T x;
-    S() = default;
-    ~S() = default;
-    S(T&& _x) : x(std::forward<T>(_x)) {}
-    // moveable, not copyable
-    S(const S&) = delete;
-    S(S&&) noexcept = default;
-    S& operator=(const S&) = delete;
-    S& operator=(S&&) noexcept = default;
-    bool operator==(const S& s) const { return x == s.x; }
-    friend std::ostream& operator<<(std::ostream& o, const S& s) {
-        o<<"I'm S<"<<libassert::type_name<T>()<<"> and I contain:"<<std::endl;
-        std::ostringstream oss;
-        oss<<s.x;
-        o<<indent(std::move(oss).str(), 4);
-        return o;
-    }
+template<class T>
+struct S {
+	T x;
+	S() = default;
+	~S() = default;
+
+	S(T&& _x) : x(std::forward<T>(_x)) {}
+
+	// moveable, not copyable
+	S(const S&) = delete;
+	S(S&&) noexcept = default;
+	S& operator=(const S&) = delete;
+	S& operator=(S&&) noexcept = default;
+
+	bool operator==(const S& s) const {
+		return x == s.x;
+	}
+
+	friend std::ostream& operator<<(std::ostream& o, const S& s) {
+		o << "I'm S<" << libassert::type_name<T>() << "> and I contain:" << std::endl;
+		std::ostringstream oss;
+		oss << s.x;
+		o << indent(std::move(oss).str(), 4);
+		return o;
+	}
 };
 
-template<> struct S<void> {
-    bool operator==(const S&) const { return false; }
+template<>
+struct S<void> {
+	bool operator==(const S&) const {
+		return false;
+	}
 };
 
 struct P {
-    std::string str;
-    P() = default;
-    ~P() = delete;
-    P(const P&) = delete;
-    P(P&&) = default;
-    P& operator=(const P&) = delete;
-    P& operator=(P&&) = delete;
-    bool operator==(const P& p) const { return str == p.str; }
-    friend std::ostream& operator<<(std::ostream& o, const P& p) {
-        o<<p.str;
-        return o;
-    }
+	std::string str;
+	P() = default;
+	~P() = delete;
+	P(const P&) = delete;
+	P(P&&) = default;
+	P& operator=(const P&) = delete;
+	P& operator=(P&&) = delete;
+
+	bool operator==(const P& p) const {
+		return str == p.str;
+	}
+
+	friend std::ostream& operator<<(std::ostream& o, const P& p) {
+		o << p.str;
+		return o;
+	}
 };
 
 struct M {
-    M() = default;
-    ~M() {
-        puts("M::~M(); called");
-    }
-    M(const M&) = delete;
-    M(M&&) = default; // only move-constructable
-    M& operator=(const M&) = delete;
-    M& operator=(M&&) = delete;
-    bool operator<(int) const & {
-        puts("M::operator<(int)& called");
-        return false;
-    }
-    bool operator<(int) const && {
-        puts("M::operator<(int)&& called");
-        return false;
-    }
+	M() = default;
+
+	~M() {
+		puts("M::~M(); called");
+	}
+
+	M(const M&) = delete;
+	M(M&&) = default; // only move-constructable
+	M& operator=(const M&) = delete;
+	M& operator=(M&&) = delete;
+
+	bool operator<(int) const& {
+		puts("M::operator<(int)& called");
+		return false;
+	}
+
+	bool operator<(int) const&& {
+		puts("M::operator<(int)&& called");
+		return false;
+	}
 };
 
 int garple() {
-    return 2;
+	return 2;
 }
 
 void rec(int n) {
-    if(n == 0) debug_assert(false);
-    else rec(n - 1);
+	if (n == 0)
+		debug_assert(false);
+	else
+		rec(n - 1);
 }
 
 void recursive_a(int), recursive_b(int);
 
 void recursive_a(int n) {
-    if(n == 0) debug_assert(false);
-    else recursive_b(n - 1);
+	if (n == 0)
+		debug_assert(false);
+	else
+		recursive_b(n - 1);
 }
 
 void recursive_b(int n) {
-    if(n == 0) debug_assert(false);
-    else recursive_a(n - 1);
+	if (n == 0)
+		debug_assert(false);
+	else
+		recursive_a(n - 1);
 }
 
 auto min_items() {
-    return 10;
+	return 10;
 }
 
 void zoog(const std::map<std::string, int>& map) {
-    #if __cplusplus >= 202002L
-     DEBUG_ASSERT(map.contains("foo"), "expected key not found", map);
-    #else
-     DEBUG_ASSERT(map.count("foo") != 1, "expected key not found", map);
-    #endif
-    DEBUG_ASSERT(map.at("bar") >= 0, "unexpected value for foo in the map", map);
+#if __cplusplus >= 202002L
+	DEBUG_ASSERT(map.contains("foo"), "expected key not found", map);
+#else
+	DEBUG_ASSERT(map.count("foo") != 1, "expected key not found", map);
+#endif
+	DEBUG_ASSERT(map.at("bar") >= 0, "unexpected value for foo in the map", map);
 }
 
 #define O_RDONLY 0
+
 int open(const char*, int) {
-    return -1;
+	return -1;
 }
 
 std::optional<float> get_param() {
-    return {};
+	return {};
 }
 
 int get_mask() {
-    return 0b00101101;
+	return 0b00101101;
 }
 
 // disable unsafe use of bool warning msvc
 #ifdef _MSC_VER
- #pragma warning(disable: 4806)
+	#pragma warning(disable : 4806)
 #endif
 
 class foo {
 public:
-    template<typename> void bar([[maybe_unused]] std::pair<int, int> x) {
-        baz();
-    }
+	template<typename>
+	void bar([[maybe_unused]] std::pair<int, int> x) {
+		baz();
+	}
 
-    void baz() {
-        puts("");
-        // General demos
-        {
-            zoog({
-                //{ "foo", 2 },
-                { "bar", -2 },
-                { "baz", 20 }
-            });
-            std::vector<int> vec = {2, 3, 5, 7, 11, 13};
-            debug_assert(vec.size() > min_items(), "vector doesn't have enough items", vec);
-        }
-        const char* path = "/home/foobar/baz";
-        {
-            int fd = open(path, O_RDONLY);
-            debug_assert(fd >= 0, "Internal error with foobars", errno, path);
-            (void)fd;
-        }
-        {
-            debug_assert(open(path, O_RDONLY) >= 0, "Internal error with foobars", errno, path);
-        }
-        {
-            FILE* f = ASSERT_VAL(fopen(path, "r") != nullptr, "Internal error with foobars", errno, path);
-            (void)f;
-        }
-        debug_assert(false, "Error while doing XYZ");
-        debug_assert(false);
-        DEBUG_ASSERT((puts("DEBUG_ASSERT called") && false));
+	void baz() {
+		puts("");
+		// General demos
+		{
+			zoog(
+				{//{ "foo", 2 },
+				 {"bar", -2},
+				 {"baz", 20}
+				}
+			);
+			std::vector<int> vec = {2, 3, 5, 7, 11, 13};
+			debug_assert(vec.size() > min_items(), "vector doesn't have enough items", vec);
+		}
+		const char* path = "/home/foobar/baz";
+		{
+			int fd = open(path, O_RDONLY);
+			debug_assert(fd >= 0, "Internal error with foobars", errno, path);
+			(void)fd;
+		}
+		{ debug_assert(open(path, O_RDONLY) >= 0, "Internal error with foobars", errno, path); }
+		{
+			FILE* f = ASSERT_VAL(fopen(path, "r") != nullptr, "Internal error with foobars", errno, path);
+			(void)f;
+		}
+		debug_assert(false, "Error while doing XYZ");
+		debug_assert(false);
+		DEBUG_ASSERT((puts("DEBUG_ASSERT called") && false));
 
-        {
-            std::map<int, int> map {{1,1}};
-            DEBUG_ASSERT(map.count(1) == 2);
-            debug_assert(map.count(1) >= 2 * garple(), "Error while doing XYZ");
-        }
-        debug_assert(0, 2 == garple());
-        {
-            std::optional<float> parameter;
-            #ifndef _MSC_VER
-             if(auto i = *ASSERT_VAL(parameter)) {
-                 static_assert(std::is_same<decltype(i), float>::value);
-             }
-             float f = *assert_val(get_param());
-             (void)f;
-            #else
-             ASSERT(parameter);
-             debug_assert(get_param());
-            #endif
-            auto x = [&] () -> decltype(auto) { return ASSERT_VAL(parameter); };
-            static_assert(std::is_same<decltype(x()), std::optional<float>&>::value);
-        }
+		{
+			std::map<int, int> map {{1, 1}};
+			DEBUG_ASSERT(map.count(1) == 2);
+			debug_assert(map.count(1) >= 2 * garple(), "Error while doing XYZ");
+		}
+		debug_assert(0, 2 == garple());
+		{
+			std::optional<float> parameter;
+#ifndef _MSC_VER
+			if (auto i = *ASSERT_VAL(parameter)) {
+				static_assert(std::is_same<decltype(i), float>::value);
+			}
+			float f = *assert_val(get_param());
+			(void)f;
+#else
+			ASSERT(parameter);
+			debug_assert(get_param());
+#endif
+			auto x = [&]() -> decltype(auto) { return ASSERT_VAL(parameter); };
+			static_assert(std::is_same<decltype(x()), std::optional<float>&>::value);
+		}
 
-        qux();
+		qux();
 
-        {
-            M() < 2;
-            puts("----");
-            debug_assert(M() < 2);
-            puts("----");
-            M m;
-            puts("----");
-            debug_assert(m < 2);
-            puts("----");
-        }
+		{
+			M() < 2;
+			puts("----");
+			debug_assert(M() < 2);
+			puts("----");
+			M m;
+			puts("----");
+			debug_assert(m < 2);
+			puts("----");
+		}
 
+		debug_assert(true ? false : true == false);
+		debug_assert(true ? false : true, "pffft");
 
-        debug_assert(true ? false : true == false);
-        debug_assert(true ? false : true, "pffft");
+		wubble();
 
-        wubble();
+		rec(10);
 
-        rec(10);
+		recursive_a(10);
 
-        recursive_a(10);
+		ASSERT(18446744073709551606ULL == -10);
 
-        ASSERT(18446744073709551606ULL == -10);
+		ASSERT(get_mask() == 0b00001101);
+		debug_assert(0xf == 16);
 
-        ASSERT(get_mask() == 0b00001101);
-        debug_assert(0xf == 16);
+		{
+			std::string s = "test\n";
+			int i = 0;
+			debug_assert(s == "test");
+			ASSERT(s[i] == 'c', "", s, i);
+		}
+		{
+			debug_assert(S<S<int>>(2) == S<S<int>>(4));
+			S<void> e, f;
+			debug_assert(e == f);
+		}
 
-        {
-            std::string s = "test\n";
-            int i = 0;
-            debug_assert(s == "test");
-            ASSERT(s[i] == 'c', "", s, i);
-        }
-        {
-            debug_assert(S<S<int>>(2) == S<S<int>>(4));
-            S<void> e, f;
-            debug_assert(e == f);
-        }
+		long long x = -9'223'372'036'854'775'807;
+		debug_assert(x & 0x4);
 
-        long long x = -9'223'372'036'854'775'807;
-        debug_assert(x & 0x4);
+		debug_assert(!x and true == 2);
+		debug_assert((puts("A"), false) && (puts("B"), false));
 
-        debug_assert(!x and true == 2);
-        debug_assert((puts("A"), false) && (puts("B"), false));
+		{
+#if defined(__GNUC__) || defined(__GNUG__) // gcc/clang
+	#pragma GCC diagnostic ignored "-Wshadow"
+#endif
+			std::string s = "h1eLlo";
+			debug_assert(
+				std::find_if(
+					s.begin(),
+					s.end(),
+					[](char c) {
+						debug_assert(not isdigit(c), c);
+						return c >= 'A' and c <= 'Z';
+					}
+				)
+				== s.end()
+			);
+		}
 
-        {
-            #if defined(__GNUC__) || defined(__GNUG__) // gcc/clang
-             #pragma GCC diagnostic ignored "-Wshadow"
-            #endif
-            std::string s = "h1eLlo";
-            debug_assert(std::find_if(s.begin(), s.end(), [](char c) {
-                debug_assert(not isdigit(c), c);
-                return c >= 'A' and c <= 'Z';
-            }) == s.end());
-        }
+		{
+			std::set<int> a = {2, 2, 4, 6, 10};
+			std::set<int> b = {2, 2, 5, 6, 10};
+			std::vector<double> c = {1.2, 2.44, 3.15159, 5.2};
+			debug_assert(a == b, c);
+			std::map<std::string, int> m0 = {{"foo", 2}, {"bar", -2}};
+			debug_assert(false, m0);
+			std::map<std::string, std::vector<int>> m1 = {
+				{"foo", {1, -2, 3, -4}},
+				{"bar", {-100, 200, 400, -800}}
+			};
+			debug_assert(false, m1);
+			auto t = std::make_tuple(1, 0.1 + 0.2, "foobars");
+			debug_assert(false, t);
+			std::array<int, 10> arr = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+			debug_assert(false, arr);
+		}
 
-        {
-            std::set<int> a = { 2, 2, 4, 6, 10 };
-            std::set<int> b = { 2, 2, 5, 6, 10 };
-            std::vector<double> c = { 1.2, 2.44, 3.15159, 5.2 };
-            debug_assert(a == b, c);
-            std::map<std::string, int> m0 = {
-                {"foo", 2},
-                {"bar", -2}
-            };
-            debug_assert(false, m0);
-            std::map<std::string, std::vector<int>> m1 = {
-                {"foo", {1, -2, 3, -4}},
-                {"bar", {-100, 200, 400, -800}}
-            };
-            debug_assert(false, m1);
-            auto t = std::make_tuple(1, 0.1 + 0.2, "foobars");
-            debug_assert(false, t);
-            std::array<int, 10> arr = {1,2,3,4,5,6,7,8,9,10};
-            debug_assert(false, arr);
-        }
-
-        // Numeric
-        // Tests useful during development
-        /*debug_assert(.1f == .1);
+		// Numeric
+		// Tests useful during development
+		/*debug_assert(.1f == .1);
         debug_assert(1.0 == 1.0 + std::numeric_limits<double>::epsilon());
         ASSERT_EQ(0x12p2, 12);
         ASSERT_EQ(0x12p2, 0b10);
@@ -387,12 +420,12 @@ public:
         debug_assert(.1f == 0.2);
 
         debug_assert(true); // this should lead to another debug_assert(false) because we're in demo mode*/
-    }
+	}
 };
 
 int main() {
-    libassert::enable_virtual_terminal_processing_if_needed();
-    libassert::set_failure_handler(custom_fail);
-    foo f;
-    f.bar<int>({});
+	libassert::enable_virtual_terminal_processing_if_needed();
+	libassert::set_failure_handler(custom_fail);
+	foo f;
+	f.bar<int>({});
 }

--- a/tests/demo/foo.cpp
+++ b/tests/demo/foo.cpp
@@ -1,5 +1,5 @@
 #include <libassert/assert.hpp>
 
 void qux() {
-    debug_assert(false);
+	debug_assert(false);
 }

--- a/tests/fetchcontent-integration/main.cpp
+++ b/tests/fetchcontent-integration/main.cpp
@@ -1,10 +1,10 @@
-#include <libassert/assert.hpp>
-
 #include <iostream>
 
+#include <libassert/assert.hpp>
+
 int main() {
-    ASSERT(true);
-    ASSUME(true);
-    DEBUG_ASSERT(true);
-    std::cout<<"Good to go"<<std::endl;
+	ASSERT(true);
+	ASSUME(true);
+	DEBUG_ASSERT(true);
+	std::cout << "Good to go" << std::endl;
 }

--- a/tests/findpackage-integration/main.cpp
+++ b/tests/findpackage-integration/main.cpp
@@ -1,10 +1,10 @@
-#include <libassert/assert.hpp>
-
 #include <iostream>
 
+#include <libassert/assert.hpp>
+
 int main() {
-    ASSERT(true);
-    ASSUME(true);
-    DEBUG_ASSERT(true);
-    std::cout<<"Good to go"<<std::endl;
+	ASSERT(true);
+	ASSUME(true);
+	DEBUG_ASSERT(true);
+	std::cout << "Good to go" << std::endl;
 }

--- a/tests/integration/a.cpp
+++ b/tests/integration/a.cpp
@@ -4,5 +4,5 @@
 void test_path_differentiation_2();
 
 void test_path_differentiation() {
-    test_path_differentiation_2();
+	test_path_differentiation_2();
 }

--- a/tests/integration/integration.cpp
+++ b/tests/integration/integration.cpp
@@ -6,8 +6,8 @@
 #include <map>
 #include <optional>
 #include <set>
-#include <string_view>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -20,133 +20,155 @@ using namespace std::literals;
 void test_path_differentiation();
 
 void custom_fail(const libassert::assertion_info& assertion) {
-    std::cout<<assertion.to_string(0, libassert::color_scheme::blank)<<std::endl<<std::endl;
-    if(assertion.type == libassert::assert_type::panic) {
-        throw std::runtime_error("foobar");
-    }
+	std::cout << assertion.to_string(0, libassert::color_scheme::blank) << std::endl << std::endl;
+	if (assertion.type == libassert::assert_type::panic) {
+		throw std::runtime_error("foobar");
+	}
 }
 
 struct debug_print_customization {
-    int x;
-    debug_print_customization(int t) : x(t) {}
-    bool operator==(const debug_print_customization& other) const {
-        return x == other.x;
-    }
-    friend std::ostream& operator<<(std::ostream& stream, const debug_print_customization&) {
-        return stream<<"wrong print";
-    }
+	int x;
+
+	debug_print_customization(int t) : x(t) {}
+
+	bool operator==(const debug_print_customization& other) const {
+		return x == other.x;
+	}
+
+	friend std::ostream& operator<<(std::ostream& stream, const debug_print_customization&) {
+		return stream << "wrong print";
+	}
 };
 
-template<> struct libassert::stringifier<debug_print_customization> {
-    std::string stringify(const debug_print_customization& p) {
-        return "(debug_print_customization = " + std::to_string(p.x) + ")";
-    }
+template<>
+struct libassert::stringifier<debug_print_customization> {
+	std::string stringify(const debug_print_customization& p) {
+		return "(debug_print_customization = " + std::to_string(p.x) + ")";
+	}
 };
 
 int foo() {
-    std::cout<<"foo() called"<<std::endl;
-    return 2;
+	std::cout << "foo() called" << std::endl;
+	return 2;
 }
+
 int bar() {
-    std::cout<<"bar() called"<<std::endl;
-    return -2;
+	std::cout << "bar() called" << std::endl;
+	return -2;
 }
 
 namespace complex_typing {
-    struct S {
-        void foo(int, std::string, void***, void* (*)(int), void(*(*)(int))(), void(*(*(*)(int))[5])());
-    };
-}
+struct S {
+	void foo(int, std::string, void***, void* (*)(int), void (*(*)(int))(), void (*(*(*)(int))[5])());
+};
+} // namespace complex_typing
 
 #line 500
+
 void rec(int n) {
-    if(n == 0) debug_assert(false);
-    else rec(n - 1);
+	if (n == 0)
+		debug_assert(false);
+	else
+		rec(n - 1);
 }
 
 void recursive_a(int), recursive_b(int);
 
 void recursive_a(int n) {
-    if(n == 0) debug_assert(false);
-    else recursive_b(n - 1);
+	if (n == 0)
+		debug_assert(false);
+	else
+		recursive_b(n - 1);
 }
 
 void recursive_b(int n) {
-    if(n == 0) debug_assert(false);
-    else recursive_a(n - 1);
+	if (n == 0)
+		debug_assert(false);
+	else
+		recursive_a(n - 1);
 }
 
-#define SECTION(s) std::cout<<"===================== ["<<(s)<<"] ====================="<<std::endl;
+#define SECTION(s) \
+	std::cout << "===================== [" << (s) << "] =====================" << std::endl;
 
 // disable unsafe use of bool warning msvc
 #ifdef _MSC_VER
- #pragma warning(disable: 4804)
+	#pragma warning(disable : 4804)
 #endif
 
 // TODO: need to check assert, verify, and check...?
 // Opt/DNDEBUG
 
 #line 1000
+
 template<typename T>
 class test_class {
 public:
-    template<typename S> void something([[maybe_unused]] std::pair<S, T> x) {
-        something_else();
-    }
+	template<typename S>
+	void something([[maybe_unused]] std::pair<S, T> x) {
+		something_else();
+	}
 
-    void something_else() {
-        // general stack traces are tested throughout
-        // simple recursion
-        SECTION("simple recursion");
-        #line 2600
-        rec(10); // FIXME: Check stacktrace in clang
-        // other recursion
-        SECTION("other recursion");
-        #line 2700
-        recursive_a(10); // FIXME: Check stacktrace in clang
+	void something_else() {
+		// general stack traces are tested throughout
+		// simple recursion
+		SECTION("simple recursion");
+#line 2600
+		rec(10); // FIXME: Check stacktrace in clang
+		// other recursion
+		SECTION("other recursion");
+#line 2700
+		recursive_a(10); // FIXME: Check stacktrace in clang
 
-        // path differentiation
-        SECTION("Path differentiation");
-        #line 2800
-        test_path_differentiation();
+		// path differentiation
+		SECTION("Path differentiation");
+#line 2800
+		test_path_differentiation();
 
-        SECTION("Type cleaning"); // also pretty thoughroughly tested above aside from std::string_view
-        #line 3200
-        {
-            test_pretty_function_cleaning({});
-        }
+		SECTION("Type cleaning"); // also pretty thoughroughly tested above aside from std::string_view
+#line 3200
+		{ test_pretty_function_cleaning({}); }
 
-        SECTION("Complex type resolution");
-        #line 3500
-        {
-            const volatile std::vector<std::string>* ptr = nullptr;
-            test_complex_typing(ptr, nullptr, "foo", nullptr, nullptr);
-        }
-    }
+		SECTION("Complex type resolution");
+#line 3500
+		{
+			const volatile std::vector<std::string>* ptr = nullptr;
+			test_complex_typing(ptr, nullptr, "foo", nullptr, nullptr);
+		}
+	}
 
-    #line 3300
-    void test_pretty_function_cleaning(const std::map<std::string, std::vector<std::string_view>>& other) {
-        std::map<std::string, std::vector<std::string_view>> map = {
-            {"foo", {"f1", "f3", "f5"}},
-            {"bar", {"b1", "b3", "b5"}}
-        };
-        debug_assert(map == other);
-    }
+#line 3300
 
-    #line 3600
-    void test_complex_typing(const volatile std::vector<std::string>* const &, int[], const char(&)[4],
-                             decltype(&complex_typing::S::foo), int complex_typing::S::*) {
-        debug_assert(false);
-    }
+	void
+	test_pretty_function_cleaning(const std::map<std::string, std::vector<std::string_view>>& other) {
+		std::map<std::string, std::vector<std::string_view>> map = {
+			{"foo", {"f1", "f3", "f5"}},
+			{"bar", {"b1", "b3", "b5"}}
+		};
+		debug_assert(map == other);
+	}
+
+#line 3600
+
+	void test_complex_typing(
+		const volatile std::vector<std::string>* const&,
+		int[],
+		const char (&)[4],
+		decltype(&complex_typing::S::foo),
+		int complex_typing::S::*
+	) {
+		debug_assert(false);
+	}
 };
 
-struct N { };
+struct N {};
 
 #line 400
+
 int main() {
-    libassert::set_failure_handler(custom_fail);
-    libassert::set_color_scheme(libassert::color_scheme::blank);
-    test_class<int> t;
-    #line 402
-    t.something(std::pair {N(), 1});
+	libassert::set_failure_handler(custom_fail);
+	libassert::set_color_scheme(libassert::color_scheme::blank);
+	test_class<int> t;
+#line 402
+	t.something(std::pair {N(), 1});
 }

--- a/tests/integration/x/a.cpp
+++ b/tests/integration/x/a.cpp
@@ -1,6 +1,7 @@
 #include <libassert/assert.hpp>
+
 // This file is used for testing path disambiguation
 
 void test_path_differentiation_2() {
-    debug_assert(false);
+	debug_assert(false);
 }

--- a/tests/unit/assertion_tests.cpp
+++ b/tests/unit/assertion_tests.cpp
@@ -1,10 +1,5 @@
-#include <gtest/gtest.h>
-
-#include "utils.hpp"
-#include "microfmt.hpp"
-#include "tokenizer.hpp"
-
 #include <array>
+#include <gtest/gtest.h>
 #include <iostream>
 #include <map>
 #include <optional>
@@ -12,117 +7,125 @@
 #include <string>
 #include <vector>
 
+#include "microfmt.hpp"
+#include "tokenizer.hpp"
+#include "utils.hpp"
+
 #ifdef TEST_MODULE
 import libassert;
-#include <libassert/assert-macros.hpp>
+	#include <libassert/assert-macros.hpp>
 #else
-#include <libassert/assert.hpp>
+	#include <libassert/assert.hpp>
 #endif
 
 using namespace std::literals;
 
 inline void failure_handler(const libassert::assertion_info& info) {
-    // everything from .to_string except the stacktrace
-    std::string output;
-    output += info.tagline(libassert::color_scheme::blank);
-    output += info.statement(libassert::color_scheme::blank);
-    output += info.print_binary_diagnostics(0, libassert::color_scheme::blank);
-    output += info.print_extra_diagnostics(0, libassert::color_scheme::blank);
-    throw std::runtime_error(output);
+	// everything from .to_string except the stacktrace
+	std::string output;
+	output += info.tagline(libassert::color_scheme::blank);
+	output += info.statement(libassert::color_scheme::blank);
+	output += info.print_binary_diagnostics(0, libassert::color_scheme::blank);
+	output += info.print_extra_diagnostics(0, libassert::color_scheme::blank);
+	throw std::runtime_error(output);
 }
 
-inline auto pre_main = [] () {
-    libassert::set_failure_handler(failure_handler);
-    return 1;
-} ();
+inline auto pre_main = []() {
+	libassert::set_failure_handler(failure_handler);
+	return 1;
+}();
 
 struct location {
-    std::string_view file;
-    int line;
-    std::string_view signature;
+	std::string_view file;
+	int line;
+	std::string_view signature;
 };
 
-constexpr std::string_view file = [] () constexpr {
-    constexpr std::string_view f = __FILE__;
-    constexpr std::size_t pos = f.find_last_of("/\\");
-    static_assert(pos != std::string_view::npos);
-    return f.substr(pos + 1);
-} ();
+constexpr std::string_view file = []() constexpr {
+	constexpr std::string_view f = __FILE__;
+	constexpr std::size_t pos = f.find_last_of("/\\");
+	static_assert(pos != std::string_view::npos);
+	return f.substr(pos + 1);
+}();
 
 std::string_view mtrim(const std::string_view s) {
-    const size_t l = s.find_first_not_of(" \n");
-    if(l == std::string_view::npos) {
-        return "";
-    }
-    const size_t r = s.find_last_not_of(" ") + 1;
-    ASSERT(r != std::string_view::npos);
-    return s.substr(l, r - l);
+	const size_t l = s.find_first_not_of(" \n");
+	if (l == std::string_view::npos) {
+		return "";
+	}
+	const size_t r = s.find_last_not_of(" ") + 1;
+	ASSERT(r != std::string_view::npos);
+	return s.substr(l, r - l);
 }
 
 std::string replace(std::string str, std::string_view needle, std::string_view replacement) {
-    if(auto pos = str.find(needle); pos != std::string::npos) {
-        return str.replace(pos, needle.size(), replacement);
-    } else {
-        return str;
-    }
+	if (auto pos = str.find(needle); pos != std::string::npos) {
+		return str.replace(pos, needle.size(), replacement);
+	} else {
+		return str;
+	}
 }
 
 std::string assertion_failure_message;
 
-#define WRAP(...) do { \
-        assertion_failure_message = ""; \
-        try { \
-            __VA_ARGS__; \
-        } catch(std::exception& e) { \
-            assertion_failure_message = e.what(); \
-        } \
-    } while(0)
+#define WRAP(...) \
+	do { \
+		assertion_failure_message = ""; \
+		try { \
+			__VA_ARGS__; \
+		} catch (std::exception & e) { \
+			assertion_failure_message = e.what(); \
+		} \
+	} while (0)
 
 std::string prepare(std::string_view string, location loc) {
-    using namespace libassert::detail;
-    auto lines = split(mtrim(string), "\n");
-    for(auto& line : lines) {
-        auto pos = line.find('|');
-        line = line.substr(pos == std::string_view::npos ? 0 : pos + 1);
-    }
-    auto message = replace(
-        join(lines, "\n"),
-        "<LOCATION>",
-        libassert::microfmt::format("{}:{}: {}", loc.file, loc.line, loc.signature)
-    );
-    return message;
+	using namespace libassert::detail;
+	auto lines = split(mtrim(string), "\n");
+	for (auto& line : lines) {
+		auto pos = line.find('|');
+		line = line.substr(pos == std::string_view::npos ? 0 : pos + 1);
+	}
+	auto message = replace(
+		join(lines, "\n"),
+		"<LOCATION>",
+		libassert::microfmt::format("{}:{}: {}", loc.file, loc.line, loc.signature)
+	);
+	return message;
 }
 
 std::string normalize(std::string message) {
-    using namespace libassert::detail;
-    // TODO: Find a better way to do this, or integrate into normal type normalization rules
-    // msvc does T const
-    replace_all(message, "char const", "const char");
-    // clang does T *
-    replace_all(message, "void *", "void*");
-    replace_all(message, "char *", "char*");
-    // clang does T[N], gcc does T [N]
-    replace_all(message, "int [5]", "int[5]");
-    // msvc includes the std::less
-    replace_all(message, ", std::less<int>", "");
-    replace_all(message, ", std::less<std::string>", "");
-    return message;
+	using namespace libassert::detail;
+	// TODO: Find a better way to do this, or integrate into normal type normalization rules
+	// msvc does T const
+	replace_all(message, "char const", "const char");
+	// clang does T *
+	replace_all(message, "void *", "void*");
+	replace_all(message, "char *", "char*");
+	// clang does T[N], gcc does T [N]
+	replace_all(message, "int [5]", "int[5]");
+	// msvc includes the std::less
+	replace_all(message, ", std::less<int>", "");
+	replace_all(message, ", std::less<std::string>", "");
+	return message;
 }
 
 #define CHECK(call, expected) \
-    do { \
-        /* using __builtin_LINE() as source_location to work around */ \
-        /* https://developercommunity.visualstudio.com/t/__builtin_LINE-function-is-reporting-w/10439054 */ \
-        /* and also there seems to be some weirdness with __LINE__ vs __builtin_LINE() on msvc */ \
-        location loc = {file, __builtin_LINE(), LIBASSERT_PFUNC}; \
-        WRAP(call); \
-        EXPECT_EQ( \
-            prepare((expected), loc), \
-            normalize(assertion_failure_message) \
-        ); \
-    } while(0)
+	do { \
+		/* using __builtin_LINE() as source_location to work around */ \
+		/* https://developercommunity.visualstudio.com/t/__builtin_LINE-function-is-reporting-w/10439054 */ \
+		/* and also there seems to be some weirdness with __LINE__ vs __builtin_LINE() on msvc */ \
+		location loc = {file, __builtin_LINE(), LIBASSERT_PFUNC}; \
+		WRAP(call); \
+		EXPECT_EQ(prepare((expected), loc), normalize(assertion_failure_message)); \
+	} while (0)
 
-#define SHOULD_PASS(statement) try { statement; SUCCEED(); } catch(const std::exception& e) { FAIL() << e.what(); }
+#define SHOULD_PASS(statement) \
+	try { \
+		statement; \
+		SUCCEED(); \
+	} catch (const std::exception& e) { \
+		FAIL() << e.what(); \
+	}
 
 // TEST(LibassertBasic, Warmup) {
 //     try {
@@ -131,20 +134,20 @@ std::string normalize(std::string message) {
 // }
 
 TEST(LibassertBasic, StringDiagnostics) {
-    std::string s = "test\n";
-    CHECK(
-        ASSERT(s == "test"),
-        R"XX(
+	std::string s = "test\n";
+	CHECK(
+		ASSERT(s == "test"),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(s == "test");
         |    Where:
         |        s => "test\n"
         )XX"
-    );
-    int i = 0;
-    CHECK(
-        ASSERT(s[i] == 'c', "", s, i),
-        R"XX(
+	);
+	int i = 0;
+	CHECK(
+		ASSERT(s[i] == 'c', "", s, i),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(s[i] == 'c', ...);
         |    Where:
@@ -153,390 +156,395 @@ TEST(LibassertBasic, StringDiagnostics) {
         |        s => "test\n"
         |        i => 0
         )XX"
-    );
-    char* buffer = nullptr;
-    char thing[] = "foo";
-    CHECK(
-        ASSERT(buffer == thing),
-        R"XX(
+	);
+	char* buffer = nullptr;
+	char thing[] = "foo";
+	CHECK(
+		ASSERT(buffer == thing),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(buffer == thing);
         |    Where:
         |        buffer => nullptr
         |        thing  => "foo"
         )XX"
-    );
-    CHECK(
-        ASSERT(buffer == +thing),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(buffer == +thing),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(buffer == +thing);
         |    Where:
         |        buffer => nullptr
         |        +thing => "foo"
         )XX"
-    );
-    std::string_view sv = "foo";
-    CHECK(
-        ASSERT(s == sv),
-        R"XX(
+	);
+	std::string_view sv = "foo";
+	CHECK(
+		ASSERT(s == sv),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(s == sv);
         |    Where:
         |        s  => "test\n"
         |        sv => "foo"
         )XX"
-    );
+	);
 }
 
 TEST(LibassertBasic, PointerDiagnostics) {
-    // TODO: Move
-    CHECK(
-        ASSERT((uintptr_t)-1 == 0xff),
-        R"XX(
+	// TODO: Move
+	CHECK(
+		ASSERT((uintptr_t)-1 == 0xff),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT((uintptr_t)-1 == 0xff);
         |    Where:
         |        (uintptr_t)-1 => 18446744073709551615 0xffffffffffffffff
         |        0xff          => 255 0xff
         )XX"
-    );
-    // TODO: Move
-    CHECK(
-        ASSERT((uintptr_t)-1 == (uintptr_t)0xff),
-        R"XX(
+	);
+	// TODO: Move
+	CHECK(
+		ASSERT((uintptr_t)-1 == (uintptr_t)0xff),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT((uintptr_t)-1 == (uintptr_t)0xff);
         |    Where:
         |        (uintptr_t)-1   => 18446744073709551615
         |        (uintptr_t)0xff => 255
         )XX"
-    );
-    void* foo = (void*)0xdeadbeefULL;
-    CHECK(
-        ASSERT(foo == nullptr),
-        R"XX(
+	);
+	void* foo = (void*)0xdeadbeefULL;
+	CHECK(
+		ASSERT(foo == nullptr),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(foo == nullptr);
         |    Where:
         |        foo => void*: 0xdeadbeef
         )XX"
-    );
+	);
 }
 
 TEST(LibassertBasic, LiteralFormatting) {
-    const uint16_t flags = 0b000101010;
-    const uint16_t mask = 0b110010101;
-    CHECK(
-        ASSERT(mask bitand flags),
-        R"XX(
+	const uint16_t flags = 0b000101010;
+	const uint16_t mask = 0b110010101;
+	CHECK(
+		ASSERT(mask bitand flags),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(mask bitand flags);
         |    Where:
         |        mask  => 405 0b0000000110010101
         |        flags => 42 0b0000000000101010
         )XX"
-    );
-    CHECK(
-        ASSERT(0xf == 16),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(0xf == 16),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(0xf == 16);
         |    Where:
         |        0xf => 15 0xf
         |        16  => 16 0x10
         )XX"
-    );
-    CHECK(
-        ASSERT(0xff == 077),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(0xff == 077),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(0xff == 077);
         |    Where:
         |        0xff => 255 0xff 0377
         |        077  => 63 0x3f 077
         )XX"
-    );
-    CHECK(
-        ASSERT('x' == 20),
-        R"XX(
+	);
+	CHECK(
+		ASSERT('x' == 20),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT('x' == 20);
         |    Where:
         |        'x' => 'x' 120
         |        20  => '\x14' 20
         )XX"
-    );
-    CHECK(
-        ASSERT('x' == 'y'),
-        R"XX(
+	);
+	CHECK(
+		ASSERT('x' == 'y'),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT('x' == 'y');
         )XX"
-    );
-    char c = 'x';
-    CHECK(
-        ASSERT(c == 20),
-        R"XX(
+	);
+	char c = 'x';
+	CHECK(
+		ASSERT(c == 20),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(c == 20);
         |    Where:
         |        c  => 'x' 120
         |        20 => '\x14' 20
         )XX"
-    );
+	);
 }
 
 TEST(LibassertBasic, FloatingPoint) {
-    CHECK(
-        ASSERT(1 == 1.5),
-        R"XX(
+	CHECK(
+		ASSERT(1 == 1.5),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(1 == 1.5);
         )XX"
-    );
-    // FIXME
-    CHECK(
-        ASSERT(0.5 != .5),
-        R"XX(
+	);
+	// FIXME
+	CHECK(
+		ASSERT(0.5 != .5),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(0.5 != .5);
         |    Where:
         |        .5 => 0.5
         )XX"
-    );
-    CHECK(
-        ASSERT(0.1 + 0.2 == 0.3),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(0.1 + 0.2 == 0.3),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(0.1 + 0.2 == 0.3);
         |    Where:
         |        0.1 + 0.2 => 0.30000000000000004
         |        0.3       => 0.29999999999999999
         )XX"
-    );
-    CHECK(
-        ASSERT(.1 + .2 == .3),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(.1 + .2 == .3),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(.1 + .2 == .3);
         |    Where:
         |        .1 + .2 => 0.30000000000000004
         |        .3      => 0.29999999999999999
         )XX"
-    );
-    float ff = .1f;
-    CHECK(
-        ASSERT(ff == .1),
-        R"XX(
+	);
+	float ff = .1f;
+	CHECK(
+		ASSERT(ff == .1),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(ff == .1);
         |    Where:
         |        ff => 0.100000001
         |        .1 => 0.10000000000000001
         )XX"
-    );
-    CHECK(
-        ASSERT(.1f == .1),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(.1f == .1),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(.1f == .1);
         |    Where:
         |        .1f => 0.100000001
         |        .1  => 0.10000000000000001
         )XX"
-    );
-    SHOULD_PASS(ASSERT(0.1f + 0.2f == 0.3f));
+	);
+	SHOULD_PASS(ASSERT(0.1f + 0.2f == 0.3f));
 }
 
 template<typename T>
 struct printable {
-    std::optional<T> f;
-    printable(T t) : f(t) {}
-    bool operator==(const printable& other) const {
-        return f == other.f;
-    }
+	std::optional<T> f;
+
+	printable(T t) : f(t) {}
+
+	bool operator==(const printable& other) const {
+		return f == other.f;
+	}
 };
 
 template<typename T>
 std::ostream& operator<<(std::ostream& stream, const printable<T>& p) {
-    return stream<<"(printable = "<<*p.f<<")";
+	return stream << "(printable = " << *p.f << ")";
 }
 
 TEST(LibassertBasic, OstreamOverloads) {
-    printable p{1.42};
-    CHECK(
-        ASSERT(p == printable{2.55}),
-        R"XX(
+	printable p {1.42};
+	CHECK(
+		ASSERT(p == printable {2.55}),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(p == printable{2.55});
         |    Where:
         |        p               => (printable = 1.42)
         |        printable{2.55} => (printable = 2.55)
         )XX"
-    );
+	);
 }
 
 template<typename T>
 struct not_printable {
-    std::optional<T> f;
-    not_printable(T t) : f(t) {}
-    bool operator==(const not_printable& other) const {
-        return f == other.f;
-    }
+	std::optional<T> f;
+
+	not_printable(T t) : f(t) {}
+
+	bool operator==(const not_printable& other) const {
+		return f == other.f;
+	}
 };
 
 TEST(LibassertBasic, NotPrintable) {
-    const not_printable p{1.42};
-    CHECK(
-        ASSERT(p == not_printable{2.55}),
-        R"XX(
+	const not_printable p {1.42};
+	CHECK(
+		ASSERT(p == not_printable {2.55}),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(p == not_printable{2.55});
         |    Where:
         |        p                   => <instance of not_printable<double>>
         |        not_printable{2.55} => <instance of not_printable<double>>
         )XX"
-    );
-    CHECK(
-        ASSERT(p.f == not_printable{2.55}.f),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(p.f == not_printable {2.55}.f),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(p.f == not_printable{2.55}.f);
         |    Where:
         |        p.f                   => std::optional<double>: 1.4199999999999999
         |        not_printable{2.55}.f => std::optional<double>: 2.5499999999999998
         )XX"
-    );
+	);
 }
 
 TEST(LibassertBasic, OptionalMessages) {
-    CHECK(
-        ASSERT(false, 2),
-        R"XX(
+	CHECK(
+		ASSERT(false, 2),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(false, ...);
         |    Extra diagnostics:
         |        2 => 2
         )XX"
-    );
-    CHECK(
-        ASSERT(false, "foo"),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(false, "foo"),
+		R"XX(
         |Assertion failed at <LOCATION>: foo
         |    ASSERT(false, ...);
         )XX"
-    );
-    CHECK(
-        ASSERT(false, "foo"s),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(false, "foo"s),
+		R"XX(
         |Assertion failed at <LOCATION>: foo
         |    ASSERT(false, ...);
         )XX"
-    );
-    CHECK(
-        ASSERT(false, "foo"sv),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(false, "foo"sv),
+		R"XX(
         |Assertion failed at <LOCATION>: foo
         |    ASSERT(false, ...);
         )XX"
-    );
-    CHECK(
-        ASSERT(false, (char*)"foo"),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(false, (char*)"foo"),
+		R"XX(
         |Assertion failed at <LOCATION>: foo
         |    ASSERT(false, ...);
         )XX"
-    );
-    CHECK(
-        ASSERT(false, "foo", 2),
-        R"XX(
-        |Assertion failed at <LOCATION>: foo
-        |    ASSERT(false, ...);
-        |    Extra diagnostics:
-        |        2 => 2
-        )XX"
-    );
-    CHECK(
-        ASSERT(false, "foo"s, 2),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(false, "foo", 2),
+		R"XX(
         |Assertion failed at <LOCATION>: foo
         |    ASSERT(false, ...);
         |    Extra diagnostics:
         |        2 => 2
         )XX"
-    );
-    CHECK(
-        ASSERT(false, "foo"sv, 2),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(false, "foo"s, 2),
+		R"XX(
         |Assertion failed at <LOCATION>: foo
         |    ASSERT(false, ...);
         |    Extra diagnostics:
         |        2 => 2
         )XX"
-    );
-    CHECK(
-        ASSERT(false, (char*)"foo", 2),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(false, "foo"sv, 2),
+		R"XX(
         |Assertion failed at <LOCATION>: foo
         |    ASSERT(false, ...);
         |    Extra diagnostics:
         |        2 => 2
         )XX"
-    );
-    CHECK(
-        ASSERT(false, nullptr),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(false, (char*)"foo", 2),
+		R"XX(
+        |Assertion failed at <LOCATION>: foo
+        |    ASSERT(false, ...);
+        |    Extra diagnostics:
+        |        2 => 2
+        )XX"
+	);
+	CHECK(
+		ASSERT(false, nullptr),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(false, ...);
         |    Extra diagnostics:
         |        nullptr => nullptr
         )XX"
-    );
-    // TODO: This behavior should probably change
-    CHECK(
-        ASSERT(false, (char*)nullptr),
-        R"XX(
+	);
+	// TODO: This behavior should probably change
+	CHECK(
+		ASSERT(false, (char*)nullptr),
+		R"XX(
         |Assertion failed at <LOCATION>: (nullptr)
         |    ASSERT(false, ...);
         )XX"
-    );
+	);
 }
 
 TEST(LibassertBasic, Errno) {
-    errno = 2;
-    CHECK(
-        ASSERT(false, errno),
-        R"XX(
+	errno = 2;
+	CHECK(
+		ASSERT(false, errno),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(false, ...);
         |    Extra diagnostics:
         |        errno =>  2 "No such file or directory"
         )XX"
-    );
-    errno = 2;
-    CHECK(
-        ASSERT(false, "foo", errno),
-        R"XX(
+	);
+	errno = 2;
+	CHECK(
+		ASSERT(false, "foo", errno),
+		R"XX(
         |Assertion failed at <LOCATION>: foo
         |    ASSERT(false, ...);
         |    Extra diagnostics:
         |        errno =>  2 "No such file or directory"
         )XX"
-    );
+	);
 }
 
 int foo() {
-    return 2;
+	return 2;
 }
+
 int bar() {
-    return -2;
+	return -2;
 }
 
 TEST(LibassertBasic, General) {
-    CHECK(
-        ASSERT(false, "foo", false, 2 * foo(), "foobar"sv, bar(), printable{2.55}),
-        R"XX(
+	CHECK(
+		ASSERT(false, "foo", false, 2 * foo(), "foobar"sv, bar(), printable {2.55}),
+		R"XX(
         |Assertion failed at <LOCATION>: foo
         |    ASSERT(false, ...);
         |    Extra diagnostics:
@@ -546,145 +554,145 @@ TEST(LibassertBasic, General) {
         |        bar()           => -2
         |        printable{2.55} => (printable = 2.55)
         )XX"
-    );
-    CHECK(
-        ASSERT([] { return false; } ()),
-        R"XX(
+	);
+	CHECK(
+		ASSERT([] { return false; }()),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT([] { return false; } ());
         )XX"
-    );
+	);
 }
 
 TEST(LibassertBasic, SignedUnsignedComparisonWithoutSafeCompareMode) {
-    SHOULD_PASS(ASSERT(18446744073709551606ULL == -10));
-    SHOULD_PASS(ASSERT(-1 > 1U));
+	SHOULD_PASS(ASSERT(18446744073709551606ULL == -10));
+	SHOULD_PASS(ASSERT(-1 > 1U));
 }
 
 TEST(LibassertBasic, ExpressionDecomposition) {
-    CHECK(
-        ASSERT(1 == (1 bitand 2)),
-        R"XX(
+	CHECK(
+		ASSERT(1 == (1 bitand 2)),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(1 == (1 bitand 2));
         |    Where:
         |        (1 bitand 2) => 0
         )XX"
-    );
-    CHECK(
-        ASSERT(1 < 1 < 0),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(1 < 1 < 0),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(1 < 1 < 0);
         |    Where:
         |        1 < 1 => false
         )XX"
-    );
-    CHECK(
-        ASSERT(0 + 0 + 0),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(0 + 0 + 0),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(0 + 0 + 0);
         |    Where:
         |        0 + 0 + 0 => 0
         )XX"
-    );
-    CHECK(
-        ASSERT(false == false == false),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(false == false == false),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(false == false == false);
         |    Where:
         |        false == false => true
         )XX"
-    );
-    CHECK(
-        ASSERT(1 << 1 == 200),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(1 << 1 == 200),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(1 << 1 == 200);
         |    Where:
         |        1 << 1 => 2
         )XX"
-    );
-    CHECK(
-        ASSERT(1 << 1 << 31),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(1 << 1 << 31),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(1 << 1 << 31);
         |    Where:
         |        1 << 1 => 2
         )XX"
-    );
-    int x = 2;
-    CHECK(
-        ASSERT(x -= 2),
-        R"XX(
+	);
+	int x = 2;
+	CHECK(
+		ASSERT(x -= 2),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(x -= 2);
         |    Where:
         |        x => 0
         )XX"
-    );
-    x = 2;
-    CHECK(
-        ASSERT(x -= x -= 1),
-        R"XX(
+	);
+	x = 2;
+	CHECK(
+		ASSERT(x -= x -= 1),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(x -= x -= 1);
         |    Where:
         |        x      => 0
         |        x -= 1 => 0
         )XX"
-    );
-    x = 2;
-    CHECK(
-        ASSERT(x -= x -= x -= 1),
-        R"XX(
+	);
+	x = 2;
+	CHECK(
+		ASSERT(x -= x -= x -= 1),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(x -= x -= x -= 1);
         |    Where:
         |        x           => 0
         |        x -= x -= 1 => 0
         )XX"
-    );
-    CHECK(
-        ASSERT(true ? false : true, "pffft"),
-        R"XX(
+	);
+	CHECK(
+		ASSERT(true ? false : true, "pffft"),
+		R"XX(
         |Assertion failed at <LOCATION>: pffft
         |    ASSERT(true ? false : true, ...);
         )XX"
-    );
-    // regression test for #26
-    int a = 1;
-    CHECK(
-        ASSERT(a >> 1),
-        R"XX(
+	);
+	// regression test for #26
+	int a = 1;
+	CHECK(
+		ASSERT(a >> 1),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(a >> 1);
         |    Where:
         |        a => 1
         )XX"
-    );
+	);
 }
 
 TEST(LibassertBasic, ValueComputation) {
-    // Ensure value names are only computed once
-    auto foo = [] {
-        static int x = 2;
-        return x++;
-    };
-    auto bar = [] {
-        static int x = -2;
-        return x--;
-    };
-    auto baz = [] {
-        static int x = 10;
-        return x++;
-    };
-    CHECK(
-        ASSERT(foo() < bar(), baz()),
-        R"XX(
+	// Ensure value names are only computed once
+	auto foo = [] {
+		static int x = 2;
+		return x++;
+	};
+	auto bar = [] {
+		static int x = -2;
+		return x--;
+	};
+	auto baz = [] {
+		static int x = 10;
+		return x++;
+	};
+	CHECK(
+		ASSERT(foo() < bar(), baz()),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(foo() < bar(), ...);
         |    Where:
@@ -693,90 +701,92 @@ TEST(LibassertBasic, ValueComputation) {
         |    Extra diagnostics:
         |        baz() => 10
         )XX"
-    );
-    EXPECT_EQ(foo(), 3);
-    EXPECT_EQ(bar(), -3);
-    EXPECT_EQ(baz(), 11);
+	);
+	EXPECT_EQ(foo(), 3);
+	EXPECT_EQ(bar(), -3);
+	EXPECT_EQ(baz(), 11);
 }
 
 TEST(LibassertBasic, LvalueForwarding) {
-    int x = 1;
-    CHECK(
-        ASSERT(x ^= 1),
-        R"XX(
+	int x = 1;
+	CHECK(
+		ASSERT(x ^= 1),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(x ^= 1);
         |    Where:
         |        x => 0 0b00000000000000000000000000000000
         |        1 => 1 0b00000000000000000000000000000001
         )XX"
-    );
-    EXPECT_EQ(x, 0);
+	);
+	EXPECT_EQ(x, 0);
 }
 
 #if defined(LIBASSERT_USE_MAGIC_ENUM) || defined(LIBASSERT_USE_ENCHANTUM)
 enum foo_e { A, B };
 enum class bar_e { A, B };
+
 TEST(LibassertBasic, EnumHandling) {
-    foo_e a = A;
-    CHECK(
-        ASSERT(a != A),
-        R"XX(
+	foo_e a = A;
+	CHECK(
+		ASSERT(a != A),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(a != A);
         |    Where:
         |        a => A
         )XX"
-    );
-    bar_e b = bar_e::A;
-    CHECK(
-        ASSERT(b != bar_e::A),
-        R"XX(
+	);
+	bar_e b = bar_e::A;
+	CHECK(
+		ASSERT(b != bar_e::A),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(b != bar_e::A);
         |    Where:
         |        b        => A
         |        bar_e::A => A
         )XX"
-    );
+	);
 }
 #else
 // TODO: Also test this outside of gcc 8
 enum foo_e { A, B };
 enum class bar_e { A, B };
+
 TEST(LibassertBasic, EnumHandling) {
-    foo_e a = A;
-    CHECK(
-        ASSERT(a != A),
-        R"XX(
+	foo_e a = A;
+	CHECK(
+		ASSERT(a != A),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(a != A);
         |    Where:
         |        a => enum foo_e: 0
         |        A => enum foo_e: 0
         )XX"
-    );
-    bar_e b = bar_e::A;
-    CHECK(
-        ASSERT(b != bar_e::A),
-        R"XX(
+	);
+	bar_e b = bar_e::A;
+	CHECK(
+		ASSERT(b != bar_e::A),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(b != bar_e::A);
         |    Where:
         |        b        => enum bar_e: 0
         |        bar_e::A => enum bar_e: 0
         )XX"
-    );
+	);
 }
 #endif
 
 TEST(LibassertBasic, Containers) {
-    std::set<int> a = { 2, 2, 4, 6, 10 };
-    std::set<int> b = { 2, 2, 5, 6, 10 };
-    std::vector<double> c = { 1.2f, 2.44f, 3.15159f, 5.2f };
-    CHECK(
-        ASSERT(a == b, c),
-        R"XX(
+	std::set<int> a = {2, 2, 4, 6, 10};
+	std::set<int> b = {2, 2, 5, 6, 10};
+	std::vector<double> c = {1.2f, 2.44f, 3.15159f, 5.2f};
+	CHECK(
+		ASSERT(a == b, c),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(a == b, ...);
         |    Where:
@@ -785,89 +795,90 @@ TEST(LibassertBasic, Containers) {
         |    Extra diagnostics:
         |        c => std::vector<double>: [1.2000000476837158, 2.440000057220459, 3.15159010887146, 5.1999998092651367]
         )XX"
-    );
-    std::map<std::string, int> m0 = {
-        {"foo", 2},
-        {"bar", -2}
-    };
-    CHECK(
-        ASSERT(false, m0),
-        R"XX(
+	);
+	std::map<std::string, int> m0 = {{"foo", 2}, {"bar", -2}};
+	CHECK(
+		ASSERT(false, m0),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(false, ...);
         |    Extra diagnostics:
         |        m0 => std::map<std::string, int>: [["bar", -2], ["foo", 2]]
         )XX"
-    );
-    std::map<std::string, std::vector<int>> m1 = {
-        {"foo", {1, -2, 3, -4}},
-        {"bar", {-100, 200, 400, -800}}
-    };
-    CHECK(
-        ASSERT(false, m1),
-        R"XX(
+	);
+	std::map<std::string, std::vector<int>> m1 = {
+		{"foo", {1, -2, 3, -4}},
+		{"bar", {-100, 200, 400, -800}}
+	};
+	CHECK(
+		ASSERT(false, m1),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(false, ...);
         |    Extra diagnostics:
         |        m1 => std::map<std::string, std::vector<int>>: [["bar", [-100, 200, 400, -800]], ["foo", [1, -2, 3, -4]]]
         )XX"
-    );
-    auto t = std::make_tuple(1, 0.1 + 0.2, "foobars");
-    CHECK(
-        ASSERT(false, t),
-        R"XX(
+	);
+	auto t = std::make_tuple(1, 0.1 + 0.2, "foobars");
+	CHECK(
+		ASSERT(false, t),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(false, ...);
         |    Extra diagnostics:
         |        t => std::tuple<int, double, const char*>: [1, 0.30000000000000004, "foobars"]
         )XX"
-    );
-    std::array<int, 10> arr = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-    CHECK(
-        ASSERT(false, arr),
-        R"XX(
+	);
+	std::array<int, 10> arr = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+	CHECK(
+		ASSERT(false, arr),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(false, ...);
         |    Extra diagnostics:
         |        arr => std::array<int, 10>: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         )XX"
-    );
-    int carr[] = { 5, 4, 3, 2, 1 };
-    CHECK(
-        ASSERT(false, carr),
-        R"XX(
+	);
+	int carr[] = {5, 4, 3, 2, 1};
+	CHECK(
+		ASSERT(false, carr),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(false, ...);
         |    Extra diagnostics:
         |        carr => int[5]: [5, 4, 3, 2, 1]
         )XX"
-    );
+	);
 }
 
 // TEST(LibassertBasic, TypeCleaning) {}
 
 struct debug_print_customization {
-    int x;
-    debug_print_customization(int t) : x(t) {}
-    bool operator==(const debug_print_customization& other) const {
-        return x == other.x;
-    }
-    friend std::ostream& operator<<(std::ostream& stream, const debug_print_customization&) {
-        return stream<<"wrong print";
-    }
+	int x;
+
+	debug_print_customization(int t) : x(t) {}
+
+	bool operator==(const debug_print_customization& other) const {
+		return x == other.x;
+	}
+
+	friend std::ostream& operator<<(std::ostream& stream, const debug_print_customization&) {
+		return stream << "wrong print";
+	}
 };
 
-template<> struct libassert::stringifier<debug_print_customization> {
-    std::string stringify(const debug_print_customization& p) {
-        return "(debug_print_customization = " + std::to_string(p.x) + ")";
-    }
+template<>
+struct libassert::stringifier<debug_print_customization> {
+	std::string stringify(const debug_print_customization& p) {
+		return "(debug_print_customization = " + std::to_string(p.x) + ")";
+	}
 };
 
 TEST(LibassertBasic, StringificationCustomizationPoint) {
-    debug_print_customization x = 2, y = 1;
-    CHECK(
-        ASSERT(x == y, x, y),
-        R"XX(
+	debug_print_customization x = 2, y = 1;
+	CHECK(
+		ASSERT(x == y, x, y),
+		R"XX(
         |Assertion failed at <LOCATION>:
         |    ASSERT(x == y, ...);
         |    Where:
@@ -877,49 +888,49 @@ TEST(LibassertBasic, StringificationCustomizationPoint) {
         |        x => (debug_print_customization = 2)
         |        y => (debug_print_customization = 1)
         )XX"
-    );
+	);
 }
 
 TEST(LibassertBasic, Panic) {
-    const std::vector<std::string> vec{"foo", "bar", "baz"};
-    CHECK(
-        PANIC("message", vec),
-        R"XX(
+	const std::vector<std::string> vec {"foo", "bar", "baz"};
+	CHECK(
+		PANIC("message", vec),
+		R"XX(
         |Panic at <LOCATION>: message
         |    PANIC(...);
         |    Extra diagnostics:
         |        vec => std::vector<std::string>: ["foo", "bar", "baz"]
         )XX"
-    );
-    float x = 40;
-    CHECK(
-        PANIC(x),
-        R"XX(
+	);
+	float x = 40;
+	CHECK(
+		PANIC(x),
+		R"XX(
         |Panic at <LOCATION>:
         |    PANIC(...);
         |    Extra diagnostics:
         |        x => 40.0
         )XX"
-    );
+	);
 }
 
 TEST(LibassertBasic, DebugAssert) {
-    int x = 1;
-    int y = 2;
-    #ifndef NDEBUG
-    CHECK(
-        DEBUG_ASSERT(x == y),
-        R"XX(
+	int x = 1;
+	int y = 2;
+#ifndef NDEBUG
+	CHECK(
+		DEBUG_ASSERT(x == y),
+		R"XX(
         |Debug Assertion failed at <LOCATION>:
         |    DEBUG_ASSERT(x == y);
         |    Where:
         |        x => 1
         |        y => 2
         )XX"
-    );
-    #else
-    SHOULD_PASS(DEBUG_ASSERT(x == y));
-    #endif
+	);
+#else
+	SHOULD_PASS(DEBUG_ASSERT(x == y));
+#endif
 }
 
 // TODO:

--- a/tests/unit/catch2-test.cpp
+++ b/tests/unit/catch2-test.cpp
@@ -1,24 +1,24 @@
 #include <cmath>
 #ifdef TEST_MODULE
-#include <catch2/catch_test_macros.hpp>
+	#include <catch2/catch_test_macros.hpp>
 import libassert;
-#include <libassert/assert-catch2-macros.hpp>
+	#include <libassert/assert-catch2-macros.hpp>
 #else
-#include <libassert/assert-catch2.hpp>
+	#include <libassert/assert-catch2.hpp>
 #endif
 
 TEST_CASE("1 + 1 is 2") {
-    ASSERT(1 + 1 == 2);
+	ASSERT(1 + 1 == 2);
 }
 
 int set(int& x, int y) {
-    auto copy = x;
-    x = y;
-    return copy;
+	auto copy = x;
+	x = y;
+	return copy;
 }
 
 TEST_CASE("set") {
-    int x = 20;
-    ASSERT(set(x, 42) == 20);
-    CHECK(x == 42);
+	int x = 20;
+	ASSERT(set(x, 42) == 20);
+	CHECK(x == 42);
 }

--- a/tests/unit/constexpr_contexts.cpp
+++ b/tests/unit/constexpr_contexts.cpp
@@ -1,17 +1,18 @@
 #ifdef TEST_MODULE
 import libassert;
-#include <libassert/assert-macros.hpp>
+	#include <libassert/assert-macros.hpp>
 #else
-#include <libassert/assert.hpp>
+	#include <libassert/assert.hpp>
 #endif
 
-template<int X> void foo() {}
+template<int X>
+void foo() {}
 
 constexpr int bar(int x) {
-    DEBUG_ASSERT(x % 2 == 0);
-    return x / 2;
+	DEBUG_ASSERT(x % 2 == 0);
+	return x / 2;
 }
 
 int main() {
-    foo<bar(2)>();
+	foo<bar(2)>();
 }

--- a/tests/unit/disambiguation.cpp
+++ b/tests/unit/disambiguation.cpp
@@ -1,15 +1,15 @@
 #include <iostream>
-#include <string_view>
 #include <string>
+#include <string_view>
 #include <tuple>
 
 #include "analysis.hpp"
 
 #ifdef TEST_MODULE
 import libassert;
-#include <libassert/assert-macros.hpp>
+	#include <libassert/assert-macros.hpp>
 #else
-#include <libassert/assert.hpp>
+	#include <libassert/assert.hpp>
 #endif
 
 #define ESC "\033["
@@ -22,34 +22,38 @@ import libassert;
 #define RESET ESC "0m"
 
 int main() {
-    std::tuple<std::string, std::string_view, bool> tests[] = {
-        {"a < 1 == 2 > ( 1 + 3 )", "==", true},
-        {"a < 1 == 2 > - 3 == ( 1 + 3 )", "==", true}, // <- disambiguated despite ambiguity
-        {"( 1 + 3 ) == a < 1 == 2 > - 3", "==", false}, // <- ambiguous
-        {"( 1 + 3 ) == a < 1 == 2 > ()", "==", true},
-        {"( 1 + 3 ) not_eq a < 1 not_eq 2 > ()", "!=", true},
-        {"a<x<x<x<x<x<x<x<x<x<1>>>>>>>>>", "<", true},
-        {"a<x<x<x<x<x<x<x<x<x<x<1>>>>>>>>>>", "<", false}, // <- max depth exceeded
-        {"1 == something<a == b>>2", "==", false}, // <- ambiguous
-        {"1 == something<a == b>>2", "<", false}, // <- should be an error
-        {"1 < something<a < b>>2", "<", false}, // <- ambiguous
-        {"1 < something<a < b>> - 2", "<", false}, // <- ambiguous
-        {"18446744073709551606ULL == -10", "==", true}
-    };
-    bool ok = true;
-    for(auto [expression, target_op, should_disambiguate] : tests) {
-        std::cout<<libassert::detail::highlight(expression, libassert::color_scheme::ansi_rgb)<<" target: "<<target_op<<std::endl;
-        auto [l, r] = libassert::detail::decompose_expression(expression, target_op);
-        std::cout<<"Final:"<<std::endl
-                 <<"left:  "<<libassert::detail::highlight(l, libassert::color_scheme::ansi_rgb)<<std::endl
-                 <<"right: "<<libassert::detail::highlight(r, libassert::color_scheme::ansi_rgb)<<std::endl<<std::endl;
-        bool disambiguated = !(l == "left" && r == "right");
-        if(should_disambiguate == disambiguated) {
-            std::cout<<GREEN "Passed" RESET<<std::endl;
-        } else {
-            std::cout<<RED "Failed" RESET<<std::endl;
-            ok = false;
-        }
-    }
-    return !ok;
+	std::tuple<std::string, std::string_view, bool> tests[] = {
+		{"a < 1 == 2 > ( 1 + 3 )", "==", true},
+		{"a < 1 == 2 > - 3 == ( 1 + 3 )", "==", true}, // <- disambiguated despite ambiguity
+		{"( 1 + 3 ) == a < 1 == 2 > - 3", "==", false}, // <- ambiguous
+		{"( 1 + 3 ) == a < 1 == 2 > ()", "==", true},
+		{"( 1 + 3 ) not_eq a < 1 not_eq 2 > ()", "!=", true},
+		{"a<x<x<x<x<x<x<x<x<x<1>>>>>>>>>", "<", true},
+		{"a<x<x<x<x<x<x<x<x<x<x<1>>>>>>>>>>", "<", false}, // <- max depth exceeded
+		{"1 == something<a == b>>2", "==", false}, // <- ambiguous
+		{"1 == something<a == b>>2", "<", false}, // <- should be an error
+		{"1 < something<a < b>>2", "<", false}, // <- ambiguous
+		{"1 < something<a < b>> - 2", "<", false}, // <- ambiguous
+		{"18446744073709551606ULL == -10", "==", true}
+	};
+	bool ok = true;
+	for (auto [expression, target_op, should_disambiguate] : tests) {
+		std::cout << libassert::detail::highlight(expression, libassert::color_scheme::ansi_rgb)
+							<< " target: " << target_op << std::endl;
+		auto [l, r] = libassert::detail::decompose_expression(expression, target_op);
+		std::cout << "Final:" << std::endl
+							<< "left:  " << libassert::detail::highlight(l, libassert::color_scheme::ansi_rgb)
+							<< std::endl
+							<< "right: " << libassert::detail::highlight(r, libassert::color_scheme::ansi_rgb)
+							<< std::endl
+							<< std::endl;
+		bool disambiguated = !(l == "left" && r == "right");
+		if (should_disambiguate == disambiguated) {
+			std::cout << GREEN "Passed" RESET << std::endl;
+		} else {
+			std::cout << RED "Failed" RESET << std::endl;
+			ok = false;
+		}
+	}
+	return !ok;
 }

--- a/tests/unit/fmt-test.cpp
+++ b/tests/unit/fmt-test.cpp
@@ -1,69 +1,70 @@
+#include <fmt/format.h>
 #include <libassert/assert-gtest.hpp>
 
-#include <fmt/format.h>
-
 struct S {
-    int x;
+	int x;
 };
 
 template<>
 struct fmt::formatter<S> {
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
-        return ctx.begin();
-    }
+	template<typename ParseContext>
+	constexpr auto parse(ParseContext& ctx) {
+		return ctx.begin();
+	}
 
-    template<typename FormatContext>
-    auto format(const S& s, FormatContext& ctx) const {
-        return fmt::format_to(ctx.out(), "s.x={}", s.x);
-    }
+	template<typename FormatContext>
+	auto format(const S& s, FormatContext& ctx) const {
+		return fmt::format_to(ctx.out(), "s.x={}", s.x);
+	}
 };
 
 TEST(LibassertFmt, FmtWorks) {
-    ASSERT(libassert::stringify(S{42}) == "s.x=42");
+	ASSERT(libassert::stringify(S {42}) == "s.x=42");
 }
 
 struct S2 {
-    int x;
+	int x;
 };
 
 template<>
 struct fmt::formatter<S2> {
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
-        return ctx.begin();
-    }
+	template<typename ParseContext>
+	constexpr auto parse(ParseContext& ctx) {
+		return ctx.begin();
+	}
 
-    template<typename FormatContext>
-    auto format(const S2& s, FormatContext& ctx) const {
-        return fmt::format_to(ctx.out(), "s2.x={}", s.x);
-    }
+	template<typename FormatContext>
+	auto format(const S2& s, FormatContext& ctx) const {
+		return fmt::format_to(ctx.out(), "s2.x={}", s.x);
+	}
 };
 
-template<> struct libassert::stringifier<S2> {
-    std::string stringify(const S2& s) {
-        return fmt::format("{}", s) + "--";
-    }
+template<>
+struct libassert::stringifier<S2> {
+	std::string stringify(const S2& s) {
+		return fmt::format("{}", s) + "--";
+	}
 };
 
 TEST(LibassertFmt, FmtPriority) {
-    ASSERT(libassert::stringify(S2{42}) == "s2.x=42--");
+	ASSERT(libassert::stringify(S2 {42}) == "s2.x=42--");
 }
 
 struct fmtable {
-    int x;
+	int x;
 };
 
-template <> struct fmt::formatter<fmtable>: formatter<string_view> {
-    auto format(const fmtable& f, format_context& ctx) const {
-        return fmt::format_to(ctx.out(), "{{{}}}", f.x);
-    }
+template<>
+struct fmt::formatter<fmtable>: formatter<string_view> {
+	auto format(const fmtable& f, format_context& ctx) const {
+		return fmt::format_to(ctx.out(), "{{{}}}", f.x);
+	}
 };
 
 TEST(LibassertFmt, FmtContainers) {
-    fmtable f{2};
-    ASSERT(libassert::detail::generate_stringification(f) == "{2}");
+	fmtable f {2};
+	ASSERT(libassert::detail::generate_stringification(f) == "{2}");
 
-    std::vector<fmtable> fvec{{{2}, {3}}};
-    ASSERT(libassert::detail::generate_stringification(fvec) == "std::vector<fmtable>: [{2}, {3}]");
+	std::vector<fmtable> fvec {{{2}, {3}}};
+	ASSERT(libassert::detail::generate_stringification(fvec) == "std::vector<fmtable>: [{2}, {3}]");
 }

--- a/tests/unit/lexer.cpp
+++ b/tests/unit/lexer.cpp
@@ -1,334 +1,330 @@
 #ifdef TEST_MODULE
-#include <gtest/gtest.h>
+	#include <gtest/gtest.h>
 
 import libassert;
-#include <libassert/assert-gtest-macros.hpp>
+	#include <libassert/assert-gtest-macros.hpp>
 #else
-#include <libassert/assert-gtest.hpp>
+	#include <libassert/assert-gtest.hpp>
 #endif
 
 #include "tokenizer.hpp"
 
 using namespace libassert::detail;
 
-template<> struct libassert::stringifier<token_t> {
-    std::string stringify(const token_t& token) {
-        return libassert::stringify(token.type) + " \"" + std::string(token.str) + "\"";
-    }
+template<>
+struct libassert::stringifier<token_t> {
+	std::string stringify(const token_t& token) {
+		return libassert::stringify(token.type) + " \"" + std::string(token.str) + "\"";
+	}
 };
 
 template<typename T>
-void check_vector(const std::optional<std::vector<T>>& output_opt, const std::optional<std::vector<T>>& expected_opt) {
-    if(output_opt.has_value() && expected_opt.has_value()) {
-        const auto& [output, expected] = std::make_pair(*output_opt, *expected_opt);
-        for(std::size_t i = 0; i < std::max(output.size(), expected.size()); i++) {
-            if(i >= output.size()) {
-                ASSERT(false, "expected item not in vector", expected[i], i, expected, output);
-            } else if(i >= expected.size()) {
-                ASSERT(false, "unexpected item in vector", output[i], i, expected, output);
-            } else {
-                ASSERT(output[i] == expected[i], i, expected, output);
-            }
-        }
-    } else {
-        ASSERT(output_opt.has_value() == expected_opt.has_value(), output_opt, expected_opt);
-    }
+void check_vector(
+	const std::optional<std::vector<T>>& output_opt,
+	const std::optional<std::vector<T>>& expected_opt
+) {
+	if (output_opt.has_value() && expected_opt.has_value()) {
+		const auto& [output, expected] = std::make_pair(*output_opt, *expected_opt);
+		for (std::size_t i = 0; i < std::max(output.size(), expected.size()); i++) {
+			if (i >= output.size()) {
+				ASSERT(false, "expected item not in vector", expected[i], i, expected, output);
+			} else if (i >= expected.size()) {
+				ASSERT(false, "unexpected item in vector", output[i], i, expected, output);
+			} else {
+				ASSERT(output[i] == expected[i], i, expected, output);
+			}
+		}
+	} else {
+		ASSERT(output_opt.has_value() == expected_opt.has_value(), output_opt, expected_opt);
+	}
 }
 
 template<typename T>
 void check_vector(const std::optional<std::vector<T>>& output, const std::vector<T>& expected) {
-    check_vector(output, std::optional{expected});
+	check_vector(output, std::optional {expected});
 }
 
 template<typename T>
 void check_vector(const std::optional<std::vector<T>>& output, std::nullopt_t expected) {
-    check_vector<T>(output, std::optional<std::vector<T>>{});
+	check_vector<T>(output, std::optional<std::vector<T>> {});
 }
 
 TEST(LexerTests, Operators) {
-    std::array punctuators = to_array<std::string_view>({
-        "{",        "}",        "[",        "]",        "(",        ")",
-        "<:",       ":>",       "<%",       "%>",       ";",        ":",        "...",
-        "?",        "::",       ".",        ".*",       "->",       "->*",      "~",
-        "!",        "+",        "-",        "*",        "/",        "%",        "^",        "&",        "|",
-        "=",        "+=",       "-=",       "*=",       "/=",       "%=",       "^=",       "&=",       "|=",
-        "==",       "!=",       "<",        ">",        "<=",       ">=",       "<=>",      "&&",       "||",
-        "<<",       ">>",       "<<=",      ">>=",      "++",       "--",       ",",
-        "and",      "or",       "xor",      "not",      "bitand",   "bitor",    "compl",
-        "and_eq",   "or_eq",    "xor_eq",   "not_eq",
-    });
-    std::string str = join(punctuators, " ");
-    auto vec = tokenize(str);
-    std::vector<token_t> expected;
-    for(auto& punctuator : punctuators) {
-        expected.push_back(token_t(token_e::punctuation, punctuator));
-        if(&punctuator - &*punctuators.begin() != punctuators.size() - 1) {
-            expected.push_back(token_t(token_e::whitespace, " "));
-        }
-    }
-    check_vector(vec, expected);
+	std::array punctuators = to_array<std::string_view>({
+		"{",   "}",   "[",   "]",      "(",     ")",     "<:",     ":>",    "<%",     "%>",     ";",
+		":",   "...", "?",   "::",     ".",     ".*",    "->",     "->*",   "~",      "!",      "+",
+		"-",   "*",   "/",   "%",      "^",     "&",     "|",      "=",     "+=",     "-=",     "*=",
+		"/=",  "%=",  "^=",  "&=",     "|=",    "==",    "!=",     "<",     ">",      "<=",     ">=",
+		"<=>", "&&",  "||",  "<<",     ">>",    "<<=",   ">>=",    "++",    "--",     ",",      "and",
+		"or",  "xor", "not", "bitand", "bitor", "compl", "and_eq", "or_eq", "xor_eq", "not_eq",
+	});
+	std::string str = join(punctuators, " ");
+	auto vec = tokenize(str);
+	std::vector<token_t> expected;
+	for (auto& punctuator : punctuators) {
+		expected.push_back(token_t(token_e::punctuation, punctuator));
+		if (&punctuator - &*punctuators.begin() != punctuators.size() - 1) {
+			expected.push_back(token_t(token_e::whitespace, " "));
+		}
+	}
+	check_vector(vec, expected);
 }
 
 TEST(LexerTests, OperatorsNoSpaces) {
-    std::array punctuators = to_array<std::string_view>({
-        "{",        "}",        "[",        "]",        "(",        ")",
-        "<:",       ":>",       "<%",       "%>",       ";",        ":",        "...",
-        "?",        "::",       ".",        ".*",       "->",       "->*",      "~",
-        "!",        "+",        "-",        "*",        "/",        "%",        "^",        "&",        "|",
-        "~", // to prevent |=
-        "=",        "+=",       "-=",       "*=",       "/=",       "%=",       "^=",       "&=",       "|=",
-        "==",       "!=",       "<",        ">",        "<=", "~",  ">=",       "<=>",      "&&",       "||",
-        "<<",       ">>",       "<<=",      ">>=",      "++",       "--",       ","
-    });
-    std::string str = join(punctuators, "");
-    auto vec = tokenize(str);
-    std::vector<token_t> expected;
-    for(auto& punctuator : punctuators) {
-        expected.push_back(token_t(token_e::punctuation, punctuator));
-    }
-    check_vector(vec, expected);
+	std::array punctuators = to_array<std::string_view>(
+		{"{",  "}",   "[",  "]",   "(",  ")",  "<:",  ":>",  "<%", "%>", ";",  ":", "...", "?",  "::",
+		 ".",  ".*",  "->", "->*", "~",  "!",  "+",   "-",   "*",  "/",  "%",  "^", "&",   "|",
+		 "~", // to prevent |=
+		 "=",  "+=",  "-=", "*=",  "/=", "%=", "^=",  "&=",  "|=", "==", "!=", "<", ">",   "<=", "~",
+		 ">=", "<=>", "&&", "||",  "<<", ">>", "<<=", ">>=", "++", "--", ","}
+	);
+	std::string str = join(punctuators, "");
+	auto vec = tokenize(str);
+	std::vector<token_t> expected;
+	for (auto& punctuator : punctuators) {
+		expected.push_back(token_t(token_e::punctuation, punctuator));
+	}
+	check_vector(vec, expected);
 }
 
 TEST(LexerTests, AlternativeOperators) {
-    std::array punctuators = to_array<std::string_view>({
-        "and",      "or",       "xor",      "not",      "bitand",   "bitor",    "compl",
-        "and_eq",   "or_eq",    "xor_eq",   "not_eq",
-    });
-    auto id = join(punctuators, "");
-    std::string str = id + " and<";
-    auto vec = tokenize(str);
-    std::vector<token_t> expected = {
-        token_t(token_e::identifier, id),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::punctuation, "and"),
-        token_t(token_e::punctuation, "<"),
-    };
-    check_vector(vec, expected);
+	std::array punctuators = to_array<std::string_view>({
+		"and",
+		"or",
+		"xor",
+		"not",
+		"bitand",
+		"bitor",
+		"compl",
+		"and_eq",
+		"or_eq",
+		"xor_eq",
+		"not_eq",
+	});
+	auto id = join(punctuators, "");
+	std::string str = id + " and<";
+	auto vec = tokenize(str);
+	std::vector<token_t> expected = {
+		token_t(token_e::identifier, id),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::punctuation, "and"),
+		token_t(token_e::punctuation, "<"),
+	};
+	check_vector(vec, expected);
 }
 
 TEST(LexerTests, AlternativeTokenEdgeCase) {
-    std::string str = "<:<::std>:>";
-    auto vec = tokenize(str);
-    std::vector<token_t> expected = {
-        token_t(token_e::punctuation, "<:"),
-        token_t(token_e::punctuation, "<"),
-        token_t(token_e::punctuation, "::"),
-        token_t(token_e::identifier, "std"),
-        token_t(token_e::punctuation, ">"),
-        token_t(token_e::punctuation, ":>"),
-    };
-    check_vector(vec, expected);
+	std::string str = "<:<::std>:>";
+	auto vec = tokenize(str);
+	std::vector<token_t> expected = {
+		token_t(token_e::punctuation, "<:"),
+		token_t(token_e::punctuation, "<"),
+		token_t(token_e::punctuation, "::"),
+		token_t(token_e::identifier, "std"),
+		token_t(token_e::punctuation, ">"),
+		token_t(token_e::punctuation, ":>"),
+	};
+	check_vector(vec, expected);
 }
 
 TEST(LexerTests, ShrDecomposition) {
-    std::string str = "1 >> 2";
-    auto vec = tokenize(str, true);
-    std::vector<token_t> expected = {
-        token_t(token_e::number, "1"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::punctuation, ">"),
-        token_t(token_e::punctuation, ">"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::number, "2")
-    };
-    check_vector(vec, expected);
+	std::string str = "1 >> 2";
+	auto vec = tokenize(str, true);
+	std::vector<token_t> expected = {
+		token_t(token_e::number, "1"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::punctuation, ">"),
+		token_t(token_e::punctuation, ">"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::number, "2")
+	};
+	check_vector(vec, expected);
 }
 
 TEST(LexerTests, SingleLineComments) {
-    std::string str = "foobar // 123";
-    auto vec = tokenize(str);
-    std::vector<token_t> expected = {
-        token_t(token_e::identifier, "foobar"),
-        token_t(token_e::whitespace, " ")
-    };
-    check_vector(vec, expected);
+	std::string str = "foobar // 123";
+	auto vec = tokenize(str);
+	std::vector<token_t> expected = {
+		token_t(token_e::identifier, "foobar"),
+		token_t(token_e::whitespace, " ")
+	};
+	check_vector(vec, expected);
 }
 
 TEST(LexerTests, MultiLineComments) {
-    std::string str = "1 /* foobar */ 2";
-    auto vec = tokenize(str);
-    std::vector<token_t> expected = {
-        token_t(token_e::number, "1"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::whitespace, " "), // TODO: This might be sub-ideal
-        token_t(token_e::number, "2")
-    };
-    check_vector(vec, expected);
+	std::string str = "1 /* foobar */ 2";
+	auto vec = tokenize(str);
+	std::vector<token_t> expected = {
+		token_t(token_e::number, "1"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::whitespace, " "), // TODO: This might be sub-ideal
+		token_t(token_e::number, "2")
+	};
+	check_vector(vec, expected);
 }
 
 TEST(LexerTests, NamedLiterals) {
-    std::string str = "false true nullptr falsetrue false1 nullptr-";
-    auto vec = tokenize(str);
-    std::vector<token_t> expected = {
-        token_t(token_e::named_literal, "false"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::named_literal, "true"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::named_literal, "nullptr"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::identifier, "falsetrue"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::identifier, "false1"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::named_literal, "nullptr"),
-        token_t(token_e::punctuation, "-"),
-    };
-    check_vector(vec, expected);
+	std::string str = "false true nullptr falsetrue false1 nullptr-";
+	auto vec = tokenize(str);
+	std::vector<token_t> expected = {
+		token_t(token_e::named_literal, "false"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::named_literal, "true"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::named_literal, "nullptr"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::identifier, "falsetrue"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::identifier, "false1"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::named_literal, "nullptr"),
+		token_t(token_e::punctuation, "-"),
+	};
+	check_vector(vec, expected);
 }
 
 TEST(LexerTests, CharLiterals) {
-    std::string str = R"('f''f'12 '\n' u8'\u1212''\N{foo'bar}' L'W''\'')";
-    auto vec = tokenize(str);
-    std::vector<token_t> expected = {
-        token_t(token_e::string, "'f'"),
-        token_t(token_e::string, "'f'"),
-        token_t(token_e::number, "12"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::string, "'\\n'"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::string, "u8'\\u1212'"),
-        token_t(token_e::string, "'\\N{foo'bar}'"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::string, "L'W'"),
-        token_t(token_e::string, "'\\''"),
-    };
-    check_vector(vec, expected);
-    check_vector(tokenize("'foo'"), std::nullopt);
+	std::string str = R"('f''f'12 '\n' u8'\u1212''\N{foo'bar}' L'W''\'')";
+	auto vec = tokenize(str);
+	std::vector<token_t> expected = {
+		token_t(token_e::string, "'f'"),
+		token_t(token_e::string, "'f'"),
+		token_t(token_e::number, "12"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::string, "'\\n'"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::string, "u8'\\u1212'"),
+		token_t(token_e::string, "'\\N{foo'bar}'"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::string, "L'W'"),
+		token_t(token_e::string, "'\\''"),
+	};
+	check_vector(vec, expected);
+	check_vector(tokenize("'foo'"), std::nullopt);
 }
 
 TEST(LexerTests, StringLiterals) {
-    std::string str = R"("f""f"12 "\n" u8"\u1212""foobar""\N{foo"bar}" L"W""foo\"foo")";
-    auto vec = tokenize(str);
-    std::vector<token_t> expected = {
-        token_t(token_e::string, "\"f\""),
-        token_t(token_e::string, "\"f\""),
-        token_t(token_e::number, "12"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::string, "\"\\n\""),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::string, "u8\"\\u1212\""),
-        token_t(token_e::string, "\"foobar\""),
-        token_t(token_e::string, "\"\\N{foo\"bar}\""),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::string, "L\"W\""),
-        token_t(token_e::string, "\"foo\\\"foo\""),
-    };
-    check_vector(vec, expected);
+	std::string str = R"("f""f"12 "\n" u8"\u1212""foobar""\N{foo"bar}" L"W""foo\"foo")";
+	auto vec = tokenize(str);
+	std::vector<token_t> expected = {
+		token_t(token_e::string, "\"f\""),
+		token_t(token_e::string, "\"f\""),
+		token_t(token_e::number, "12"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::string, "\"\\n\""),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::string, "u8\"\\u1212\""),
+		token_t(token_e::string, "\"foobar\""),
+		token_t(token_e::string, "\"\\N{foo\"bar}\""),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::string, "L\"W\""),
+		token_t(token_e::string, "\"foo\\\"foo\""),
+	};
+	check_vector(vec, expected);
 }
 
 TEST(LexerTests, Numbers) {
-    std::string str = R"TT(100 20 066 080 0x4fefe 0b101001010 .12 1. 1.f .12f 1e1 1e+2 1.e-2 0x1.1p+10)TT";
-    auto vec = tokenize(str);
-    std::vector<token_t> expected = {
-        token_t(token_e::number, "100"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::number, "20"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::number, "066"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::number, "080"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::number, "0x4fefe"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::number, "0b101001010"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::number, ".12"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::number, "1."),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::number, "1.f"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::number, ".12f"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::number, "1e1"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::number, "1e+2"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::number, "1.e-2"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::number, "0x1.1p+10"),
-    };
-    check_vector(vec, expected);
+	std::string str =
+		R"TT(100 20 066 080 0x4fefe 0b101001010 .12 1. 1.f .12f 1e1 1e+2 1.e-2 0x1.1p+10)TT";
+	auto vec = tokenize(str);
+	std::vector<token_t> expected = {
+		token_t(token_e::number, "100"),         token_t(token_e::whitespace, " "),
+		token_t(token_e::number, "20"),          token_t(token_e::whitespace, " "),
+		token_t(token_e::number, "066"),         token_t(token_e::whitespace, " "),
+		token_t(token_e::number, "080"),         token_t(token_e::whitespace, " "),
+		token_t(token_e::number, "0x4fefe"),     token_t(token_e::whitespace, " "),
+		token_t(token_e::number, "0b101001010"), token_t(token_e::whitespace, " "),
+		token_t(token_e::number, ".12"),         token_t(token_e::whitespace, " "),
+		token_t(token_e::number, "1."),          token_t(token_e::whitespace, " "),
+		token_t(token_e::number, "1.f"),         token_t(token_e::whitespace, " "),
+		token_t(token_e::number, ".12f"),        token_t(token_e::whitespace, " "),
+		token_t(token_e::number, "1e1"),         token_t(token_e::whitespace, " "),
+		token_t(token_e::number, "1e+2"),        token_t(token_e::whitespace, " "),
+		token_t(token_e::number, "1.e-2"),       token_t(token_e::whitespace, " "),
+		token_t(token_e::number, "0x1.1p+10"),
+	};
+	check_vector(vec, expected);
 }
 
 TEST(LexerTests, UDLs) {
-    std::string str = R"TT('1'sv "12"sv 20uint 1._f 0x1.1p+10_foo 1+foo)TT";
-    auto vec = tokenize(str);
-    std::vector<token_t> expected = {
-        token_t(token_e::string, "'1'sv"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::string, "\"12\"sv"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::number, "20uint"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::number, "1._f"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::number, "0x1.1p+10_foo"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::number, "1"),
-        token_t(token_e::punctuation, "+"),
-        token_t(token_e::identifier, "foo"),
-    };
-    check_vector(vec, expected);
+	std::string str = R"TT('1'sv "12"sv 20uint 1._f 0x1.1p+10_foo 1+foo)TT";
+	auto vec = tokenize(str);
+	std::vector<token_t> expected = {
+		token_t(token_e::string, "'1'sv"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::string, "\"12\"sv"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::number, "20uint"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::number, "1._f"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::number, "0x1.1p+10_foo"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::number, "1"),
+		token_t(token_e::punctuation, "+"),
+		token_t(token_e::identifier, "foo"),
+	};
+	check_vector(vec, expected);
 }
 
 TEST(LexerTests, IdentifiersAndKeywords) {
-    std::string str = R"TT(12f f12 foo_bar200.0 break for() foo() this.foo this->foo char)TT";
-    auto vec = tokenize(str);
-    std::vector<token_t> expected = {
-        token_t(token_e::number, "12f"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::identifier, "f12"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::identifier, "foo_bar200"),
-        token_t(token_e::number, ".0"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::keyword, "break"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::keyword, "for"),
-        token_t(token_e::punctuation, "("),
-        token_t(token_e::punctuation, ")"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::identifier, "foo"),
-        token_t(token_e::punctuation, "("),
-        token_t(token_e::punctuation, ")"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::keyword, "this"),
-        token_t(token_e::punctuation, "."),
-        token_t(token_e::identifier, "foo"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::keyword, "this"),
-        token_t(token_e::punctuation, "->"),
-        token_t(token_e::identifier, "foo"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::keyword, "char"),
-    };
-    check_vector(vec, expected);
+	std::string str = R"TT(12f f12 foo_bar200.0 break for() foo() this.foo this->foo char)TT";
+	auto vec = tokenize(str);
+	std::vector<token_t> expected = {
+		token_t(token_e::number, "12f"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::identifier, "f12"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::identifier, "foo_bar200"),
+		token_t(token_e::number, ".0"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::keyword, "break"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::keyword, "for"),
+		token_t(token_e::punctuation, "("),
+		token_t(token_e::punctuation, ")"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::identifier, "foo"),
+		token_t(token_e::punctuation, "("),
+		token_t(token_e::punctuation, ")"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::keyword, "this"),
+		token_t(token_e::punctuation, "."),
+		token_t(token_e::identifier, "foo"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::keyword, "this"),
+		token_t(token_e::punctuation, "->"),
+		token_t(token_e::identifier, "foo"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::keyword, "char"),
+	};
+	check_vector(vec, expected);
 }
 
 TEST(LexerTests, InvalidInputIsRejected) {
-    auto vec1 = tokenize(R"TT(Error: Didn't return the correct result)TT");
-    check_vector(vec1, std::nullopt);
-    auto vec2 = tokenize(R"TT(Error: Didn't return the correct result, or didn't return the right result)TT");
-    check_vector(vec2, std::nullopt);
+	auto vec1 = tokenize(R"TT(Error: Didn't return the correct result)TT");
+	check_vector(vec1, std::nullopt);
+	auto vec2 =
+		tokenize(R"TT(Error: Didn't return the correct result, or didn't return the right result)TT");
+	check_vector(vec2, std::nullopt);
 }
 
 TEST(LexerTests, Regression1) {
-    auto vec = tokenize(R"TT(std::optional<std::vector<token_t>>: nullopt)TT");
-    std::vector<token_t> expected = {
-        token_t(token_e::identifier, "std"),
-        token_t(token_e::punctuation, "::"),
-        token_t(token_e::identifier, "optional"),
-        token_t(token_e::punctuation, "<"),
-        token_t(token_e::identifier, "std"),
-        token_t(token_e::punctuation, "::"),
-        token_t(token_e::identifier, "vector"),
-        token_t(token_e::punctuation, "<"),
-        token_t(token_e::identifier, "token_t"),
-        token_t(token_e::punctuation, ">>"),
-        token_t(token_e::punctuation, ":"),
-        token_t(token_e::whitespace, " "),
-        token_t(token_e::identifier, "nullopt"),
-    };
-    check_vector(vec, expected);
+	auto vec = tokenize(R"TT(std::optional<std::vector<token_t>>: nullopt)TT");
+	std::vector<token_t> expected = {
+		token_t(token_e::identifier, "std"),
+		token_t(token_e::punctuation, "::"),
+		token_t(token_e::identifier, "optional"),
+		token_t(token_e::punctuation, "<"),
+		token_t(token_e::identifier, "std"),
+		token_t(token_e::punctuation, "::"),
+		token_t(token_e::identifier, "vector"),
+		token_t(token_e::punctuation, "<"),
+		token_t(token_e::identifier, "token_t"),
+		token_t(token_e::punctuation, ">>"),
+		token_t(token_e::punctuation, ":"),
+		token_t(token_e::whitespace, " "),
+		token_t(token_e::identifier, "nullopt"),
+	};
+	check_vector(vec, expected);
 }

--- a/tests/unit/literals.cpp
+++ b/tests/unit/literals.cpp
@@ -3,51 +3,51 @@
 #include <cstdlib>
 #include <initializer_list>
 #include <regex>
-#include <string_view>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "microfmt.hpp"
 
 inline std::vector<std::string> split(std::string_view s, std::string_view delim) {
-    std::vector<std::string> vec;
-    size_t old_pos = 0;
-    size_t pos = 0;
-    std::string token;
-    while((pos = s.find(delim, old_pos)) != std::string::npos) {
-            token = s.substr(old_pos, pos - old_pos);
-            vec.push_back(token);
-            old_pos = pos + delim.length();
-    }
-    //if(old_pos != s.length()) { // TODO: verify condition?
-        vec.emplace_back(s.substr(old_pos));
-    //}
-    return vec;
+	std::vector<std::string> vec;
+	size_t old_pos = 0;
+	size_t pos = 0;
+	std::string token;
+	while ((pos = s.find(delim, old_pos)) != std::string::npos) {
+		token = s.substr(old_pos, pos - old_pos);
+		vec.push_back(token);
+		old_pos = pos + delim.length();
+	}
+	//if(old_pos != s.length()) { // TODO: verify condition?
+	vec.emplace_back(s.substr(old_pos));
+	//}
+	return vec;
 }
 
-constexpr const char * const ws = " \t\n\r\f\v";
+constexpr const char* const ws = " \t\n\r\f\v";
 
 // trim from end of string (right)
 inline std::string& rtrim(std::string& s, const char* t = ws) {
-    s.erase(s.find_last_not_of(t) + 1);
-    return s;
+	s.erase(s.find_last_not_of(t) + 1);
+	return s;
 }
 
 // trim from beginning of string (left)
 inline std::string& ltrim(std::string& s, const char* t = ws) {
-    s.erase(0, s.find_first_not_of(t));
-    return s;
+	s.erase(0, s.find_first_not_of(t));
+	return s;
 }
 
 // trim from both ends of string (right then left)
 inline std::string& trim(std::string& s, const char* t = ws) {
-    return ltrim(rtrim(s, t), t);
+	return ltrim(rtrim(s, t), t);
 }
 
 #define let auto
 
 int main() {
-    std::string match_raw = R"QQ(
+	std::string match_raw = R"QQ(
         0b0
         0B0
         0b1'10101010'0'1
@@ -76,7 +76,7 @@ int main() {
         1e2
         1e2f
     )QQ";
-    std::string dont_match_raw = R"QQ(
+	std::string dont_match_raw = R"QQ(
         0B
         0b'1'1'0'1
         0b1'1'0'1'
@@ -122,56 +122,79 @@ int main() {
         1'e2
         1e2f'
     )QQ";
-    let match_cases = split(trim(match_raw), "\n");
-    let dont_match_cases = split(trim(dont_match_raw), "\n");
-    for(let& set : {&match_cases, &dont_match_cases}) {
-        for(let& item : *set) {
-            item = trim(item);
-        }
-    }
-    static std::string optional_integer_suffix = "(?:[Uu](?:LL?|ll?|Z|z)?|(?:LL?|ll?|Z|z)[Uu]?)?";
-    static std::regex int_binary  = std::regex("^0[Bb][01](?:'?[01])*" + optional_integer_suffix + "$");
-    static std::regex int_octal   = std::regex("^0(?:'?[0-7])+" + optional_integer_suffix + "$");
-    static std::regex int_decimal = std::regex("^(?:0|[1-9](?:'?\\d)*)" + optional_integer_suffix + "$");
-    static std::regex int_hex     = std::regex("^0[Xx](?!')(?:'?[\\da-fA-F])+" + optional_integer_suffix + "$");
+	let match_cases = split(trim(match_raw), "\n");
+	let dont_match_cases = split(trim(dont_match_raw), "\n");
+	for (let& set : {&match_cases, &dont_match_cases}) {
+		for (let& item : *set) {
+			item = trim(item);
+		}
+	}
+	static std::string optional_integer_suffix = "(?:[Uu](?:LL?|ll?|Z|z)?|(?:LL?|ll?|Z|z)[Uu]?)?";
+	static std::regex int_binary =
+		std::regex("^0[Bb][01](?:'?[01])*" + optional_integer_suffix + "$");
+	static std::regex int_octal = std::regex("^0(?:'?[0-7])+" + optional_integer_suffix + "$");
+	static std::regex int_decimal =
+		std::regex("^(?:0|[1-9](?:'?\\d)*)" + optional_integer_suffix + "$");
+	static std::regex int_hex =
+		std::regex("^0[Xx](?!')(?:'?[\\da-fA-F])+" + optional_integer_suffix + "$");
 
-    static std::string digit_sequence = "\\d(?:'?\\d)*";
-    static std::string fractional_constant = libassert::microfmt::format("(?:(?:{})?\\.{}|{}\\.)", digit_sequence, digit_sequence, digit_sequence);
-    static std::string exponent_part = "(?:[Ee][\\+-]?" + digit_sequence + ")";
-    static std::string suffix = "[FfLl]";
-    static std::regex float_decimal = std::regex(libassert::microfmt::format("^(?:{}{}?|{}{}){}?$",
-                                    fractional_constant, exponent_part,
-                                    digit_sequence, exponent_part, suffix));
-    static std::string hex_digit_sequence = "[\\da-fA-F](?:'?[\\da-fA-F])*";
-    static std::string hex_frac_const = libassert::microfmt::format("(?:(?:{})?\\.{}|{}\\.)", hex_digit_sequence, hex_digit_sequence, hex_digit_sequence);
-    static std::string binary_exp = "[Pp][\\+-]?" + digit_sequence;
-    static std::regex float_hex = std::regex(libassert::microfmt::format("^0[Xx](?:{}|{}){}{}?$",
-                                    hex_frac_const, hex_digit_sequence, binary_exp, suffix));
-    let matches_any = [&](const std::string& str) {
-        let matches = [](const std::string& value, const std::regex& re) {
-            std::smatch base_match;
-            return std::regex_match(value, base_match, re);
-        };
-        return matches(str, int_binary)
-            || matches(str, int_octal)
-            || matches(str, int_decimal)
-            || matches(str, int_hex)
-            || matches(str, float_decimal)
-            || matches(str, float_hex);
-    };
-    bool ok = true;
-    for(let const& item : match_cases) {
-        if(!matches_any(item)) {
-            printf("test case failed, valid literal not matched: %s\n", item.c_str());
-            ok = false;
-        }
-    }
-    for(let const& item : dont_match_cases) {
-        if(matches_any(item)) {
-            printf("test case failed, invalid literal matched: %s\n", item.c_str());
-            ok = false;
-        }
-    }
-    printf("Done\n");
-    return !ok;
+	static std::string digit_sequence = "\\d(?:'?\\d)*";
+	static std::string fractional_constant = libassert::microfmt::format(
+		"(?:(?:{})?\\.{}|{}\\.)",
+		digit_sequence,
+		digit_sequence,
+		digit_sequence
+	);
+	static std::string exponent_part = "(?:[Ee][\\+-]?" + digit_sequence + ")";
+	static std::string suffix = "[FfLl]";
+	static std::regex float_decimal = std::regex(
+		libassert::microfmt::format(
+			"^(?:{}{}?|{}{}){}?$",
+			fractional_constant,
+			exponent_part,
+			digit_sequence,
+			exponent_part,
+			suffix
+		)
+	);
+	static std::string hex_digit_sequence = "[\\da-fA-F](?:'?[\\da-fA-F])*";
+	static std::string hex_frac_const = libassert::microfmt::format(
+		"(?:(?:{})?\\.{}|{}\\.)",
+		hex_digit_sequence,
+		hex_digit_sequence,
+		hex_digit_sequence
+	);
+	static std::string binary_exp = "[Pp][\\+-]?" + digit_sequence;
+	static std::regex float_hex = std::regex(
+		libassert::microfmt::format(
+			"^0[Xx](?:{}|{}){}{}?$",
+			hex_frac_const,
+			hex_digit_sequence,
+			binary_exp,
+			suffix
+		)
+	);
+	let matches_any = [&](const std::string& str) {
+		let matches = [](const std::string& value, const std::regex& re) {
+			std::smatch base_match;
+			return std::regex_match(value, base_match, re);
+		};
+		return matches(str, int_binary) || matches(str, int_octal) || matches(str, int_decimal)
+			|| matches(str, int_hex) || matches(str, float_decimal) || matches(str, float_hex);
+	};
+	bool ok = true;
+	for (let const& item : match_cases) {
+		if (!matches_any(item)) {
+			printf("test case failed, valid literal not matched: %s\n", item.c_str());
+			ok = false;
+		}
+	}
+	for (let const& item : dont_match_cases) {
+		if (matches_any(item)) {
+			printf("test case failed, invalid literal matched: %s\n", item.c_str());
+			ok = false;
+		}
+	}
+	printf("Done\n");
+	return !ok;
 }

--- a/tests/unit/std_format20.cpp
+++ b/tests/unit/std_format20.cpp
@@ -2,106 +2,108 @@
 
 #ifdef LIBASSERT_USE_STD_FORMAT
 
-#include <format>
+	#include <format>
 
 struct S {
-    int x;
+	int x;
 };
 
 template<>
 struct std::formatter<S> {
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
-        return ctx.begin();
-    }
+	template<typename ParseContext>
+	constexpr auto parse(ParseContext& ctx) {
+		return ctx.begin();
+	}
 
-    template<typename FormatContext>
-    auto format(const S& s, FormatContext& ctx) const {
-        return std::format_to(ctx.out(), "s.x={}", s.x);
-    }
+	template<typename FormatContext>
+	auto format(const S& s, FormatContext& ctx) const {
+		return std::format_to(ctx.out(), "s.x={}", s.x);
+	}
 };
 
 TEST(LibassertFmt, StdFormatWorks) {
-    ASSERT(libassert::stringify(S{42}) == "s.x=42");
+	ASSERT(libassert::stringify(S {42}) == "s.x=42");
 }
 
 struct S2 {
-    int x;
+	int x;
 };
 
 template<>
 struct std::formatter<S2> {
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
-        return ctx.begin();
-    }
+	template<typename ParseContext>
+	constexpr auto parse(ParseContext& ctx) {
+		return ctx.begin();
+	}
 
-    template<typename FormatContext>
-    auto format(const S2& s, FormatContext& ctx) const {
-        return std::format_to(ctx.out(), "s2.x={}", s.x);
-    }
+	template<typename FormatContext>
+	auto format(const S2& s, FormatContext& ctx) const {
+		return std::format_to(ctx.out(), "s2.x={}", s.x);
+	}
 };
 
-template<> struct libassert::stringifier<S2> {
-    std::string stringify(const S2& s) {
-        return std::format("{}", s) + "--";
-    }
+template<>
+struct libassert::stringifier<S2> {
+	std::string stringify(const S2& s) {
+		return std::format("{}", s) + "--";
+	}
 };
 
 TEST(LibassertFmt, StdFormatPriority1) {
-    ASSERT(libassert::stringify(S2{42}) == "s2.x=42--");
+	ASSERT(libassert::stringify(S2 {42}) == "s2.x=42--");
 }
 
 struct S3 {
-    int x;
+	int x;
 };
 
 template<>
 struct std::formatter<S3> {
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
-        return ctx.begin();
-    }
+	template<typename ParseContext>
+	constexpr auto parse(ParseContext& ctx) {
+		return ctx.begin();
+	}
 
-    template<typename FormatContext>
-    auto format(const S3& s, FormatContext& ctx) const {
-        return std::format_to(ctx.out(), "std::format chosen");
-    }
+	template<typename FormatContext>
+	auto format(const S3& s, FormatContext& ctx) const {
+		return std::format_to(ctx.out(), "std::format chosen");
+	}
 };
 
 template<>
 struct fmt::formatter<S3> {
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
-        return ctx.begin();
-    }
+	template<typename ParseContext>
+	constexpr auto parse(ParseContext& ctx) {
+		return ctx.begin();
+	}
 
-    template<typename FormatContext>
-    auto format(const S3& s, FormatContext& ctx) const {
-        return fmt::format_to(ctx.out(), "fmt::format chosen");
-    }
+	template<typename FormatContext>
+	auto format(const S3& s, FormatContext& ctx) const {
+		return fmt::format_to(ctx.out(), "fmt::format chosen");
+	}
 };
 
 TEST(LibassertFmt, StdFormatPriority2) {
-    ASSERT(libassert::stringify(S3{42}) == "std::format chosen");
+	ASSERT(libassert::stringify(S3 {42}) == "std::format chosen");
 }
 
 struct fmtable {
-    int x;
+	int x;
 };
 
-template <> struct std::formatter<fmtable>: formatter<string_view> {
-    auto format(const fmtable& f, format_context& ctx) const {
-        return std::format_to(ctx.out(), "{{{}}}", f.x);
-    }
+template<>
+struct std::formatter<fmtable>: formatter<string_view> {
+	auto format(const fmtable& f, format_context& ctx) const {
+		return std::format_to(ctx.out(), "{{{}}}", f.x);
+	}
 };
 
 TEST(LibassertFmt, StdFormatContainers) {
-    fmtable f{2};
-    ASSERT(libassert::detail::generate_stringification(f) == "{2}");
+	fmtable f {2};
+	ASSERT(libassert::detail::generate_stringification(f) == "{2}");
 
-    std::vector<fmtable> fvec{{{2}, {3}}};
-    ASSERT(libassert::detail::generate_stringification(fvec) == "std::vector<fmtable>: [{2}, {3}]");
+	std::vector<fmtable> fvec {{{2}, {3}}};
+	ASSERT(libassert::detail::generate_stringification(fvec) == "std::vector<fmtable>: [{2}, {3}]");
 }
 
 #endif

--- a/tests/unit/std_format23.cpp
+++ b/tests/unit/std_format23.cpp
@@ -2,109 +2,111 @@
 
 #ifdef LIBASSERT_USE_STD_FORMAT
 
-#include <format>
+	#include <format>
 
 struct S {
-    int x;
+	int x;
 };
 
 template<>
 struct std::formatter<S> {
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
-        return ctx.begin();
-    }
+	template<typename ParseContext>
+	constexpr auto parse(ParseContext& ctx) {
+		return ctx.begin();
+	}
 
-    template<typename FormatContext>
-    auto format(const S& s, FormatContext& ctx) const {
-        return std::format_to(ctx.out(), "s.x={}", s.x);
-    }
+	template<typename FormatContext>
+	auto format(const S& s, FormatContext& ctx) const {
+		return std::format_to(ctx.out(), "s.x={}", s.x);
+	}
 };
 
 TEST(LibassertFmt, StdFormatWorks) {
-    ASSERT(libassert::stringify(S{42}) == "s.x=42");
+	ASSERT(libassert::stringify(S {42}) == "s.x=42");
 }
 
 struct S2 {
-    int x;
+	int x;
 };
 
 template<>
 struct std::formatter<S2> {
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
-        return ctx.begin();
-    }
+	template<typename ParseContext>
+	constexpr auto parse(ParseContext& ctx) {
+		return ctx.begin();
+	}
 
-    template<typename FormatContext>
-    auto format(const S2& s, FormatContext& ctx) const {
-        return std::format_to(ctx.out(), "s2.x={}", s.x);
-    }
+	template<typename FormatContext>
+	auto format(const S2& s, FormatContext& ctx) const {
+		return std::format_to(ctx.out(), "s2.x={}", s.x);
+	}
 };
 
-template<> struct libassert::stringifier<S2> {
-    std::string stringify(const S2& s) {
-        return std::format("{}", s) + "--";
-    }
+template<>
+struct libassert::stringifier<S2> {
+	std::string stringify(const S2& s) {
+		return std::format("{}", s) + "--";
+	}
 };
 
 TEST(LibassertFmt, StdFormatPriority1) {
-    ASSERT(libassert::stringify(S2{42}) == "s2.x=42--");
+	ASSERT(libassert::stringify(S2 {42}) == "s2.x=42--");
 }
 
 struct S3 {
-    int x;
+	int x;
 };
 
 template<>
 struct std::formatter<S3> {
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
-        return ctx.begin();
-    }
+	template<typename ParseContext>
+	constexpr auto parse(ParseContext& ctx) {
+		return ctx.begin();
+	}
 
-    template<typename FormatContext>
-    auto format(const S3& s, FormatContext& ctx) const {
-        return std::format_to(ctx.out(), "std::format chosen");
-    }
+	template<typename FormatContext>
+	auto format(const S3& s, FormatContext& ctx) const {
+		return std::format_to(ctx.out(), "std::format chosen");
+	}
 };
 
 template<>
 struct fmt::formatter<S3> {
-    template<typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
-        return ctx.begin();
-    }
+	template<typename ParseContext>
+	constexpr auto parse(ParseContext& ctx) {
+		return ctx.begin();
+	}
 
-    template<typename FormatContext>
-    auto format(const S3& s, FormatContext& ctx) const {
-        return fmt::format_to(ctx.out(), "fmt::format chosen");
-    }
+	template<typename FormatContext>
+	auto format(const S3& s, FormatContext& ctx) const {
+		return fmt::format_to(ctx.out(), "fmt::format chosen");
+	}
 };
 
 TEST(LibassertFmt, StdFormatPriority2) {
-    ASSERT(libassert::stringify(S3{42}) == "std::format chosen");
+	ASSERT(libassert::stringify(S3 {42}) == "std::format chosen");
 }
 
 struct fmtable {
-    int x;
+	int x;
 };
 
-template <> struct std::formatter<fmtable>: formatter<string_view> {
-    template<class FormatContext>
-    auto format(const fmtable& f, FormatContext& ctx) const {
-        return std::format_to(ctx.out(), "{{{}}}", f.x);
-    }
+template<>
+struct std::formatter<fmtable>: formatter<string_view> {
+	template<class FormatContext>
+	auto format(const fmtable& f, FormatContext& ctx) const {
+		return std::format_to(ctx.out(), "{{{}}}", f.x);
+	}
 };
 
 static_assert(std::formattable<fmtable, char>);
 
 TEST(LibassertFmt, StdFormatContainers) {
-    fmtable f{2};
-    ASSERT(libassert::detail::generate_stringification(f) == "{2}");
+	fmtable f {2};
+	ASSERT(libassert::detail::generate_stringification(f) == "{2}");
 
-    std::vector<fmtable> fvec{{{2}, {3}}};
-    ASSERT(libassert::detail::generate_stringification(fvec) == "std::vector<fmtable>: [{2}, {3}]");
+	std::vector<fmtable> fvec {{{2}, {3}}};
+	ASSERT(libassert::detail::generate_stringification(fvec) == "std::vector<fmtable>: [{2}, {3}]");
 }
 
 #endif

--- a/tests/unit/stringify.cpp
+++ b/tests/unit/stringify.cpp
@@ -4,8 +4,8 @@
 #include <memory>
 #include <optional>
 #include <ostream>
-#include <string_view>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -13,258 +13,314 @@
 #undef ASSERT_LOWERCASE
 
 #ifdef TEST_MODULE
-#include <gtest/gtest.h>
+	#include <gtest/gtest.h>
 
 import libassert;
-#include <libassert/assert-gtest-macros.hpp>
+	#include <libassert/assert-gtest-macros.hpp>
 #else
-#include <libassert/assert-gtest.hpp>
+	#include <libassert/assert-gtest.hpp>
 #endif
 
 using namespace libassert::detail;
 using namespace std::literals;
 
 struct ostream_printable {
-    int x;
+	int x;
 };
 
 std::ostream& operator<<(std::ostream& os, ostream_printable item) {
-    return os << "{" << item.x << "}";
+	return os << "{" << item.x << "}";
 }
 
 struct S {};
+
 struct S2 {};
 
 struct A {};
+
 struct B {};
+
 struct C {};
 
 TEST(Stringify, BasicTypes) {
-    ASSERT(generate_stringification(false) == R"(false)");
-    ASSERT(generate_stringification(42) == R"(42)");
-    ASSERT(generate_stringification(2.25) == R"(2.25)");
+	ASSERT(generate_stringification(false) == R"(false)");
+	ASSERT(generate_stringification(42) == R"(42)");
+	ASSERT(generate_stringification(2.25) == R"(2.25)");
 }
 
 TEST(Stringify, Pointers) {
-    ASSERT(generate_stringification(nullptr) == R"(nullptr)");
-    int x;
-    int* ptr = &x;
-    auto s = generate_stringification(ptr);
-    ASSERT(s.find("int*: 0x") == std::size_t(0) || s.find("int *: 0x") == std::size_t(0), "", s);
+	ASSERT(generate_stringification(nullptr) == R"(nullptr)");
+	int x;
+	int* ptr = &x;
+	auto s = generate_stringification(ptr);
+	ASSERT(s.find("int*: 0x") == std::size_t(0) || s.find("int *: 0x") == std::size_t(0), "", s);
 }
 
 TEST(Stringify, SmartPointers) {
-    auto uptr = std::make_unique<int>(62);
-    ASSERT(generate_stringification(uptr) == R"(std::unique_ptr<int>: 62)");
-    ASSERT(generate_stringification(std::unique_ptr<int>()) == R"(std::unique_ptr<int>: nullptr)");
-    ASSERT(generate_stringification(std::make_unique<S>()).find(R"(std::unique_ptr<S>: 0x)") == std::size_t(0), generate_stringification(std::make_unique<S>()));
+	auto uptr = std::make_unique<int>(62);
+	ASSERT(generate_stringification(uptr) == R"(std::unique_ptr<int>: 62)");
+	ASSERT(generate_stringification(std::unique_ptr<int>()) == R"(std::unique_ptr<int>: nullptr)");
+	ASSERT(
+		generate_stringification(std::make_unique<S>()).find(R"(std::unique_ptr<S>: 0x)")
+			== std::size_t(0),
+		generate_stringification(std::make_unique<S>())
+	);
 
-    std::unique_ptr<std::vector<int>> uptr2(new std::vector<int>{1,2,3,4});
-    ASSERT(generate_stringification(uptr2) == R"(std::unique_ptr<std::vector<int>>: [1, 2, 3, 4])");
-    auto d = [](int*) {};
-    std::unique_ptr<int, decltype(d)> uptr3(nullptr, d);
-    ASSERT(generate_stringification(uptr3).find("std::unique_ptr<int,") == std::size_t(0));
-    ASSERT(generate_stringification(uptr3).find("nullptr") != std::string::npos);
+	std::unique_ptr<std::vector<int>> uptr2(new std::vector<int> {1, 2, 3, 4});
+	ASSERT(generate_stringification(uptr2) == R"(std::unique_ptr<std::vector<int>>: [1, 2, 3, 4])");
+	auto d = [](int*) {};
+	std::unique_ptr<int, decltype(d)> uptr3(nullptr, d);
+	ASSERT(generate_stringification(uptr3).find("std::unique_ptr<int,") == std::size_t(0));
+	ASSERT(generate_stringification(uptr3).find("nullptr") != std::string::npos);
 }
 
 TEST(Stringify, Strings) {
-    ASSERT(generate_stringification("foobar") == R"("foobar")");
-    ASSERT(generate_stringification("foobar"sv) == R"("foobar")");
-    ASSERT(generate_stringification("foobar"s) == R"("foobar")");
-    ASSERT(generate_stringification(char(42)) == R"('*')");
-    // Note: There's buggy behavior here with how MSVC stringizes the raw string literal when /Zc:preprocessor is not
-    // used. https://godbolt.org/z/13acEWTGc
-    ASSERT(generate_stringification(R"("foobar")") == R"xx("\"foobar\"")xx");
+	ASSERT(generate_stringification("foobar") == R"("foobar")");
+	ASSERT(generate_stringification("foobar"sv) == R"("foobar")");
+	ASSERT(generate_stringification("foobar"s) == R"("foobar")");
+	ASSERT(generate_stringification(char(42)) == R"('*')");
+	// Note: There's buggy behavior here with how MSVC stringizes the raw string literal when /Zc:preprocessor is not
+	// used. https://godbolt.org/z/13acEWTGc
+	ASSERT(generate_stringification(R"("foobar")") == R"xx("\"foobar\"")xx");
 }
 
 #if __GNUC__ >= 9
 // Somehow bugged for gcc 8, resulting in a segfault on std::filesystem::path::~path(). This happens completely
 // independent of anything cpptrace, some awful ABI issue and I can't be bothered to figure it out. Can't repro on CE.
 TEST(Stringify, Paths) {
-    ASSERT(generate_stringification(std::filesystem::path("/home/foo")) == R"("/home/foo")");
+	ASSERT(generate_stringification(std::filesystem::path("/home/foo")) == R"("/home/foo")");
 }
 #endif
 
 struct recursive_stringify {
-    using value_type = int;
-    struct const_iterator {
-        int i;
-        using value_type = recursive_stringify;
-        value_type operator*() const {
-            return recursive_stringify{};
-        }
-        const_iterator operator++(int) {
-            auto copy = *this;
-            i++;
-            return copy;
-        }
-        bool operator!=(const const_iterator& other) const {
-            return i != other.i;
-        }
-    };
-    const_iterator begin() const {
-        return {0};
-    }
-    const_iterator end() const {
-        return {5};
-    }
+	using value_type = int;
+
+	struct const_iterator {
+		int i;
+		using value_type = recursive_stringify;
+
+		value_type operator*() const {
+			return recursive_stringify {};
+		}
+
+		const_iterator operator++(int) {
+			auto copy = *this;
+			i++;
+			return copy;
+		}
+
+		bool operator!=(const const_iterator& other) const {
+			return i != other.i;
+		}
+	};
+
+	const_iterator begin() const {
+		return {0};
+	}
+
+	const_iterator end() const {
+		return {5};
+	}
 };
 
 TEST(Stringify, RecursiveStringify) {
-    ASSERT(generate_stringification(recursive_stringify{}) == R"(recursive_stringify: [<instance of recursive_stringify>, <instance of recursive_stringify>, <instance of recursive_stringify>, <instance of recursive_stringify>, <instance of recursive_stringify>])");
+	ASSERT(
+		generate_stringification(recursive_stringify {})
+		== R"(recursive_stringify: [<instance of recursive_stringify>, <instance of recursive_stringify>, <instance of recursive_stringify>, <instance of recursive_stringify>, <instance of recursive_stringify>])"
+	);
 }
 
 struct recursive_stringify_pathological {
-    using value_type = int;
-    struct const_iterator {
-        int i;
-        using value_type = std::vector<recursive_stringify_pathological>;
-        value_type operator*() const {
-            return value_type{};
-        }
-        const_iterator operator++(int) {
-            auto copy = *this;
-            i++;
-            return copy;
-        }
-        bool operator!=(const const_iterator& other) const {
-            return i != other.i;
-        }
-    };
-    const_iterator begin() const {
-        return {0};
-    }
-    const_iterator end() const {
-        return {5};
-    }
+	using value_type = int;
+
+	struct const_iterator {
+		int i;
+		using value_type = std::vector<recursive_stringify_pathological>;
+
+		value_type operator*() const {
+			return value_type {};
+		}
+
+		const_iterator operator++(int) {
+			auto copy = *this;
+			i++;
+			return copy;
+		}
+
+		bool operator!=(const const_iterator& other) const {
+			return i != other.i;
+		}
+	};
+
+	const_iterator begin() const {
+		return {0};
+	}
+
+	const_iterator end() const {
+		return {5};
+	}
 };
 
 TEST(Stringify, RecursiveStringifyPathological) {
-    ASSERT(generate_stringification(recursive_stringify_pathological{}) == R"(recursive_stringify_pathological: [[], [], [], [], []])");
+	ASSERT(
+		generate_stringification(recursive_stringify_pathological {})
+		== R"(recursive_stringify_pathological: [[], [], [], [], []])"
+	);
 }
 
 TEST(Stringify, Containers) {
-    std::array arr{1,2,3,4,5};
-    static_assert(stringifiable<std::array<int, 5>>);
-    ASSERT(generate_stringification(arr) == R"(std::array<int, 5>: [1, 2, 3, 4, 5])");
-    std::map<int, int> map{{1,2},{3,4}};
-    #if defined(_WIN32) && !LIBASSERT_IS_GCC
-    ASSERT(generate_stringification(map) == R"(std::map<int, int, std::less<int>>: [[1, 2], [3, 4]])");
-    #else
-    ASSERT(generate_stringification(map) == R"(std::map<int, int>: [[1, 2], [3, 4]])");
-    #endif
-    std::tuple<int, float, std::string, std::array<int, 5>> tuple = {1, 1.25f, "good", arr};
-    ASSERT(generate_stringification(tuple) == R"(std::tuple<int, float, std::string, std::array<int, 5>>: [1, 1.25, "good", [1, 2, 3, 4, 5]])");
-    std::optional<int> opt;
-    ASSERT(generate_stringification(opt) == R"(std::optional<int>: nullopt)");
-    opt = 63;
-    ASSERT(generate_stringification(opt) == R"(std::optional<int>: 63)");
-    ASSERT(generate_stringification(std::optional<S>(S{})) == R"(std::optional<S>: <instance of S>)");
-    std::vector<int> vec2 {2, 42, {}, 60};
-    ASSERT(generate_stringification(vec2) == R"(std::vector<int>: [2, 42, 0, 60])");
-    std::vector<std::optional<int>> vec {2, 42, {}, 60};
-    ASSERT(generate_stringification(vec) == R"(std::vector<std::optional<int>>: [2, 42, nullopt, 60])");
-    std::vector<std::optional<std::vector<std::pair<int, float>>>> vovp {{{{2, 1.2f}}}, {}, {{{20, 6.2f}}}};
-    ASSERT(generate_stringification(vovp) == R"(std::vector<std::optional<std::vector<std::pair<int, float>>>>: [[[2, 1.20000005]], nullopt, [[20, 6.19999981]]])");
-    std::vector<int> vlong(1100);
-    #define TEN "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "
-    #define HUNDRED TEN TEN TEN TEN TEN TEN TEN TEN TEN TEN
-    ASSERT(
-        generate_stringification(vlong) == "std::vector<int>: ["
-            HUNDRED HUNDRED HUNDRED HUNDRED HUNDRED HUNDRED HUNDRED HUNDRED HUNDRED HUNDRED "..."
-        "]"
-    );
-    int carr[] = {1, 1, 2, 3, 5, 8};
-    static_assert(stringifiable<int[5]>);
-    static_assert(stringifiable_container<int[5]>());
-    #if LIBASSERT_IS_CLANG || LIBASSERT_IS_MSVC
-    ASSERT(generate_stringification(carr) == R"(int[6]: [1, 1, 2, 3, 5, 8])");
-    #else
-    ASSERT(generate_stringification(carr) == R"(int [6]: [1, 1, 2, 3, 5, 8])");
-    #endif
-    // non-printable containers
-    std::vector<S> svec(10);
-    static_assert(!stringifiable<std::vector<S>>);
-    static_assert(!stringifiable_container<std::vector<S>>());
-    static_assert(!stringifiable<S>);
-    static_assert(!stringifiable_container<S>());
-    ASSERT(generate_stringification(svec) == R"(<instance of std::vector<S>>)");
-    std::vector<std::vector<S2>> svec2(10, std::vector<S2>(10));
-    //static_assert(!stringification::stringifiable<std::vector<std::vector<S2>>>);
-    ASSERT(generate_stringification(svec2) == R"(<instance of std::vector<std::vector<S2>>>)");
-    std::vector<std::vector<int>> svec3(10, std::vector<int>(10));
-    static_assert(stringifiable<std::vector<std::vector<int>>>);
-    ASSERT(generate_stringification(svec3) == R"(std::vector<std::vector<int>>: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])");
+	std::array arr {1, 2, 3, 4, 5};
+	static_assert(stringifiable<std::array<int, 5>>);
+	ASSERT(generate_stringification(arr) == R"(std::array<int, 5>: [1, 2, 3, 4, 5])");
+	std::map<int, int> map {{1, 2}, {3, 4}};
+#if defined(_WIN32) && !LIBASSERT_IS_GCC
+	ASSERT(
+		generate_stringification(map) == R"(std::map<int, int, std::less<int>>: [[1, 2], [3, 4]])"
+	);
+#else
+	ASSERT(generate_stringification(map) == R"(std::map<int, int>: [[1, 2], [3, 4]])");
+#endif
+	std::tuple<int, float, std::string, std::array<int, 5>> tuple = {1, 1.25f, "good", arr};
+	ASSERT(
+		generate_stringification(tuple)
+		== R"(std::tuple<int, float, std::string, std::array<int, 5>>: [1, 1.25, "good", [1, 2, 3, 4, 5]])"
+	);
+	std::optional<int> opt;
+	ASSERT(generate_stringification(opt) == R"(std::optional<int>: nullopt)");
+	opt = 63;
+	ASSERT(generate_stringification(opt) == R"(std::optional<int>: 63)");
+	ASSERT(
+		generate_stringification(std::optional<S>(S {})) == R"(std::optional<S>: <instance of S>)"
+	);
+	std::vector<int> vec2 {2, 42, {}, 60};
+	ASSERT(generate_stringification(vec2) == R"(std::vector<int>: [2, 42, 0, 60])");
+	std::vector<std::optional<int>> vec {2, 42, {}, 60};
+	ASSERT(
+		generate_stringification(vec) == R"(std::vector<std::optional<int>>: [2, 42, nullopt, 60])"
+	);
+	std::vector<std::optional<std::vector<std::pair<int, float>>>> vovp {
+		{{{2, 1.2f}}},
+		{},
+		{{{20, 6.2f}}}
+	};
+	ASSERT(
+		generate_stringification(vovp)
+		== R"(std::vector<std::optional<std::vector<std::pair<int, float>>>>: [[[2, 1.20000005]], nullopt, [[20, 6.19999981]]])"
+	);
+	std::vector<int> vlong(1100);
+#define TEN "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "
+#define HUNDRED TEN TEN TEN TEN TEN TEN TEN TEN TEN TEN
+	ASSERT(
+		generate_stringification(vlong)
+		== "std::vector<int>: [" HUNDRED HUNDRED HUNDRED HUNDRED HUNDRED HUNDRED HUNDRED HUNDRED
+			HUNDRED HUNDRED
+			 "..."
+			 "]"
+	);
+	int carr[] = {1, 1, 2, 3, 5, 8};
+	static_assert(stringifiable<int[5]>);
+	static_assert(stringifiable_container<int[5]>());
+#if LIBASSERT_IS_CLANG || LIBASSERT_IS_MSVC
+	ASSERT(generate_stringification(carr) == R"(int[6]: [1, 1, 2, 3, 5, 8])");
+#else
+	ASSERT(generate_stringification(carr) == R"(int [6]: [1, 1, 2, 3, 5, 8])");
+#endif
+	// non-printable containers
+	std::vector<S> svec(10);
+	static_assert(!stringifiable<std::vector<S>>);
+	static_assert(!stringifiable_container<std::vector<S>>());
+	static_assert(!stringifiable<S>);
+	static_assert(!stringifiable_container<S>());
+	ASSERT(generate_stringification(svec) == R"(<instance of std::vector<S>>)");
+	std::vector<std::vector<S2>> svec2(10, std::vector<S2>(10));
+	//static_assert(!stringification::stringifiable<std::vector<std::vector<S2>>>);
+	ASSERT(generate_stringification(svec2) == R"(<instance of std::vector<std::vector<S2>>>)");
+	std::vector<std::vector<int>> svec3(10, std::vector<int>(10));
+	static_assert(stringifiable<std::vector<std::vector<int>>>);
+	ASSERT(
+		generate_stringification(svec3)
+		== R"(std::vector<std::vector<int>>: [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])"
+	);
 }
 
 struct format_resetter {
-    ~format_resetter() {
-        libassert::set_fixed_literal_format(libassert::literal_format::default_format);
-        libassert::set_literal_format_mode(libassert::literal_format_mode::infer);
-    }
+	~format_resetter() {
+		libassert::set_fixed_literal_format(libassert::literal_format::default_format);
+		libassert::set_literal_format_mode(libassert::literal_format_mode::infer);
+	}
 };
 
 TEST(Stringify, LiteralFormatting) {
-    format_resetter resetter;
-    ASSERT(generate_stringification(100) == "100");
-    libassert::set_fixed_literal_format(libassert::literal_format::integer_hex | libassert::literal_format::integer_octal);
-    libassert::detail::set_literal_format("", "", "", false);
-    ASSERT(generate_stringification(100) == "100 0x64 0144");
-    libassert::set_literal_format_mode(libassert::literal_format_mode::infer);
+	format_resetter resetter;
+	ASSERT(generate_stringification(100) == "100");
+	libassert::set_fixed_literal_format(
+		libassert::literal_format::integer_hex | libassert::literal_format::integer_octal
+	);
+	libassert::detail::set_literal_format("", "", "", false);
+	ASSERT(generate_stringification(100) == "100 0x64 0144");
+	libassert::set_literal_format_mode(libassert::literal_format_mode::infer);
 
-    std::tuple<A, B, C> tuple2;
-    ASSERT(generate_stringification(tuple2) == R"(<instance of std::tuple<A, B, C>>)");
-    std::tuple<A, B, float, C> tuple3 = {{}, {}, 1.2, {}};
-    ASSERT(generate_stringification(tuple3) == R"(std::tuple<A, B, float, C>: [<instance of A>, <instance of B>, 1.20000005, <instance of C>])");
+	std::tuple<A, B, C> tuple2;
+	ASSERT(generate_stringification(tuple2) == R"(<instance of std::tuple<A, B, C>>)");
+	std::tuple<A, B, float, C> tuple3 = {{}, {}, 1.2, {}};
+	ASSERT(
+		generate_stringification(tuple3)
+		== R"(std::tuple<A, B, float, C>: [<instance of A>, <instance of B>, 1.20000005, <instance of C>])"
+	);
 
-    ostream_printable op{2};
-    ASSERT(generate_stringification(op) == "{2}");
+	ostream_printable op {2};
+	ASSERT(generate_stringification(op) == "{2}");
 
-    std::vector<ostream_printable> opvec{{{2}, {3}}};
-    ASSERT(generate_stringification(opvec) == "std::vector<ostream_printable>: [{2}, {3}]");
+	std::vector<ostream_printable> opvec {{{2}, {3}}};
+	ASSERT(generate_stringification(opvec) == "std::vector<ostream_printable>: [{2}, {3}]");
 }
 
 struct basic_fields {
-    struct value_type {
-        value_type() {}
-    };
-    struct const_iterator {
-        bool operator==(const const_iterator&) const {
-            return true;
-        }
-    };
-    const_iterator begin() {
-        return {};
-    }
-    const_iterator end() {
-        return {};
-    }
+	struct value_type {
+		value_type() {}
+	};
+
+	struct const_iterator {
+		bool operator==(const const_iterator&) const {
+			return true;
+		}
+	};
+
+	const_iterator begin() {
+		return {};
+	}
+
+	const_iterator end() {
+		return {};
+	}
 };
 
 TEST(Stringify, Regression01) {
-    // regression test for #90, just making sure this can compile
-    constexpr bool b = stringifiable_container<basic_fields::value_type>();
-    ASSERT(!b);
-    basic_fields fields;
-    ASSERT(fields.begin() == fields.end());
+	// regression test for #90, just making sure this can compile
+	constexpr bool b = stringifiable_container<basic_fields::value_type>();
+	ASSERT(!b);
+	basic_fields fields;
+	ASSERT(fields.begin() == fields.end());
 }
 
 TEST(Stringify, Tuples) {
-    std::tuple<int, float> tuple{1, 2};
-    ASSERT(generate_stringification(tuple) == R"(std::tuple<int, float>: [1, 2.0])");
-    std::tuple<> tuple2;
-    ASSERT(generate_stringification(tuple2) == R"(std::tuple<>: [])");
+	std::tuple<int, float> tuple {1, 2};
+	ASSERT(generate_stringification(tuple) == R"(std::tuple<int, float>: [1, 2.0])");
+	std::tuple<> tuple2;
+	ASSERT(generate_stringification(tuple2) == R"(std::tuple<>: [])");
 }
 
 TEST(Stringify, Bytes) {
-    format_resetter resetter;
-    std::byte b{0x7f};
-    unsigned char c = 0x7f;
-    EXPECT(generate_stringification(c) == R"(127)");
-    EXPECT(generate_stringification(b) == R"(127)");
-    libassert::set_fixed_literal_format(libassert::literal_format::integer_hex | libassert::literal_format::integer_octal);
-    EXPECT(generate_stringification(c) == R"(127 0x7f 0177)");
-    EXPECT(generate_stringification(b) == R"(127 0x7f 0177)");
+	format_resetter resetter;
+	std::byte b {0x7f};
+	unsigned char c = 0x7f;
+	EXPECT(generate_stringification(c) == R"(127)");
+	EXPECT(generate_stringification(b) == R"(127)");
+	libassert::set_fixed_literal_format(
+		libassert::literal_format::integer_hex | libassert::literal_format::integer_octal
+	);
+	EXPECT(generate_stringification(c) == R"(127 0x7f 0177)");
+	EXPECT(generate_stringification(b) == R"(127 0x7f 0177)");
 }
 
 // TODO: Other formats

--- a/tests/unit/temporaries-test.cpp
+++ b/tests/unit/temporaries-test.cpp
@@ -1,0 +1,34 @@
+#include <libassert/assert-gtest.hpp>
+
+namespace {
+int count = 0;
+struct Counter {
+    Counter() { ++count; }
+    ~Counter() { --count; }
+};
+}
+
+TEST(LibassertTemp, TempWorks) {
+    ASSERT(count == 0);
+    ASSERT((Counter{}, count) == 1);
+
+    int inner_count = 0;
+    try {
+        LIBASSERT_ASSERT(
+            // intentionally assert false
+            (Counter{}, false),
+
+            // to evaluate extra arg
+            ([&](){
+                // record the value of count
+                LIBASSERT_ASSERT((Counter{}, inner_count = count, false));
+                return 0;
+            })()
+        );
+    } catch (...) {
+    }
+
+    // check the recorded value
+    ASSERT(inner_count == 2);
+    ASSERT(count == 0);
+}

--- a/tests/unit/temporaries-test.cpp
+++ b/tests/unit/temporaries-test.cpp
@@ -2,33 +2,38 @@
 
 namespace {
 int count = 0;
+
 struct Counter {
-    Counter() { ++count; }
-    ~Counter() { --count; }
+	Counter() {
+		++count;
+	}
+
+	~Counter() {
+		--count;
+	}
 };
-}
+} // namespace
 
 TEST(LibassertTemp, TempWorks) {
-    ASSERT(count == 0);
-    ASSERT((Counter{}, count) == 1);
+	ASSERT(count == 0);
+	ASSERT((Counter {}, count) == 1);
 
-    int inner_count = 0;
-    try {
-        LIBASSERT_ASSERT(
-            // intentionally assert false
-            (Counter{}, false),
+	int inner_count = 0;
+	try {
+		LIBASSERT_ASSERT(
+			// intentionally assert false
+			(Counter {}, false),
 
-            // to evaluate extra arg
-            ([&](){
-                // record the value of count
-                LIBASSERT_ASSERT((Counter{}, inner_count = count, false));
-                return 0;
-            })()
-        );
-    } catch (...) {
-    }
+			// to evaluate extra arg
+			([&]() {
+				// record the value of count
+				LIBASSERT_ASSERT((Counter {}, inner_count = count, false));
+				return 0;
+			})()
+		);
+	} catch (...) {}
 
-    // check the recorded value
-    ASSERT(inner_count == 2);
-    ASSERT(count == 0);
+	// check the recorded value
+	ASSERT(inner_count == 2);
+	ASSERT(count == 0);
 }

--- a/tests/unit/test_public_utilities.cpp
+++ b/tests/unit/test_public_utilities.cpp
@@ -4,36 +4,37 @@
 
 #ifdef TEST_MODULE
 import libassert;
-#include <libassert/assert-macros.hpp>
+	#include <libassert/assert-macros.hpp>
 #else
-#include <libassert/assert.hpp>
+	#include <libassert/assert.hpp>
 #endif
 
 using namespace libassert;
 
 std::string replace(std::string str, std::string_view substr, std::string_view replacement) {
-    std::string::size_type pos = 0;
-    // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-    while((pos = str.find(substr.data(), pos, substr.length())) != std::string::npos) {
-        str.replace(pos, substr.length(), replacement.data(), replacement.length());
-        pos += replacement.length();
-    }
-    return str;
+	std::string::size_type pos = 0;
+	// NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+	while ((pos = str.find(substr.data(), pos, substr.length())) != std::string::npos) {
+		str.replace(pos, substr.length(), replacement.data(), replacement.length());
+		pos += replacement.length();
+	}
+	return str;
 }
 
 int main() {
-    // pretty_type_name tests
-    auto pretty_name = pretty_type_name<std::map<std::string, int>>();
-    DEBUG_ASSERT(pretty_name.find("basic_string") == std::string::npos);
-    DEBUG_ASSERT(pretty_name.find("allocator") == std::string::npos);
-    // stringification tests
-    DEBUG_ASSERT(stringify(12) == "12");
-    DEBUG_ASSERT(stringify('x') == "'x'");
-    DEBUG_ASSERT(
-        replace(
-            replace(stringify(std::make_pair("foobar", 20)), "char const", "const char"),
-            "char *",
-            "char*"
-        ) == R"(std::pair<const char*, int>: ["foobar", 20])"
-    );
+	// pretty_type_name tests
+	auto pretty_name = pretty_type_name<std::map<std::string, int>>();
+	DEBUG_ASSERT(pretty_name.find("basic_string") == std::string::npos);
+	DEBUG_ASSERT(pretty_name.find("allocator") == std::string::npos);
+	// stringification tests
+	DEBUG_ASSERT(stringify(12) == "12");
+	DEBUG_ASSERT(stringify('x') == "'x'");
+	DEBUG_ASSERT(
+		replace(
+			replace(stringify(std::make_pair("foobar", 20)), "char const", "const char"),
+			"char *",
+			"char*"
+		)
+		== R"(std::pair<const char*, int>: ["foobar", 20])"
+	);
 }

--- a/tests/unit/test_type_prettier.cpp
+++ b/tests/unit/test_type_prettier.cpp
@@ -3,25 +3,25 @@
 
 #ifdef TEST_MODULE
 import libassert;
-#include <libassert/assert-macros.hpp>
+	#include <libassert/assert-macros.hpp>
 #else
-#include <libassert/assert.hpp>
+	#include <libassert/assert.hpp>
 #endif
 
 int main() {
-    bool success = true;
-    auto test = [&success](const std::string& type, const std::string& expected) {
-        auto pretty = libassert::detail::prettify_type(type);
-        if(pretty != expected) {
-            std::cout<<"Error:"<<std::endl;
-            std::cout<<"Expected:"<<expected<<std::endl;
-            std::cout<<"Result:  "<<pretty<<std::endl;
-            success = false;
-        }
-    };
-    test(
-        R"(class std::map<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >,class std::vector<int,class std::allocator<int> >,struct std::less<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > >,class std::allocator<struct std::pair<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const ,class std::vector<int,class std::allocator<int> > > > >)",
-        R"(std::map<std::string, std::vector<int>, std::less<std::string>>)"
-    );
-    return !success;
+	bool success = true;
+	auto test = [&success](const std::string& type, const std::string& expected) {
+		auto pretty = libassert::detail::prettify_type(type);
+		if (pretty != expected) {
+			std::cout << "Error:" << std::endl;
+			std::cout << "Expected:" << expected << std::endl;
+			std::cout << "Result:  " << pretty << std::endl;
+			success = false;
+		}
+	};
+	test(
+		R"(class std::map<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >,class std::vector<int,class std::allocator<int> >,struct std::less<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > >,class std::allocator<struct std::pair<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const ,class std::vector<int,class std::allocator<int> > > > >)",
+		R"(std::map<std::string, std::vector<int>, std::less<std::string>>)"
+	);
+	return !success;
 }

--- a/tests/unit/type_handling.cpp
+++ b/tests/unit/type_handling.cpp
@@ -1,130 +1,150 @@
 #undef ASSERT_LOWERCASE
 #include <cassert>
-#include <libassert/assert.hpp>
-
 #include <cstdlib>
 #include <iostream>
-#include <string_view>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
+#include <libassert/assert.hpp>
+
 using namespace libassert::detail;
 
 // Some test cases for TMP stuff
-static_assert(std::is_same<decltype(std::declval<expression_decomposer<int, nothing, nothing>>().get_value()), int&>::value);
-static_assert(std::is_same<decltype(std::declval<expression_decomposer<int&, nothing, nothing>>().get_value()), int&>::value);
-static_assert(std::is_same<decltype(std::declval<expression_decomposer<int, int, ops::lteq>>().get_value()), bool>::value);
-static_assert(std::is_same<decltype(std::declval<expression_decomposer<int, int, ops::lteq>>().take_lhs()), int&&>::value);
-static_assert(std::is_same<decltype(std::declval<expression_decomposer<int&, int, ops::lteq>>().take_lhs()), int&>::value);
+static_assert(std::is_same<
+							decltype(std::declval<expression_decomposer<int, nothing, nothing>>().get_value()),
+							int&>::value);
+static_assert(std::is_same<
+							decltype(std::declval<expression_decomposer<int&, nothing, nothing>>().get_value()),
+							int&>::value);
+static_assert(std::is_same<
+							decltype(std::declval<expression_decomposer<int, int, ops::lteq>>().get_value()),
+							bool>::value);
+static_assert(std::is_same<
+							decltype(std::declval<expression_decomposer<int, int, ops::lteq>>().take_lhs()),
+							int&&>::value);
+static_assert(std::is_same<
+							decltype(std::declval<expression_decomposer<int&, int, ops::lteq>>().take_lhs()),
+							int&>::value);
 
 static_assert(is_string_type<char*>);
 static_assert(is_string_type<const char*>);
 static_assert(is_string_type<char[5]>);
 static_assert(is_string_type<const char[5]>);
-static_assert(!is_string_type<char(*)[5]>);
-static_assert(is_string_type<char(&)[5]>);
+static_assert(!is_string_type<char (*)[5]>);
+static_assert(is_string_type<char (&)[5]>);
 static_assert(is_string_type<const char (&)[27]>);
 static_assert(!is_string_type<std::vector<char>>);
 static_assert(!is_string_type<int>);
 static_assert(is_string_type<std::string>);
 static_assert(is_string_type<std::string_view>);
 
-template<typename T> constexpr bool is_lvalue(T&&) {
-  return std::is_lvalue_reference<T>::value;
+template<typename T>
+constexpr bool is_lvalue(T&&) {
+	return std::is_lvalue_reference<T>::value;
 }
 
 struct only_move_constructable {
-    int x;
-    only_move_constructable(int _x) : x(_x) {}
-    ~only_move_constructable() = default;
-    only_move_constructable(const only_move_constructable&) = delete;
-    only_move_constructable(only_move_constructable&&) = default;
-    only_move_constructable& operator=(const only_move_constructable&) = delete;
-    only_move_constructable& operator=(only_move_constructable&&) = delete;
-    bool operator==(int y) const {
-        return x == y;
-    }
+	int x;
+
+	only_move_constructable(int _x) : x(_x) {}
+
+	~only_move_constructable() = default;
+	only_move_constructable(const only_move_constructable&) = delete;
+	only_move_constructable(only_move_constructable&&) = default;
+	only_move_constructable& operator=(const only_move_constructable&) = delete;
+	only_move_constructable& operator=(only_move_constructable&&) = delete;
+
+	bool operator==(int y) const {
+		return x == y;
+	}
 };
 
 int main() {
-    // test rvalue
-    {
-        decltype(auto) a = DEBUG_ASSERT_VAL(only_move_constructable(2) == 2);
-        static_assert(std::is_same<decltype(a), only_move_constructable>::value);
-        assert(!is_lvalue(DEBUG_ASSERT_VAL(only_move_constructable(2) == 2)));
-        assert(DEBUG_ASSERT_VAL(only_move_constructable(2) == 2).x == 2);
-        //assert(debug_assert(only_move_constructable(2) == 2).x++ == 2); // not allowed
-    }
+	// test rvalue
+	{
+		decltype(auto) a = DEBUG_ASSERT_VAL(only_move_constructable(2) == 2);
+		static_assert(std::is_same<decltype(a), only_move_constructable>::value);
+		assert(!is_lvalue(DEBUG_ASSERT_VAL(only_move_constructable(2) == 2)));
+		assert(DEBUG_ASSERT_VAL(only_move_constructable(2) == 2).x == 2);
+		//assert(debug_assert(only_move_constructable(2) == 2).x++ == 2); // not allowed
+	}
 
-    // test lvalue
-    {
-        only_move_constructable x(2);
-        decltype(auto) b = DEBUG_ASSERT_VAL(x == 2);
-        static_assert(std::is_same<decltype(b), only_move_constructable&>::value);
-        assert(is_lvalue(DEBUG_ASSERT_VAL(x == 2)));
-        DEBUG_ASSERT_VAL(x == 2).x++;
-        ASSERT(x.x == 3);
-    }
+	// test lvalue
+	{
+		only_move_constructable x(2);
+		decltype(auto) b = DEBUG_ASSERT_VAL(x == 2);
+		static_assert(std::is_same<decltype(b), only_move_constructable&>::value);
+		assert(is_lvalue(DEBUG_ASSERT_VAL(x == 2)));
+		DEBUG_ASSERT_VAL(x == 2).x++;
+		ASSERT(x.x == 3);
+	}
 
-    // test values are forwarded properly
-    // serves as a regression test against issue with std::forwarding with the wrong type
-    {
-        // there was an issue with the decomposer trying to forward s << 2 as an S rather than a B
-        struct S;
-        struct B {
-            bool operator==(int) const {
-                return true;
-            }
-        };
-        struct S {
-            B operator<<(int) const {
-                return B{};
-            }
-        };
-        S s;
-        decltype(auto) v = DEBUG_ASSERT_VAL(s << 2 == false);
-        static_assert(std::is_same<decltype(v), B>::value);
-    }
-    {
-        struct S;
-        struct B {
-            bool operator==(int) const {
-                return true;
-            }
-        };
-        B b;
-        struct S {
-            B& _b;
-            B& operator<<(int) const {
-                return _b;
-            }
-        };
-        S s{b};
-        decltype(auto) v = DEBUG_ASSERT_VAL(s << 2 == false);
-        static_assert(std::is_same<decltype(v), B&>::value);
-    }
+	// test values are forwarded properly
+	// serves as a regression test against issue with std::forwarding with the wrong type
+	{
+		// there was an issue with the decomposer trying to forward s << 2 as an S rather than a B
+		struct S;
 
-    // above cases test lhs returns, now test the case where the full value is returned
-    {
-        auto v0 = DEBUG_ASSERT_VAL(1 | 2);
-        ASSERT(v0 == 3);
-        auto v1 = DEBUG_ASSERT_VAL(7 & 4);
-        ASSERT(v1 == 4);
-        auto v2 = DEBUG_ASSERT_VAL(1 << 16);
-        ASSERT(v2 == 65536);
-        auto v3 = DEBUG_ASSERT_VAL(32 >> 2);
-        ASSERT(v3 == 8);
-    }
+		struct B {
+			bool operator==(int) const {
+				return true;
+			}
+		};
 
-    // test _VAL returns the correct type
-    {
-        auto f = [] {
-            return DEBUG_ASSERT_VAL(false);
-        };
-        static_assert(std::is_same<decltype(f()), bool>::value);
-    }
+		struct S {
+			B operator<<(int) const {
+				return B {};
+			}
+		};
 
-    return 0;
+		S s;
+		decltype(auto) v = DEBUG_ASSERT_VAL(s << 2 == false);
+		static_assert(std::is_same<decltype(v), B>::value);
+	}
+	{
+		struct S;
+
+		struct B {
+			bool operator==(int) const {
+				return true;
+			}
+		};
+
+		B b;
+
+		struct S {
+			B& _b;
+
+			B& operator<<(int) const {
+				return _b;
+			}
+		};
+
+		S s {b};
+		decltype(auto) v = DEBUG_ASSERT_VAL(s << 2 == false);
+		static_assert(std::is_same<decltype(v), B&>::value);
+	}
+
+	// above cases test lhs returns, now test the case where the full value is returned
+	{
+		auto v0 = DEBUG_ASSERT_VAL(1 | 2);
+		ASSERT(v0 == 3);
+		auto v1 = DEBUG_ASSERT_VAL(7 & 4);
+		ASSERT(v1 == 4);
+		auto v2 = DEBUG_ASSERT_VAL(1 << 16);
+		ASSERT(v2 == 65536);
+		auto v3 = DEBUG_ASSERT_VAL(32 >> 2);
+		ASSERT(v3 == 8);
+	}
+
+	// test _VAL returns the correct type
+	{
+		auto f = [] { return DEBUG_ASSERT_VAL(false); };
+		static_assert(std::is_same<decltype(f()), bool>::value);
+	}
+
+	return 0;
 }


### PR DESCRIPTION
i first ran into this bug while using libassert with eigen, which uses expression templates (not very well imo)
writing code like this
```cpp
void compare(Eigen::MatrixXd a, Eigen::MatrixXd b) {
    LIBASSERT_ASSERT(a * a * a == b);
}
```
results in undefined behavior, because the `a * a` produces a temporary that contains references to `a`, which is then referenced by the expression holding `(a * a) * a`.
if you store this to a local then the lifetime of that temporary is ended by the time the comparison is actually evaluated, resulting in undefined behavior

my suggested fix is to replace `do { auto expr = decomposition; } while (0)` with `[&](auto expr) { ... } (decomposition)`, but let me know if you have a different solution