### PR TITLE
Add LIBASSERT_INSTALL option to control install rule generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,7 +282,7 @@ endif()
 
 # ---- Install Rules ----
 
-if(NOT CMAKE_SKIP_INSTALL_RULES)
+if(LIBASSERT_INSTALL AND NOT CMAKE_SKIP_INSTALL_RULES)
   include(cmake/InstallRules.cmake)
 endif()
 

--- a/cmake/OptionVariables.cmake
+++ b/cmake/OptionVariables.cmake
@@ -89,6 +89,13 @@ set(
 # depends on CMAKE_INSTALL_LIBDIR which is marked as advanced in GNUInstallDirs
 mark_as_advanced(LIBASSERT_INSTALL_CMAKEDIR)
 
+# Controls whether the install rules are generated. Defaults to on only when
+# libassert is the top level project, so that consumers using add_subdirectory
+# or FetchContent don't install libassert's headers and package files when they
+# run their own install target.
+option(LIBASSERT_INSTALL "Generate and install libassert package files" ${PROJECT_IS_TOP_LEVEL})
+mark_as_advanced(LIBASSERT_INSTALL)
+
 # Enables obtaining cpptrace via find_package instead of using FetchContent to
 # obtain it from the official GitHub repo
 option(LIBASSERT_USE_EXTERNAL_CPPTRACE "Obtain cpptrace via find_package instead of FetchContent" OFF)


### PR DESCRIPTION
Closes #158. Install rules ran even when libassert was pulled in via add_subdirectory or FetchContent, so a consumer would install libassert's headers and package files when running their own install target. This adds a LIBASSERT_INSTALL option that defaults to PROJECT_IS_TOP_LEVEL and guards the install rules include, so a subproject no longer installs libassert by default but can opt back in with -DLIBASSERT_INSTALL=ON. CMAKE_SKIP_INSTALL_RULES is still honored.